### PR TITLE
Add people info to community page

### DIFF
--- a/_data/people.yaml
+++ b/_data/people.yaml
@@ -95,7 +95,6 @@ ChiaraBertipaglia:
   affiliation: "Columbia University\u2019s Zuckerman Institute"
   country: USA
   expertise:
-  - OLS-1 project lead
   - Neuroscience
   first-name: Chiara
   last-name: Bertipaglia
@@ -194,7 +193,6 @@ Fnyasimi:
     '
   country: Kenya
   expertise:
-  - OLS-1 project lead
   - Bioinformatics
   - Biomedical Research
   first-name: Festus
@@ -287,8 +285,6 @@ Kevinxufs:
 Kiragu-Mwaura:
   affiliation: Institute of Primate Research
   country: Kenya
-  expertise:
-  - OLS-1 project lead
   first-name: David
   last-name: Kiragu Mwaura
   pronouns: he/him
@@ -338,8 +334,6 @@ KirstieJane:
 KristinaRiemer:
   affiliation: University of Arizona
   country: USA
-  expertise:
-  - OLS-1 project lead
   first-name: Kristina
   last-name: Riemer
   pronouns: she/her
@@ -347,8 +341,6 @@ KristinaRiemer:
 LandiMi2:
   affiliation: International Livestock Research Institute
   country: Kenya
-  expertise:
-  - OLS-1 project lead
   first-name: Michael
   last-name: Kofia Landi
   pronouns: he/him
@@ -388,16 +380,12 @@ LauraCarter:
 Lilian9:
   affiliation: Information Training and Outreach Centre for Africa
   country: Kenya
-  expertise:
-  - OLS-1 project lead
   first-name: Lilian
   last-name: Juma
   pronouns: she/her
 MagicMilly:
   affiliation: University of Arizona
   country: USA
-  expertise:
-  - OLS-1 project lead
   first-name: Emily
   last-name: Cain
   pronouns: she/her
@@ -405,8 +393,6 @@ MagicMilly:
 Megmugure:
   affiliation: International Livestock Research Institute
   country: Kenya
-  expertise:
-  - OLS-1 project lead
   first-name: Margaret
   last-name: Wanjiku
   pronouns: she/her
@@ -414,8 +400,6 @@ Megmugure:
 MorphoFun:
   affiliation: The George Washington University
   country: USA
-  expertise:
-  - OLS-1 project lead
   first-name: Sandy
   last-name: Kawano
   pronouns: she/her
@@ -460,8 +444,6 @@ NPalopoli:
 NaraLB:
   affiliation: "Museu Paraense Em\xEDlio Goeldi"
   country: Brazil
-  expertise:
-  - OLS-1 project lead
   first-name: Naraiana
   last-name: Loureiro Benone
   pronouns: she/her
@@ -476,7 +458,6 @@ SamGuay:
   country: Canada
   email: samuel.guay@umontreal.ca
   expertise:
-  - OLS-1 project lead
   - Open Science
   - Building website with Hugo
   - Reproducible reports
@@ -513,8 +494,6 @@ SebastianEggert:
 Sithyphus:
   affiliation: University of Arizona
   country: USA
-  expertise:
-  - OLS-1 project lead
   first-name: Jorge
   last-name: Barrios
   pronouns: he/him
@@ -711,8 +690,6 @@ alexwlchan:
 anayan321:
   affiliation: Mahidol University
   country: Thailand
-  expertise:
-  - OLS-1 project lead
   first-name: Anunya
   last-name: Opasawatchai
   pronouns: she/her
@@ -999,8 +976,6 @@ bgruening:
 billbrod:
   affiliation: New York University
   country: USA
-  expertise:
-  - OLS-1 project lead
   first-name: Billy
   last-name: (William) Broderick
   pronouns: he/him
@@ -1008,8 +983,6 @@ billbrod:
 bonetcarne:
   affiliation: BCNatal Fetal Medicine Research Center
   country: Spain
-  expertise:
-  - OLS-1 project lead
   first-name: Elisenda
   last-name: Bonet-Carne
   pronouns: she/her
