### PR TITLE
Some work on speaker guide

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,4 @@ gem 'jekyll-paginate', group: :jekyll_plugins
 gem 'jekyll-archives', group: :jekyll_plugins
 gem 'jekyll-last-modified-at', group: :jekyll_plugins
 gem 'html-proofer', group: :jekyll_plugins
+gem 'jekyll-redirect-from', group: :jekyll_plugins

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -266,6 +266,7 @@ DEPENDENCIES
   jekyll-archives
   jekyll-last-modified-at
   jekyll-paginate
+  jekyll-redirect-from
 
 BUNDLED WITH
    2.1.4

--- a/_config.yml
+++ b/_config.yml
@@ -25,3 +25,4 @@ includes_dir: .
 
 plugins:
   - jekyll-last-modified-at
+  - jekyll-redirect-from

--- a/_ols-2/speaker-guide.md
+++ b/_ols-2/speaker-guide.md
@@ -24,13 +24,13 @@ Malvika Sharan and Yo Yehudi. You can reach out to us by emailing
 
 We are currently running our [second cohort with 33
 projects]({% link _ols-2/projects-participants.md %})
-(September-December 2020) that consist of 50 participants ([see this
+(September-December 2020) that consist of around 50 participants ([see this
 post]({% link _posts/2020-09-01-ols2-announcement.md %})).
 A complete syllabus of this cohort can be found [here](https://openlifesci.org/ols-2/schedule).
 
 # About our Code of Conduct
 
-All our members, participants and speakers are expected to abide by our [Code of conduct & community participationguidelines]({% link code-of-conduct.md %}) that apply to all our community spaces including online calls.
+All our members, participants and speakers are expected to abide by our [Code of conduct & community participation guidelines]({% link code-of-conduct.md %}) that apply to all our community spaces including online calls.
 
 If you experience or witness any unacceptable behaviour, or have any other concerns, please report it by contacting the organisers - Bérénice, Malvika and Yo. ([{{ site.email }}](mailto:{{ site.email }})).
 
@@ -83,7 +83,7 @@ Your talk will be allotted 10-15 minutes (including Q&A session) during the call
 
 You are welcome to attend the entire call or attend only for the section relevant for your talk. If you prefer the latter, please join the call a minimum of 5 minutes before your talk.
 
-You can use slides, documents or any other resource to deliver your talk. Please consider accessibility and inclusivity when designing your talk ([see this for reference](https://www.w3.org/WAI/teach-advocate/accessible-presentations/#preparing-slides-and-projected-material-speakers)). 
+You can use slides, documents or any other resource to deliver your talk. Please consider accessibility and inclusivity when designing your talk ([see this for reference](https://www.w3.org/WAI/teach-advocate/accessible-presentations/#preparing-slides-and-projected-material-speakers)).
 
 You will be asked to share your screen to present your talk. You can see the [screen sharing instructions here](https://support.zoom.us/hc/en-us/articles/201362153-How-Do-I-Share-My-Screen-).
 

--- a/_ols-2/speaker-guide.md
+++ b/_ols-2/speaker-guide.md
@@ -11,45 +11,38 @@ redirect_from: /ols-speaker-guide
 
 
 Thank you for considering speaking at our upcoming Cohort call! We look forward to welcoming you. **🎉🥳️👏**
-----------------------------------------------------------------------------------------------------------
 
-About Open Life Science
------------------------
+# About Open Life Science
 
-The Open Life Science (OLS) program
-([https://openlifesci.org/](https://openlifesci.org/)) is
+The [Open Life Science (OLS) program]({% link index.md %}) is
 designed for the early-stage researchers and potential academic leaders
 in becoming Open Science ambassadors in their communities.
 
 This program is led by the OLS team members, i.e. us - Bérénice Batut,
 Malvika Sharan and Yo Yehudi. You can reach out to us by emailing
-[team@openlifesci.org](mailto:team@openlifesci.org).
+[{{ site.email }}](mailto:{{ site.email }}).
 
 We are currently running our [second cohort with 33
-projects](https://openlifesci.org/ols-2/projects-participants/)
+projects]({% link _ols-2/projects-participants.md %})
 (September-December 2020) that consist of 50 participants ([see this
-post](https://openlifesci.org/posts/2020/09/01/ols2-announcement/)).
-A complete syllabus of this cohort can be found here:
-[https://openlifesci.org/ols-2/schedule](https://openlifesci.org/ols-2/schedule).
+post]({% link _posts/2020-09-01-ols2-announcement.md %})).
+A complete syllabus of this cohort can be found [here](https://openlifesci.org/ols-2/schedule).
 
-About our Code of Conduct
--------------------------
+# About our Code of Conduct
 
--   All our members, participants and speakers are expected to abide by our [Code of conduct & community participationguidelines](https://openlifesci.org/code-of-conduct) that apply to all our community spaces including online calls.
+All our members, participants and speakers are expected to abide by our [Code of conduct & community participationguidelines]({% link code-of-conduct.md %}) that apply to all our community spaces including online calls.
 
--   If you experience or witness any unacceptable behaviour, or have any other concerns, please report it by contacting the organisers - Bérénice, Malvika and Yo. ([team\@openlifesci.org](mailto:team@openlifesci.org)).
+If you experience or witness any unacceptable behaviour, or have any other concerns, please report it by contacting the organisers - Bérénice, Malvika and Yo. ([{{ site.email }}](mailto:{{ site.email }})).
 
--   To report an issue involving one of the organisers, please email one of the members individually ([berenice@openlifesci.org](mailto:berenice@openlifesci.org), [malvika@openlifesci.org](mailto:malvika@openlifesci.org), [yo@openlifesci.org](mailto:yo@openlifesci.org)).
+To report an issue involving one of the organisers, please email one of the members individually ([berenice@openlifesci.org](mailto:berenice@openlifesci.org), [malvika@openlifesci.org](mailto:malvika@openlifesci.org), [yo@openlifesci.org](mailto:yo@openlifesci.org)).
 
-About the cohort calls
-----------------------
+# About the cohort calls
 
--   Every second week, we host online cohort calls (1.5 hours each) where [relevant content related to Open Life Science](https://openlifesci.org/ols-2#schedule) is shared and discussed with all participants of the program.
+Every second week, we host online cohort calls (1.5 hours each) where [relevant content related to Open Life Science]({% link _ols-2/schedule.md %}) is shared and discussed with all participants of the program.
 
 These cohort calls introduce new Open Science related topics that are relevant for our participants to develop their project and bring them to the next stage.
 
-Cohort call format
-------------------
+# Cohort call format
 
 These calls are a mix of presentations by invited speakers like you,
 breakout discussions (in small groups), silent note-taking and Question
@@ -59,26 +52,21 @@ The OLS team will share the topic of your call, exact date and time, and
 any relevant information with you. Please feel free to reach out to them
 if further details on your talk might be necessary.
 
-**Online Zoom calls:**
+## Online Zoom calls
 
--   These calls take place online via Zoom, a link for which will be shared with you, usually via the cohort call notes.
+These calls take place online via Zoom, a link for which will be shared with you, usually via the cohort call notes.
 
--   You can check if Zoom works on your system by using this link: [http://zoom.us/test](http://zoom.us/test).
+You can check if Zoom works on your system by using this link: [http://zoom.us/test](http://zoom.us/test).
 
-**Call notes:**
+## Call notes
 
--   The OLS team will share a collaborative document with the cohort call agenda in your invitation email, which is also linked to the online schedule:
- [https://openlifesci.org/ols-2/schedule](https://openlifesci.org/ols-2/schedule)
+The OLS team will share a collaborative document with the cohort call agenda in your invitation email, which is also linked to the [online schedule]({% link _ols-2/schedule.md %})
 
--   These notes will be available for all our participants for future reference.
+These notes will be available for all our participants for future reference. You are welcome to contribute to the notes from your session.
 
--   You are welcome to contribute to the notes from your session.
+# Cohort call speakers
 
-Cohort call speakers
---------------------
-
-We invite [experts like
-you](https://openlifesci.org/about#experts) to these calls to talk
+We invite [experts like you](/about#experts) to these calls to talk
 about their work, provide personal perspectives, share personal stories
 or anecdotes, and engage our participants in understanding the practical
 applications of the Open Science tools/approaches.
@@ -89,32 +77,32 @@ certain aspect or concept of Open Science in their work. The OLS team
 should have shared the details of the topic and further details of this
 call with you.
 
-Presentations/talks at the cohort call
---------------------------------------
+# Presentations/talks at the cohort call
 
 Your talk will be allotted 10-15 minutes (including Q&A session) during the call (OLS team should have confirmed this).
 
--   You are welcome to attend the entire call or attend only for the section relevant for your talk. If you prefer the latter, please join the call a minimum of 5 minutes before your talk.
+You are welcome to attend the entire call or attend only for the section relevant for your talk. If you prefer the latter, please join the call a minimum of 5 minutes before your talk.
 
--   You can use slides, documents or any other resource to deliver your talk. Please consider accessibility and inclusivity when designing your talk ([see this for reference](https://www.w3.org/WAI/teach-advocate/accessible-presentations/#preparing-slides-and-projected-material-speakers)).
+You can use slides, documents or any other resource to deliver your talk. Please consider accessibility and inclusivity when designing your talk ([see this for reference](https://www.w3.org/WAI/teach-advocate/accessible-presentations/#preparing-slides-and-projected-material-speakers)). 
 
--   You can use the collaborative notes before or during the call to guide the Q&A session.
+You will be asked to share your screen to present your talk. You can see the [screen sharing instructions here](https://support.zoom.us/hc/en-us/articles/201362153-How-Do-I-Share-My-Screen-).
 
--   If a breakout discussion is planned after your talk, the OLS team will reach out to you to agree on the questions or format for this guided discussion.
+If you use slides, you can [make a copy of this presentation](https://docs.google.com/presentation/d/18MwCMBrJL7LwbFvy76il-rk_wBuXq5T2oQ9iHrsvegg/edit?usp=sharing) to start creating your presentation online. It would be great if you can share the link of your talk with the OLS team before the call.
 
--   You will be asked to share your screen to present your talk. You can see the [screen sharing instructions here](https://support.zoom.us/hc/en-us/articles/201362153-How-Do-I-Share-My-Screen-).
+You can use the collaborative notes before or during the call to guide the Q&A session.
 
--   If you are ok for our participants to reach out to you after the call, please share your contact info in the presentation and/or the collaborative note.
+If a breakout discussion is planned after your talk, the OLS team will reach out to you to agree on the questions or format for this guided discussion.
 
--   You can [make a copy of this presentation](https://docs.google.com/presentation/d/18MwCMBrJL7LwbFvy76il-rk_wBuXq5T2oQ9iHrsvegg/edit?usp=sharing) to start creating your presentation online. It would be great if you can share the link of your talk with the OLS team before the call.
+If you are ok for our participants to reach out to you after the call, please share your contact info in the presentation and/or the collaborative note.
 
-**Call recording:**
 
--   Please note that this call will be recorded for our participants, especially those who can't attend this call in-person. These recordings will be shared on our [official Youtube channel](https://www.youtube.com/channel/UCs12-ZgnDJOWIWN3Vo1XHXA).
- If your time allows, you can also watch a video from one of our
- previous calls (here is the [full
+## Call recording
+
+Please note that this call will be recorded for our participants, especially those who can't attend this call in-person. These recordings will be shared on our [official Youtube channel]({{ site.youtube }}).
+
+You can turn off your webcam before joining the call if you do not want to appear on the recording and turn it on if/when you don't mind being on the video.
+
+If you prefer that your section is not recorded, please let the OLS team members know, so that they pause the recording for your section and resume afterwards.
+
+If your time allows, you can also watch a video from one of our previous calls (here is the [full
 playlist](https://www.youtube.com/playlist?list=PL1CvC6Ez54KAtOhuCv8e8dqaHkUylUYDB)).
-
--   You can turn off your webcam before joining the call if you do not want to appear on the recording and turn it on if/when you don't mind being on the video.
-
--   If you prefer that your section is not recorded, please let the OLS team members know, so that they pause the recording for your section and resume afterwards.

--- a/_ols-2/speaker-guide.md
+++ b/_ols-2/speaker-guide.md
@@ -6,6 +6,7 @@ photos:
   name: Visuals on Unsplash
   license: CC-0
   url: https://unsplash.com/photos/Y4qzW3AsvqI
+redirect_from: /ols-speaker-guide
 ---
 
 

--- a/ols-2.md
+++ b/ols-2.md
@@ -282,7 +282,7 @@ The calls will be hosted online using the Zoom web-conferencing option. A link f
 
 ## OLS Speaker Guide
 
-We have [a short guide for invited speakers]({% link ols-speaker-guide.md %}).
+We have [a short guide for invited speakers]({% link _ols-2/speaker-guide.md %}).
 
 ## Communication channels
 


### PR DESCRIPTION
I moved the speaker guide of OLS-2 folder (as it was introduce this way). To avoid any issue with links, I added a plugin which redirect the previous location to the new location.

I also worked on the internal links there.