### PR TITLE
Add community page with avatars of all people

### DIFF
--- a/community.md
+++ b/community.md
@@ -1,0 +1,29 @@
+---
+layout: page
+title: Community
+---
+
+Thank You! to the {{ site.data.people | size }} awesome persons who participate(d) to Open Life Science! 
+
+
+<div class="community">
+{% for user in site.data.people %}
+  {% assign username = user[0] %}
+  {% assign details = user[1] %}
+<div class="card people-card" id="{{ username }}">
+  <div class="card-content">
+    <div class="media">
+      <div class="media-left people-card-avatar">
+        <figure class="image is-48x48">
+          <img
+            class="is-rounded"
+            src="https://avatars.githubusercontent.com/{{ username }}"
+            alt="The GitHub avatar of {{ details.name }}"
+          />
+        </figure>
+      </div>
+    </div>
+  </div>
+</div>
+{% endfor %}
+</div>

--- a/css/custom.scss
+++ b/css/custom.scss
@@ -259,3 +259,42 @@ $link-active: $link-hover;
   max-width: 550px;
   text-align: center;
 }
+
+.community {
+  margin-bottom: 1em;
+
+  .card {
+    box-shadow: none;
+  }
+
+  .card-content {
+    padding-top: 1em;
+    padding-left: 0em;
+    padding-right: 0em;
+    padding-bottom: 0em;
+  }
+
+  @include mobile() {
+    .people-card {
+      margin-bottom: 1em;
+    }
+
+    .people-card-meta {
+      overflow-x: initial;
+    }
+
+    .people-card-avatar {
+      display: none;
+    }
+  }
+
+  @include tablet() {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(60px, 1fr));
+  }
+
+  .image {
+    margin-left: 0px;
+    margin-right: 0px;
+  }
+}


### PR DESCRIPTION
<img width="1095" alt="Screenshot 2020-07-10 at 21 49 46" src="https://user-images.githubusercontent.com/1842467/87192687-48a98000-c2f7-11ea-8c0e-703eb4630317.png">

It is available under `/community` (not linked from anywhere), to help creating "Acknowledgement" slide