@@ -1023,7 +996,6 @@ bruno-soares:
     '
   country: Brazil
   expertise:
-  - OLS-1 project lead
   - SciComm
   - Community building
   - Open Data
@@ -1094,7 +1066,6 @@ cassgvp:
   country: UK
   email: cassandra.gouldvanpraag@gmail.com
   expertise:
-  - OLS-1 project lead
   - Online conferences
   - Behaviour change
   - Community engagement
@@ -1119,7 +1090,6 @@ christinerogers:
     '
   country: Canada
   expertise:
-  - OLS-1 project lead
   - Data sharing
   - Open science
   - Software development
@@ -1155,8 +1125,6 @@ da5nsy:
 dannycolin:
   affiliation: "Universit\xE9 de Montr\xE9al"
   country: Canada
-  expertise:
-  - OLS-1 project lead
   first-name: Danny
   last-name: Colin
   pronouns: he/him
@@ -1185,8 +1153,6 @@ dasaderi:
 davidviryachen:
   affiliation: Osaka University
   country: Japan
-  expertise:
-  - OLS-1 project lead
   first-name: David
   last-name: Chentanaman
   pronouns: he/him
@@ -1194,8 +1160,6 @@ davidviryachen:
 dlebauer:
   affiliation: University of Arizona
   country: USA
-  expertise:
-  - OLS-1 project lead
   first-name: David
   last-name: LeBauer
   pronouns: he/him
@@ -1210,8 +1174,6 @@ dylan-bastiaans:
 elsasci:
   affiliation: eLife
   country: UK
-  expertise:
-  - OLS-1 project lead
   first-name: Elsa
   github: false
   last-name: Loissel
@@ -1243,8 +1205,6 @@ emmyft:
 ewuramaminka:
   affiliation: University of Manchester
   country: UK
-  expertise:
-  - OLS-1 project lead
   first-name: Deborah
   last-name: Akuoko
   pronouns: she/her
@@ -1395,8 +1355,6 @@ hilyatuz-zahroh:
 homo-sapiens34:
   affiliation: IITP RAS
   country: Russia
-  expertise:
-  - OLS-1 project lead
   first-name: Zoe
   last-name: Chervontseva
   pronouns: she/her
@@ -1767,8 +1725,6 @@ laurichi13:
 lazycipher:
   affiliation: Galgotias University
   country: India
-  expertise:
-  - OLS-1 project lead
   first-name: Himanshu
   last-name: Singh
   pronouns: he/him
@@ -1992,8 +1948,6 @@ martinagvilas:
 matuskalas:
   affiliation: University of Bergen
   country: Norway
-  expertise:
-  - OLS-1 project lead
   first-name: "Mat\xFA\u0161"
   last-name: "Kala\u0161"
   pronouns: he/him
@@ -2702,8 +2656,6 @@ stephen-klusza:
 sudarshangc:
   affiliation: Media Lab Nepal
   country: Nepal
-  expertise:
-  - OLS-1 project lead
   first-name: Sudarshan
   last-name: GC
   pronouns: he/him
@@ -2850,7 +2802,6 @@ unode:
   - Full-stack developer
   - Computational Training
   - Reproducibility
-  - OLS-1 project lead
   - Computational biology
   - Metagenomics
   - Meta-transcriptomics

--- a/_includes/people.html
+++ b/_includes/people.html
@@ -53,6 +53,12 @@
       </div>
     </div>
 
+    {% if ols-roles %}
+    <p class="people">
+      <div class="people-description-question">Roles in OLS:</div> {{ ols-roles }}
+    </p>
+    {% endif %}
+
     {% if user.expertise %}
     <p class="people">
       <div class="people-description-question">Expertise:</div> {{ user.expertise | join: ", " }}

