### PR TITLE
Small fixes

### DIFF
--- a/_includes/overall-schedule.md
+++ b/_includes/overall-schedule.md
@@ -7,7 +7,7 @@ During the program,
 
 Organizers will inform participants of the week schedule by email.
 
-<iframe class="calendar" src="https://calendar.google.com/calendar/embed?src=n3rqhvuff05ojkl0opfsvh49fk%40group.calendar.google.com"  frameborder="0" scrolling="no"></iframe>
+<iframe src="https://calendar.google.com/calendar/b/1/embed?height=600&amp;wkst=1&amp;bgcolor=%23ffffff&amp;ctz=Europe%2FParis&amp;src=bjNycWh2dWZmMDVvamtsMG9wZnN2aDQ5ZmtAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&amp;color=%23D50000&amp;mode=AGENDA&amp;hl=en_GB&amp;showTitle=0&amp;showNav=0&amp;showDate=1&amp;showPrint=0&amp;showTabs=1&amp;showCalendars=0" width="1152" frameborder="0" scrolling="no"></iframe>
 
 [<i class="fas fa-calendar-plus"></i> *Subscribe to the OLS calendar*](https://calendar.google.com/calendar/r?cid=n3rqhvuff05ojkl0opfsvh49fk@group.calendar.google.com)
 

--- a/about.md
+++ b/about.md
@@ -69,19 +69,23 @@ Our mentors will
 
 ## Becoming a mentor
 
-We are currently recruiting the mentors for the first round. Please reach out to one of the organizers if you are interested.
+We are currently recruiting the mentors for the second round. Please reach out to one of the organizers if you are interested.
 
 ## Our mentors
 
-<div class="people">
-{% for entry in site.data.people %}
-    {% assign username = entry[0] %}
-    {% assign user = site.data.people[username] %}
-    {% if user.mentor %}
-      {% include _includes/people.html user=user username=username %}
-    {% endif %}
+Our program is only possible thanks to our awesome mentors:
+
+{% assign projects = site.data.ols-1-projects %}
+{% assign mentors = '' %}
+{% for project in projects %}
+    {% for m in project.mentors %}
+        {% capture mentors %}{{ mentors }}, {{ m }}{% endcapture %}
+    {% endfor %}
 {% endfor %}
-</div>
+{% assign ols-1-mentors = mentors | remove_first: ', ' | split: ", " | uniq | sort %}
+
+- [The {{ ols-1-mentors | size }} mentors for **OLS-1** (January to May 2020)](/ols-1#mentors)
+- [The possible mentors for **OLS-2** (September to December 2020)](/ols-2#mentors)
 
 # Experts
 
@@ -103,19 +107,16 @@ Experts may be invited to:
 - be interviewed by the organisers (~15 minutes)
 - invited by mentor-mentee pair to share their expert consultation on certain projects. (~30 minutes)
 
-We are currently recruiting the experts for the first round.
+We are currently recruiting the experts for the second round.
 
 ## Our experts
 
-<div class="people">
-{% for entry in site.data.people %}
-    {% assign username = entry[0] %}
-    {% assign user = site.data.people[username] %}
-    {% if user.expert %}
-      {% include _includes/people.html user=user username=username %}
-    {% endif %}
-{% endfor %}
-</div>
+Our experts are essential for the program:
+
+{% assign ols-1-experts = site.data.ols-1-experts-speakers.experts %}
+
+- [The {{ ols-1-experts | uniq | size }} experts for **OLS-1** (January to May 2020)](/ols-1#experts)
+- [The possible experts for **OLS-2** (September to December 2020)](/ols-2#experts)
 
 # Organizers
 
@@ -129,8 +130,6 @@ We are graduates, mentors, and hosts of various [Mozilla Open Leaders](https://f
     {% endif %}
 {% endfor %}
 </div>
-
-
 
 We also participate in a wide range of activities in different international communities of practice in the life sciences:
 - [ELIXIR (European bioinformatics network)](https://elixir-europe.org/)


### PR DESCRIPTION
1. Mentors and experts are only listed in the cohort page not in the about page (link to cohort pages)

   ![Screenshot 2020-05-19 at 21 48 28](https://user-images.githubusercontent.com/1842467/82372590-8509df80-9a1c-11ea-9ddc-e7b4169850d5.png)

2. Calendar is display using the planning view in schedule page
 
   ![Screenshot 2020-05-19 at 21 59 24](https://user-images.githubusercontent.com/1842467/82372554-74596980-9a1c-11ea-98a5-f9c8cbbf769c.png)
