### PR TITLE
remove a non functioning tab from header

### DIFF
--- a/_includes/default-header.html
+++ b/_includes/default-header.html
@@ -26,7 +26,6 @@
               <a class="navbar-item" href="/index#applications"> Applications </a>
               <a class="navbar-item" href="/index#projects"> Projects </a>
               <a class="navbar-item" href="/index#the-program-itself"> The program itself </a>
-              <a class="navbar-item" href="/index#cohort-calls"> Cohort Calls </a>
             </div>
           </div>
 

--- a/index.md
+++ b/index.md
@@ -20,7 +20,12 @@ This is a **15-week long personal mentorship and cohort-based training**, where 
 - connect with members across different projects, communities, backgrounds, and identities
 - empower each other to become effective Open Science ambassadors in their communities
 
+## Applications
+
 **We are currently running our [first cohort](ols-1) from January to April 2020.**
+
+Announcement for the next round will posted in May 2020. 
+Meanwhile register your interest by getting in touch with team. 
 
 ## Projects
 


### PR DESCRIPTION
Removed the cohort call tab from the front page header as it is a page of its own now