--- a/_layouts/community.html
+++ b/_layouts/community.html
@@ -1,0 +1,40 @@
+---
+layout: page
+---
+
+Thank You! to the {{ site.data.people | size }} awesome people who participate in or contribute to Open Life Science!
+
+<div class="community">
+    {% for user in site.data.people %}
+        {% assign username = user[0] %}
+        {% assign details = user[1] %}
+        <div class="card people-card">
+            <div class="card-content">
+                <div class="media">
+                    <div class="media-left people-card-avatar">
+                        <figure class="image is-48x48">
+                            <a href="#{{ username }}">
+                                <img
+                                    class="is-rounded"
+                                    src="https://avatars.githubusercontent.com/{{ username }}"
+                                    alt="The GitHub avatar of {{ details.name }}"/>
+                            </a>
+                        </figure>
+                    </div>
+                </div>
+            </div>
+        </div>
+    {% endfor %}
+</div>
+
+<h2>Details</h2>
+
+<div class="people">
+    {% for entry in site.data.people %}
+        {% assign username = entry[0] %}
+        {% assign user = entry[1] %}
+        {% include _includes/people.html username=username user=user %}
+    {% endfor %}
+</div>
+
+

--- a/_layouts/community.html
+++ b/_layouts/community.html
@@ -36,15 +36,36 @@ Thank You! to the {{ site.data.people | size }} awesome people who participate i
 {% assign ols-1-mentors = '' %}
 {% for project in ols-1-projects %}
     {% for p in project.participants %}
-        {% capture ols-1-participants %}{{ ols-1-participants }}, {{ p }}{% endcapture %}
+        {% capture ols-1-participants %}{{ ols-1-participants }} {{ p }}{% endcapture %}
     {% endfor %}
     {% for m in project.mentors %}
-        {% capture ols-1-mentors %}{{ ols-1-mentors }}, {{ m }}{% endcapture %}
+        {% capture ols-1-mentors %}{{ ols-1-mentors }} {{ m }}{% endcapture %}
     {% endfor %}
 {% endfor %}
 <!-- extract experts and organizers -->
-{% assign ols-1-experts = site.data.ols-1-metadata.experts %}
-{% assign ols-1-organizers = site.data.ols-1-metadata.organizers %}
+{% assign ols-1-experts = site.data.ols-1-metadata.experts | join: ' ' %}
+{% assign ols-1-organizers = site.data.ols-1-metadata.organizers | join: ' ' %}
+<!-- extract speakers and call hosts -->
+{% assign ols-1-speakers = '' %}
+{% assign ols-1-hosts = '' %}
+{% for w in site.data.ols-1-schedule %}
+    {% for c in w[1].calls %}
+        {% if c.type == 'Cohort' %}
+            {% for r in c.resources %}
+                {% if r.type == 'slides' and r.speaker %}
+                    {% capture ols-1-speakers %}{{ ols-1-speakers}} {{ r.speaker }}{% endcapture %}
+                {% endif %}
+            {% endfor %}
+        {% endif %}
+        {% if c.hosts %}
+            {% for h in c.hosts %}
+                {% capture ols-1-hosts %}{{ ols-1-hosts}} {{ h }}{% endcapture %}
+            {% endfor %}
+        {% endif %}
+    {% endfor %}
+{% endfor %}
+<!-- combine all -->
+{% capture ols-1-people %}{{ ols-1-participants }} {{ ols-1-experts }} {{ ols-1-mentors }} {{ ols-1-organizers }} {{ ols-1-speakers }} {{ ols-1-hosts }}{% endcapture %}
 
 <!-- OLS-2 -->
 <!-- extract participants and mentors -->
@@ -53,21 +74,88 @@ Thank You! to the {{ site.data.people | size }} awesome people who participate i
 {% assign ols-2-mentors = '' %}
 {% for project in ols-2-projects %}
     {% for p in project.participants %}
-        {% capture ols-2-participants %}{{ ols-2-participants }}, {{ p }}{% endcapture %}
+        {% capture ols-2-participants %}{{ ols-2-participants }} {{ p }}{% endcapture %}
     {% endfor %}
     {% for m in project.mentors %}
-        {% capture ols-2-mentors %}{{ ols-2-mentors }}, {{ m }}{% endcapture %}
+        {% capture ols-2-mentors %}{{ ols-2-mentors }} {{ m }}{% endcapture %}
     {% endfor %}
 {% endfor %}
 <!-- extract experts and organizers -->
 {% assign ols-2-experts = site.data.ols-2-metadata.experts %}
 {% assign ols-2-organizers = site.data.ols-2-metadata.organizers %}
