### PR TITLE
Update default-header.html to make previous OLS clickable with the last cohort

### DIFF
--- a/_includes/default-header.html
+++ b/_includes/default-header.html
@@ -21,7 +21,7 @@
       <div id="top-menu" class="navbar-menu">
         <div class="navbar-end">
           <div class="navbar-item has-dropdown is-hoverable">
-            <a class="navbar-link" href="/index#a-mentoring--training-program-for-open-science-ambassadors-in-life-science">The program</a>
+            <a class="navbar-link" href="/index#a-mentoring--training-program-for-open-science-ambassadors">The program</a>
             <div class="navbar-dropdown">
               <a class="navbar-item" href="/index#applications"> Applications </a>
               <a class="navbar-item" href="/index#projects"> Projects </a>
@@ -40,10 +40,10 @@
           </div>
 
           <div class="navbar-item has-dropdown is-hoverable">
-            <a class="navbar-link">Previous OLS</a>
+            <a class="navbar-link" href="/ols-1">Previous OLS</a>
             <div class="navbar-dropdown">
               <div class="navbar-item navbar-previous-title">OLS-1</div>
-              <a class="navbar-item" href="/ols-1"> Syllabus </a>
+              <a class="navbar-item" href="/ols-1#syllabus"> Syllabus </a>
               <a class="navbar-item" href="/ols-1#schedule"> Schedule</a>
               <a class="navbar-item" href="/ols-1/projects-participants/"> Projects & Participants</a>
               <a class="navbar-item" href="/ols-1#mentors"> Mentors & Experts</a>


### PR DESCRIPTION
# Allowing "/OLS-1" to appear when clicked on previous cohort

- It isn't clickable at the moment
- The link can be updated with the most recently concluded cohort