+<!-- extract speakers and call hosts -->
+{% assign ols-2-speakers = '' %}
+{% assign ols-2-hosts = '' %}
+{% for w in site.data.ols-2-schedule %}
+    {% for c in w[1].calls %}
+        {% if c.type == 'Cohort' %}
+            {% for r in c.resources %}
+                {% if r.type == 'slides' and r.speaker %}
+                    {% capture ols-2-speakers %}{{ ols-2-speakers}} {{ r.speaker }}{% endcapture %}
+                {% endif %}
+            {% endfor %}
+        {% endif %}
+        {% if c.hosts %}
+            {% for h in c.hosts %}
+                {% capture ols-2-hosts %}{{ ols-2-hosts}} {{ h }}{% endcapture %}
+            {% endfor %}
+        {% endif %}
+    {% endfor %}
+{% endfor %}
+<!-- combine all -->
+{% capture ols-2-people %}{{ ols-2-participants }} {{ ols-2-experts }} {{ ols-2-mentors }} {{ ols-2-organizers }} {{ ols-2-speakers }} {{ ols-2-hosts }}{% endcapture %}
 
 <div class="people">
     {% for entry in site.data.people %}
         {% assign username = entry[0] %}
         {% assign user = entry[1] %}
-        {% include _includes/people.html username=username user=user %}
+        {% assign ols-roles = '' %}
+        {% if ols-1-people contains username %}
+            {% assign roles = '' %}
+            {% if ols-1-participants contains username %}
+                {% capture roles %}{{ roles }}, project lead{% endcapture %}
+            {% endif %}
+            {% if ols-1-mentors contains username %}
+                {% capture roles %}{{ roles }}, mentor{% endcapture %}
+            {% endif %}
+            {% if ols-1-experts contains username %}
+                {% capture roles %}{{ roles }}, expert{% endcapture %}
+            {% endif %}
+            {% if ols-1-speakers contains username %}
+                {% capture roles %}{{ roles }}, speaker{% endcapture %}
+            {% endif %}
+            {% if ols-1-hosts contains username %}
+                {% capture roles %}{{ roles }}, call host{% endcapture %}
+            {% endif %}
+            {% if ols-1-organizers contains username %}
+                {% capture roles %}{{ roles }}, organizer{% endcapture %}
+            {% endif %}
+            {% capture ols-roles %}{{ ols-roles }} - OLS-1 {{ roles | remove_first: ', ' }}{% endcapture %}
+        {% endif %}
+        {% if ols-2-people contains username %}
+            {% assign roles = '' %}
+            {% if ols-2-participants contains username %}
+                {% capture roles %}{{ roles }}, project lead{% endcapture %}
+            {% endif %}
+            {% if ols-2-mentors contains username %}
+                {% capture roles %}{{ roles }}, mentor{% endcapture %}
+            {% endif %}
+            {% if ols-2-experts contains username %}
+                {% capture roles %}{{ roles }}, expert{% endcapture %}
+            {% endif %}
+            {% if ols-2-speakers contains username %}
+                {% capture roles %}{{ roles }}, speaker{% endcapture %}
+            {% endif %}
+            {% if ols-2-hosts contains username %}
+                {% capture roles %}{{ roles }}, call host{% endcapture %}
+            {% endif %}
+            {% if ols-2-organizers contains username %}
+                {% capture roles %}{{ roles }}, organizer{% endcapture %}
+            {% endif %}
+            {% capture ols-roles %}{{ ols-roles }} - OLS-2 {{ roles | remove_first: ', ' }}{% endcapture %}
+        {% endif %}
+        {% assign ols-roles = ols-roles | remove_first: ' - ' %}
+        {% include _includes/people.html username=username user=user ols-roles=ols-roles%}
     {% endfor %}
 </div>
 

--- a/_layouts/community.html
+++ b/_layouts/community.html
@@ -29,6 +29,40 @@ Thank You! to the {{ site.data.people | size }} awesome people who participate i
 
 <h2>Details</h2>
 
+<!-- OLS-1 -->
+<!-- extract participants and mentors -->
+{% assign ols-1-projects = site.data.ols-1-projects %}
+{% assign ols-1-participants = '' %}
+{% assign ols-1-mentors = '' %}
+{% for project in ols-1-projects %}
+    {% for p in project.participants %}
+        {% capture ols-1-participants %}{{ ols-1-participants }}, {{ p }}{% endcapture %}
+    {% endfor %}
+    {% for m in project.mentors %}
+        {% capture ols-1-mentors %}{{ ols-1-mentors }}, {{ m }}{% endcapture %}
+    {% endfor %}
+{% endfor %}
+<!-- extract experts and organizers -->
+{% assign ols-1-experts = site.data.ols-1-metadata.experts %}
+{% assign ols-1-organizers = site.data.ols-1-metadata.organizers %}
+
+<!-- OLS-2 -->
+<!-- extract participants and mentors -->
+{% assign ols-2-projects = site.data.ols-2-projects %}
+{% assign ols-2-participants = '' %}
+{% assign ols-2-mentors = '' %}
+{% for project in ols-2-projects %}
+    {% for p in project.participants %}
+        {% capture ols-2-participants %}{{ ols-2-participants }}, {{ p }}{% endcapture %}
+    {% endfor %}
+    {% for m in project.mentors %}
+        {% capture ols-2-mentors %}{{ ols-2-mentors }}, {{ m }}{% endcapture %}
+    {% endfor %}
+{% endfor %}
+<!-- extract experts and organizers -->
+{% assign ols-2-experts = site.data.ols-2-metadata.experts %}
+{% assign ols-2-organizers = site.data.ols-2-metadata.organizers %}
+
 <div class="people">
     {% for entry in site.data.people %}
         {% assign username = entry[0] %}

--- a/community.md
+++ b/community.md
@@ -1,28 +1,8 @@
 ---
-layout: page
+layout: community
 title: Community
+image: https://images.unsplash.com/photo-1469571486292-0ba58a3f068b?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1050&q=80
+photos:
+  name: Tim Marshall
+  url: https://unsplash.com/photos/cAtzHUz7Z8g
 ---
-
-Thank You! to the {{ site.data.people | size }} awesome people who participate in or contribute to Open Life Science!
-
-<div class="community">
-{% for user in site.data.people %}
-  {% assign username = user[0] %}
-  {% assign details = user[1] %}
-<div class="card people-card" id="{{ username }}">
-  <div class="card-content">
-    <div class="media">
-      <div class="media-left people-card-avatar">
-        <figure class="image is-48x48">
-          <img
-            class="is-rounded"
-            src="https://avatars.githubusercontent.com/{{ username }}"
-            alt="The GitHub avatar of {{ details.name }}"
-          />
-        </figure>
-      </div>
-    </div>
-  </div>
-</div>
-{% endfor %}
-</div>

--- a/css/custom.scss
+++ b/css/custom.scss
@@ -315,4 +315,15 @@ $link-active: $link-hover;
     margin-left: 0px;
     margin-right: 0px;
   }
+
+  a {
+    border-bottom: none;
+    color: inherit;
+
+    &:active,
+    &:focus,
+    &:hover {
+      background: none;
+    }
+  }
 }


### PR DESCRIPTION
This PR:

- Fix #210 with on the top only avatar and then details about people

   ![Screenshot 2020-12-28 at 18 18 36](https://user-images.githubusercontent.com/1842467/103231945-73d16b80-4939-11eb-90ec-4e5408cdb86f.png)


- Add information about roles in the different cohorts, extracted from the files in `_data`

	In community page, roles are extracted and displayed before the expertise:

	
    ![Screenshot 2020-12-28 at 18 18 55](https://user-images.githubusercontent.com/1842467/103232041-ba26ca80-4939-11eb-8df6-5367f5e4a536.png)

	Roles are not visible in other pages (too much to extract every time):

	
    ![Screenshot 2020-12-28 at 18 19 46](https://user-images.githubusercontent.com/1842467/103232077-cdd23100-4939-11eb-9028-4f351a678c13.png)

	Current scripts should be optimized (too much redundancy) - but later
