### PR TITLE
First round of addition of registered experts and mentors

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,3 +211,26 @@ In this file, for each week, it is listed the timeframe and the different calls 
    - `title`
    - `speaker`: username in `_data/people.yaml`, if slides
    - `link`
+
+## Order experts and possible mentors by expertise areas
+
+In metadata file for cohort, experts and possible mentors can be ordered by expertise area to be display in cohort page given these areas. 
+
+To order them:
+
+1. Activate the conda environment
+
+   ```
+   $ source activate open-life-science-website
+   ```
+
+   Or alternatively, get locally:
+   - Python 3.*
+   - pyyaml
+   - pandas
+
+2. Run the script which sort expertise and save information in metadata file
+
+   ```
+   $ python bin/sort-expertises.py -c <cohort id>
+   ```

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Add someone to the list of people:
     - `gitter`
     - `orcid`
     - `affiliation`
+    - `city`
     - `country` (*mandatory*)
     - `pronouns`
     - `expertise`
@@ -146,10 +147,12 @@ Add many people in a row to `_data/people.yaml`:
    - `First name`
    - `Last name`
    - `Email`
+   - `Github username`
    - `Twitter username`
    - `Website`
    - `ORCID`
    - `Affiliation`
+   - `City`
    - `Country`
    - `Pronouns`
    - `Areas of expertise (1 element per line)`

--- a/_data/ols-1-metadata.yaml
+++ b/_data/ols-1-metadata.yaml
@@ -15,21 +15,21 @@ experts:
   - annakrystalli
   - anneclinio
   - bgruening
-  - BhuvanaMeenakshiK
+  - bhuvanameenakshik
   - dasaderi
-  - Demellina
+  - demellina
   - emmyft
   - fpsom
   - gedankenstuecke
   - ha0ye
   - hdinkel
-  - InquisitiveVi
-  - JasonJWilliamsNY
+  - inquisitivevi
+  - jasonjwilliamsny
   - joelostblom
   - kariljordan
   - katrinleinweber
   - kipkurui
-  - KirstieJane
+  - kirstiejane
   - kswhitney
   - luispedro
   - mkuzak
@@ -44,7 +44,7 @@ experts:
   - rainsworth
   - satagopam7
   - unode
-  - VickyNembaware
+  - vickynembaware
 organizers:
   - bebatut
   - malvikasharan

--- a/_data/ols-1-projects.yaml
+++ b/_data/ols-1-projects.yaml
@@ -5,7 +5,7 @@
 - name: Open Science Community Barcelona (OSCBa)
   participants:
     - bonetcarne
-  mentors: Zebetus
+  mentors: zebetus
   description: >
     This project aims to create a community of local scientists to share and promote open science in Barcelona,
     Spain. I would like to use as an example the <a href="https://openscience-utrecht.com/">OSCU</a>
@@ -30,7 +30,7 @@
     related policies
   participants:
     - ewuramaminka
-  mentors: VickyNembaware
+  mentors: vickynembaware
   description: >
     Most sub Saharan African countries barely have quality health data for national policy
     making, especially on cancer. Thus, more work might be needed to improve the data quality,
@@ -46,7 +46,7 @@
 
 - name: Infusing a culture of open science within the community of researchers at the Zuckerman Institute
   participants:
-    - ChiaraBertipaglia
+    - chiarabertipaglia
   mentors: mkuzak
   description: >
     The community of <a href="https://zuckermaninstitute.columbia.edu/">Columbia University’s Zuckerman Institute</a> is composed of neuroscientists at
@@ -67,10 +67,10 @@
 
 - name: Bioinformatics Hub of Kenya (BHK)
   participants:
-    - Fnyasimi
-    - Megmugure
-    - Kiragu-Mwaura
-    - LandiMi2
+    - fnyasimi
+    - megmugure
+    - kiragu-mwaura
+    - landimi2
   mentors:
     - tobyhodges
     - malvikasharan
@@ -114,7 +114,7 @@
 - name: "@Diversidade em Foco"
   participants:
     - bruno-soares
-    - NaraLB
+    - naralb
   mentors: unode
   description: >
     [Biodiversidade em Foco](http://www.abc.org.br/atuacao/nacional/projeto-de-ciencia-para-o-brasil/biodiversidade-em-foco/)
@@ -182,7 +182,7 @@
 
 - name: Open Connect Platform in Africa
   participants:
-    - Lilian9
+    - lilian9
   mentors: kipkurui
   description: >
     In Open community, there is disconnect between Open practitioners and advocates hence need for
@@ -316,10 +316,10 @@
 
 - name: Improving Documentation for Open Data and Software in the Agricultural Research Community
   participants:
-    - KristinaRiemer
+    - kristinariemer
     - dlebauer
-    - MagicMilly
-    - Sithyphus
+    - magicmilly
+    - sithyphus
   mentors: katrinleinweber
   description: >
     We are members of the Data Infrastructure for Agriculture Group at <a href="https://www.arizona.edu/">The University of Arizona</a>.
@@ -367,7 +367,7 @@
 
 - name: Enabling open science practices in biology education
   participants:
-    - MorphoFun
+    - morphofun
   mentors: fpsom
   description: >
     The proposed project would establish a foundation for developing a tutorial on training
@@ -389,7 +389,7 @@
 
 - name: Open Science UMontreal (OSUM)
   participants:
-    - SamGuay
+    - samguay
     - dannycolin
   mentors: ajstewartlang
   description: >

--- a/_data/ols-1-projects.yaml
+++ b/_data/ols-1-projects.yaml
@@ -416,7 +416,7 @@
 
 - name: Creating network of Data Champions at the library of Free University of Amsterdam
   participants:
-    - LangData
+    - karvovskaya
   mentors: pherterich
   description: >
     From February 1st I am starting a new position as community manager RDM at the library

--- a/_data/ols-1-schedule.yaml
+++ b/_data/ols-1-schedule.yaml
@@ -511,7 +511,7 @@
         - 
           type: slides
           title: Using Personas and Pathways to Build Community
-          speaker: KirstieJane
+          speaker: kirstiejane
           link: https://docs.google.com/presentation/d/1-rdQipVmJ5lWelQ1oEbi86EbFwTpDh5TLeJ2TAg-oo4/present?token=AC4w5VjIFg3LDysFSoGymFzYFj2KWG5TLw%3A1596111072881&includes_info_params=1&eisi=CLmJloz59OoCFZFzJgodzMEHYA#slide=id.g6e991a6830_0_0
         - 
           type: document

--- a/_data/ols-2-metadata.yaml
+++ b/_data/ols-2-metadata.yaml
@@ -40,7 +40,7 @@ experts:
   - kipkurui
   - KirstieJane
   #- kswhitney # need to confirm
-  - LangData
+  - karvovskaya
   - lauracion
   - luispedro
   - lwinfree
@@ -116,7 +116,7 @@ possible-mentors:
   #- Kiragu-Mwaura
   #- kswhitney # need to confirm
   - LandiMi2
-  - LangData
+  - karvovskaya
   - Lilian9
   - lpantano
   - luispedro

--- a/_data/ols-2-metadata.yaml
+++ b/_data/ols-2-metadata.yaml
@@ -13,17 +13,17 @@ experts:
   - anita-broellochs
   #- annakrystalli # need to confirm
   #- anneclinio # need to confirm
-  - ArielleBL
+  - ariellebl
   - bduckles
   - bebatut
   - bgruening
   #- BhuvanaMeenakshiK # need to confirm
   - burkemlou
   - cassgvp
-  - ChiaraBertipaglia
+  - chiarabertipaglia
   - christinerogers
   - dasaderi
-  - Demellina
+  - demellina
   - emmyft
   - fpsom
   - gedankenstuecke
@@ -31,14 +31,14 @@ experts:
   - ha0ye
   - hdinkel
   #- InquisitiveVi # need to confirm
-  - JasonJWilliamsNY
+  - jasonjwilliamsny
   - jcolomb
   - jezcope
   - kariljordan
   - klauer2207
   #- katrinleinweber # need to confirm
   - kipkurui
-  - KirstieJane
+  - kirstiejane
   #- kswhitney # need to confirm
   - karvovskaya
   - lauracion
@@ -53,7 +53,7 @@ experts:
   #- mruizvelley # need to confirm
   #- mvdbeek # need to confirm
   - nerantzis
-  - NPalopoli
+  - npalopoli
   - npscience
   #- nsoranzo # need to confirm
   - orchid00
@@ -64,21 +64,21 @@ experts:
   - rgaiacs
   - rossmounce
   #- satagopam7 # need to confirm
-  - SantosRAC
+  - santosrac
   - sdopoku
   - sgibson91
   - sofia-kirke-forslund
   - thessaly
-  - TKlingstrom
+  - tklingstrom
   - tnabtaf
   - tobyhodges
   - tsonika
   - unode
   - vcheplygina
-  - VickyNembaware
+  - vickynembaware
   - yochannah
   - yvanlebras
-  - Zebetus
+  - zebetus
 possible-mentors:
   - aidanbudd
   - ajstewartlang
@@ -87,7 +87,7 @@ possible-mentors:
   - anita-broellochs
   - anjali-mazumder
   #- annefou # need to confirm
-  - ArielleBL
+  - ariellebl
   - bebatut
   - bgruening
   #- billbrod # ask later when OLS-2 launched, need to check with Rodrigo
@@ -97,10 +97,10 @@ possible-mentors:
   - christinerogers
   #- dasaderi # need to confirm
   #- davidviryachen # ask later when OLS-2 launched, need to check with Holger
-  - Delphine-L
+  - delphine-l
   #- dlebauer # need to check with Katrin
   - emmyft
-  - Fnyasimi
+  - fnyasimi
   - fpsom
   #- ha0ye # ask later when OLS-2 launched
   - hdinkel
@@ -115,9 +115,9 @@ possible-mentors:
   - kipkurui
   #- Kiragu-Mwaura
   #- kswhitney # need to confirm
-  - LandiMi2
+  - landimi2
   - karvovskaya
-  - Lilian9
+  - lilian9
   - lpantano
   - luispedro
   #- MagicMilly # ask later when OLS-2 launched, need to check with Katrin
@@ -126,7 +126,7 @@ possible-mentors:
   - martinagvilas
   - mblue9
   - meagdoh
-  - Megmugure
+  - megmugure
   - mesfind
   #- MorphoFun # need to check with Fotis
   - mkuzak
@@ -141,16 +141,16 @@ possible-mentors:
   - rgaiacs
   #- rodrigocam # need to confirm
   - rs_khetani
-  - SamGuay
+  - samguay
   - sdopoku
   - sgibson91
   - tnabtaf
   - tsonika
   - unode
-  #- VickyNembaware # need to confirm
+  #- vickynembaware # need to confirm
   - yochannah
   - yvanlebras
-  - Zebetus
+  - zebetus
 organizers:
   - bebatut
   - malvikasharan

--- a/_data/ols-2-projects.yaml
+++ b/_data/ols-2-projects.yaml
@@ -45,7 +45,7 @@
 
 - name: Creating community awareness of open science practices in phytolith research
   participants:
-    - EKaroune
+    - ekaroune
   mentors:
     - yvanlebras
   description: |
@@ -86,7 +86,7 @@
 
 - name: Creating a single pipeline for metagenome classification
   participants:
-    - MuhammetCelik
+    - muhammetcelik
   mentors:
     - malloryfreeberg
   description: |
@@ -105,7 +105,7 @@
   participants:
     - bailey-harrington
   mentors:
-    - piv-gopalasingam
+    - pivg
   description: |
     Chronic Learning is an open resource for academics and individuals who are
     trying to teach or learn something new; the scope is not limited to science.
@@ -143,7 +143,7 @@
     - coopersmout
   mentors:
     - luispedro
-    - Lilian9
+    - lilian9
   description: |
     Open Science practices have the potential to benefit everyone in the life
     science community (and broader society), but their adoption is limited by
@@ -166,7 +166,7 @@
 - name: Developing the Research Software and Systems Engineering Community to support Life Sciences in Africa
   participants:
     - pvanheus
-    - Banshee1221
+    - banshee1221
   mentors:
     - mesfind
     - rgaiacs
@@ -226,7 +226,7 @@
 
 - name: Global land-use and land-cover data under historical, current, and future climatic conditions for ecologists
   participants:
-    - Tai-Rocha
+    - tai-rocha
   mentors:
     - bruno-soares
     - yvanlebras
@@ -250,10 +250,10 @@
 
 - name: BioLab Open Source Projects
   participants:
-    - Boi-KONE
+    - boi-kone
     - bakary-n'tji diallo
   mentors:
-    - Delphine-L
+    - delphine-l
   description: |
     BioLab Open Source Projects is the beginning of a platform where biomedical
     researchers, and computer scientists will work closely with to solve some
@@ -279,7 +279,7 @@
 
 - name: Target approach in the stages of liver cirrhosis to reverse back in good condition.
   participants:
-    - WasifaRahman
+    - wasifarahman
   mentors:
     - tsonika
     - malvikasharan
@@ -361,7 +361,7 @@
 
 - name: Sharing 3D Modeling Workflows for Biomechanists and Palaeontologists
   participants:
-    - EvaCHerbst
+    - evacherbst
     - dylan-bastiaans
   mentors:
     - hdinkel
@@ -521,7 +521,7 @@
 
 - name: OpenWorkstation - A modular and open-source concept for customized automation equipment
   participants:
-    - SebastianEggert
+    - sebastianeggert
   mentors:
     - meagdoh
   description: |
@@ -548,9 +548,9 @@
 
 - name: The Turing Way - Guide for Ethical Research
   participants:
-    - BrainonSilicon
-    - Ismael-KG
-    - LauraCarter
+    - brainonsilicon
+    - ismael-kg
+    - lauracarter
   mentors:
     - jezcope
     - anjali-mazumder
@@ -591,9 +591,9 @@
 - name: Turing Data Stories
   participants:
     - crangelsmith
-    - DavidBeavan
+    - davidbeavan
     - samvanstroud
-    - Kevinxufs
+    - kevinxufs
   mentors:
     - yochannah
   description: |
@@ -619,10 +619,10 @@
 
 - name: Embedding Accessibility in The Turing Way Open Source Community Guidance
   participants:
-    - NehaMoopen
+    - nehamoopen
     - paulowoicho
   mentors:
-    - SamGuay
+    - samguay
   description: |
     The Turing Way book is a community-driven book for reproducible research
     in data science. It is written by data scientists, academics, researchers,
@@ -650,7 +650,7 @@
 
 - name: Towards open and citizen-led data informing the decarbonisation of existing housing
   participants:
-    - KateSimpson
+    - katesimpson
   mentors:
     - ArielleBL
   description: |
@@ -675,7 +675,7 @@
 
 - name: Autistica - Turing Citizen Science Project
   participants:
-    - GeorgiaHCA
+    - georgiahca
     - katoss
   mentors:
     - anelda

--- a/_data/ols-2-projects.yaml
+++ b/_data/ols-2-projects.yaml
@@ -732,7 +732,7 @@
     - ekeluv
   mentors:
     - kipkurui
-    - LangData
+    - karvovskaya
   description: |
     The H3ABioNet Open Learning Circles (OLC) Initiative aims to build a 
     community of peers committed to learning and teaching each other 

--- a/_data/ols-2-schedule.yaml
+++ b/_data/ols-2-schedule.yaml
@@ -494,7 +494,7 @@
         -
           type: slides
           title: Open Protocols
-          speaker: GanleyEmma
+          speaker: ganleyemma
           link: https://docs.google.com/presentation/d/1_8Fp5DKh_XXwj34DwR-dzTvUCk1c0ynhy7MvmaHFFoA/present?token=AC4w5ViYvEiWzkDp6pI6j2zDny92AF5luQ%3A1603710808548&includes_info_params=1&eisi=CMH6w6iQ0uwCFXVpTAodBIcBVw#slide=id.g849ffa2549_0_171
         -
           type: slides

--- a/_data/ols-3-metadata.yaml
+++ b/_data/ols-3-metadata.yaml
@@ -1,48 +1,508 @@
-# List of experts and guest speakers for OLS-2
+# List of experts, possible mentors and organizers for OLS-3
 #
 #
 # People should be also in people.yaml file and linked using their GitHub username
+# Ordering by expertise should be done by running the bin/sort-expertises.py script
 ---
 experts:
-  - alexwlchan
-  - anenadic
-  - ariellebl
+- alexwlchan
+- anenadic
+- ariellebl
+- bebatut
+- burkemlou
+- demellina
+- ealescak
+- estherplomp
+- fpsom
+- gedankenstuecke
+- ivotron
+- jezcope
+- harpreetsingh05
+- karvovskaya
+- kmexter
+- lauracion
+- malvikasharan
+- martinagvilas
+- npalopoli
+- pivg
+- profgiuseppe
+- rainsworth
+- thessaly
+- tobyhodges
+- tsonika
+- yochannah
+- yvanlebras
+experts-with-expertise:
+  Addiction research:
+  - lauracion
+  Algorithm design:
+  - malvikasharan
+  Archaeology:
+  - estherplomp
+  Astrophysics:
+  - kmexter
+  - rainsworth
+  Automation:
+  - profgiuseppe
+  Best software delivery practices applied in scientific contexts:
+  - ivotron
+  Bioanthropology:
+  - estherplomp
+  Bioinformatics:
   - bebatut
   - burkemlou
-  - demellina
-  - estherplomp
   - fpsom
   - gedankenstuecke
-  - ivotron
-  - jezcope
-  - karvovskaya
+  - harpreetsingh05
+  - malvikasharan
+  Citizen science:
+  - bebatut
+  - gedankenstuecke
+  - thessaly
+  Code of conducts:
+  - ariellebl
+  Collaborating with Git & GitHub/GitLab:
+  - tobyhodges
+  Communication:
+  - ealescak
+  Community building:
+  - ealescak
   - lauracion
   - malvikasharan
-  - martinagvilas
+  - rainsworth
+  - yochannah
+  Community consultation:
+  - ariellebl
+  Community goals:
+  - ariellebl
+  Community management:
+  - gedankenstuecke
+  Community science:
+  - thessaly
+  Computational Epigenomics:
+  - tsonika
+  Computational biology:
+  - ariellebl
+  - npalopoli
+  Computer Science:
+  - ivotron
+  Continuous integration:
+  - profgiuseppe
+  Course delivery:
+  - pivg
+  Course design:
+  - pivg
+  Culture change:
+  - ariellebl
+  Data Science:
+  - tsonika
+  Data Science best practices:
+  - malvikasharan
+  Data analysis:
+  - yvanlebras
+  Data management:
+  - jezcope
+  - kmexter
+  - yvanlebras
+  Designing and developing training material:
+  - tobyhodges
+  DevOps for science:
+  - ivotron
+  Digital preservation:
+  - jezcope
+  Diversity:
+  - ealescak
+  Drug discovery:
+  - ariellebl
+  Ecology:
+  - yvanlebras
+  Education:
   - npalopoli
   - pivg
-  - profgiuseppe
-  - rainsworth
-  - thessaly
-  - tobyhodges
-  - tsonika
-  - yochannah
-  - yvanlebras
-possible-mentors:
-  - bebatut
-  - bruno-soares
-  - burkemlou
+  Event planning:
+  - ealescak
+  FAIR:
   - estherplomp
-  - fpsom
-  - hrhotz
-  - jezcope
+  FAIR data:
+  - kmexter
+  FAIR training materials:
+  - burkemlou
+  Fieldwork:
   - karvovskaya
+  Functional genomics:
+  - burkemlou
+  Galaxy:
+  - bebatut
+  Galaxy training:
+  - bebatut
+  Genomics:
+  - tsonika
+  Git:
+  - jezcope
   - malvikasharan
-  - pivg
+  - profgiuseppe
   - tobyhodges
+  GitHub:
+  - rainsworth
+  - tobyhodges
+  GitLab:
+  - tobyhodges
+  Health data science and artificial intelligence/Biostatistics:
+  - lauracion
+  High-throughput sequencing:
+  - bebatut
+  Inclusion:
+  - ealescak
+  Inclusive and collaborative practices:
+  - malvikasharan
+  Isotopes:
+  - estherplomp
+  Leadership:
+  - ealescak
+  Libraries:
+  - jezcope
+  Life Science:
+  - burkemlou
+  Linked data for community science:
+  - thessaly
+  Machine learning:
+  - fpsom
+  - harpreetsingh05
+  - martinagvilas
+  - tsonika
+  Marine data:
+  - kmexter
+  Mentoring:
   - yochannah
-  - yvanlebras
-organizers:
+  Mentorship:
+  - malvikasharan
+  Metagenomics:
+  - bebatut
+  Molecular Modeling:
+  - harpreetsingh05
+  Molecular interactions:
+  - npalopoli
+  Neuroimaging:
+  - martinagvilas
+  Neuroscience:
+  - martinagvilas
+  Neuroscience.:
+  - ariellebl
+  No listed expertise:
+  - alexwlchan
+  OLS co-lead:
   - bebatut
   - malvikasharan
   - yochannah
+  Open Science:
+  - fpsom
+  Open Science/Research:
+  - rainsworth
+  Open access:
+  - demellina
+  Open access publishing:
+  - jezcope
+  Open and public databases and sources:
+  - profgiuseppe
+  Open and reproducible research best practices:
+  - anenadic
+  Open data:
+  - estherplomp
+  - kmexter
+  Open education:
+  - lauracion
+  Open infrastructure:
+  - martinagvilas
+  Open infrastructure for science:
+  - ivotron
+  Open peer review:
+  - demellina
+  Open protocols:
+  - estherplomp
+  Open research:
+  - demellina
+  Open science:
+  - demellina
+  Open science communities:
+  - martinagvilas
+  Open science hardware:
+  - thessaly
+  Open source:
+  - jezcope
+  - martinagvilas
+  Open source documentation:
+  - martinagvilas
+  Organising events:
+  - rainsworth
+  Osteology:
+  - estherplomp
+  Parasitology:
+  - burkemlou
+  'Pedagogical approaches to instructor training and curricula development ':
+  - anenadic
+  Personal data:
+  - gedankenstuecke
+  Preprints:
+  - demellina
+  Proteins:
+  - npalopoli
+  Publishing web content with Wordpress or Jekyll and GitHub/GitLab Pages:
+  - tobyhodges
+  Python:
+  - gedankenstuecke
+  - malvikasharan
+  R Programming:
+  - harpreetsingh05
+  Reproducibility:
+  - rainsworth
+  Reproducible science:
+  - profgiuseppe
+  Research data management:
+  - estherplomp
+  - karvovskaya
+  Research methods:
+  - ealescak
+  Road mapping and strategy planning:
+  - ariellebl
+  Science and tech democratization:
+  - thessaly
+  Science communication:
+  - pivg
+  Scientific community engagement:
+  - tobyhodges
+  Software development:
+  - yochannah
+  Structural bioinformatics:
+  - npalopoli
+  Teaching:
+  - ealescak
+  Teaching and organising workshops:
+  - tobyhodges
+  Theoretical linguistics:
+  - karvovskaya
+  Training:
+  - burkemlou
+  - fpsom
+  - pivg
+  Training and teaching tech to researchers:
+  - anenadic
+  Transcriptomics:
+  - tsonika
+  Unix:
+  - malvikasharan
+  Version control:
+  - martinagvilas
+  Virtual events:
+  - rainsworth
+  Web:
+  - jezcope
+  Web development:
+  - gedankenstuecke
+  Webinar and workshop development:
+  - burkemlou
+  eLearning:
+  - burkemlou
+organizers:
+- bebatut
+- malvikasharan
+- yochannah
+possible-mentors:
+- bebatut
+- bruno-soares
+- burkemlou
+- ealescak
+- estherplomp
+- fpsom
+- harpreetsingh05
+- hrhotz
+- jezcope
+- karvovskaya
+- malloryfreeberg
+- malvikasharan
+- pivg
+- tobyhodges
+- yochannah
+- yvanlebras
+possible-mentors-with-expertise:
+  Algorithm design:
+  - malvikasharan
+  Archaeology:
+  - estherplomp
+  Bioanthropology:
+  - estherplomp
+  Bioconductor:
+  - hrhotz
+  Biodiversity:
+  - bruno-soares
+  Bioinformatics:
+  - bebatut
+  - burkemlou
+  - fpsom
+  - harpreetsingh05
+  - hrhotz
+  - malloryfreeberg
+  - malvikasharan
+  Citizen science:
+  - bebatut
+  Collaborating with Git & GitHub/GitLab:
+  - tobyhodges
+  Communication:
+  - ealescak
+  Community building:
+  - bruno-soares
+  - ealescak
+  - malvikasharan
+  - yochannah
+  Course delivery:
+  - pivg
+  Course design:
+  - pivg
+  Data Science best practices:
+  - malvikasharan
+  Data analysis:
+  - yvanlebras
+  Data management:
+  - jezcope
+  - malloryfreeberg
+  - yvanlebras
+  Designing and developing training material:
+  - tobyhodges
+  Digital preservation:
+  - jezcope
+  Diversity:
+  - ealescak
+  Ecology:
+  - yvanlebras
+  Education:
+  - pivg
+  Event planning:
+  - ealescak
+  FAIR:
+  - estherplomp
+  FAIR principles:
+  - malloryfreeberg
+  FAIR training materials:
+  - burkemlou
+  Fieldwork:
+  - karvovskaya
+  Functional genomics:
+  - burkemlou
+  Galaxy:
+  - bebatut
+  - hrhotz
+  - malloryfreeberg
+  Galaxy training:
+  - bebatut
+  Git:
+  - jezcope
+  - malvikasharan
+  - tobyhodges
+  GitHub:
+  - malloryfreeberg
+  - tobyhodges
+  GitLab:
+  - tobyhodges
+  High-throughput sequencing:
+  - bebatut
+  Human genomics and phenomics:
+  - malloryfreeberg
+  Inclusion:
+  - ealescak
+  Inclusive and collaborative practices:
+  - malvikasharan
+  Isotopes:
+  - estherplomp
+  Leadership:
+  - ealescak
+  Libraries:
+  - jezcope
+  Life Science:
+  - burkemlou
+  Machine learning:
+  - fpsom
+  - harpreetsingh05
+  Mentoring:
+  - yochannah
+  Mentorship:
+  - malvikasharan
+  Metadata:
+  - malloryfreeberg
+  Metagenomics:
+  - bebatut
+  Molecular Modeling:
+  - harpreetsingh05
+  Next Generation Sequencing:
+  - hrhotz
+  OLS co-lead:
+  - bebatut
+  - malvikasharan
+  - yochannah
+  Ontologies:
+  - malloryfreeberg
+  Open Data:
+  - bruno-soares
+  Open Science:
+  - fpsom
+  Open access publishing:
+  - jezcope
+  Open data:
+  - estherplomp
+  Open protocols:
+  - estherplomp
+  Open source:
+  - jezcope
+  Osteology:
+  - estherplomp
+  Parasitology:
+  - burkemlou
+  Post-transcriptional gene regulation:
+  - malloryfreeberg
+  PostgreSQL:
+  - hrhotz
+  Project management:
+  - malloryfreeberg
+  Publishing web content with Wordpress or Jekyll and GitHub/GitLab Pages:
+  - tobyhodges
+  Python:
+  - malvikasharan
+  R:
+  - malloryfreeberg
+  R Programming:
+  - harpreetsingh05
+  RNA biology:
+  - malloryfreeberg
+  Research data management:
+  - estherplomp
+  - karvovskaya
+  Research methods:
+  - ealescak
+  SQL:
+  - malloryfreeberg
+  SciComm:
+  - bruno-soares
+  Science communication:
+  - pivg
+  Scientific community engagement:
+  - tobyhodges
+  Single cell sequencing:
+  - malloryfreeberg
+  Software development:
+  - yochannah
+  Teaching:
+  - ealescak
+  Teaching and organising workshops:
+  - tobyhodges
+  Theoretical linguistics:
+  - karvovskaya
+  Training:
+  - burkemlou
+  - fpsom
+  - pivg
+  Unix:
+  - malvikasharan
+  Web:
+  - jezcope
+  Webinar and workshop development:
+  - burkemlou
+  eLearning:
+  - burkemlou

--- a/_data/ols-3-metadata.yaml
+++ b/_data/ols-3-metadata.yaml
@@ -7,6 +7,7 @@
 experts:
 - adam-gristwood
 - aidanbudd
+- alexandra-holinski
 - alexwlchan
 - anenadic
 - ariellebl
@@ -20,10 +21,12 @@ experts:
 - gedankenstuecke
 - ivotron
 - jezcope
+- kswhitney
 - harpreetsingh05
 - karvovskaya
 - kmexter
 - lauracion
+- meagdoh
 - malvikasharan
 - martinagvilas
 - npalopoli
@@ -31,9 +34,12 @@ experts:
 - prashbio
 - profgiuseppe
 - rainsworth
+- serahrono
+- sgibson91
 - thessaly
 - tobyhodges
 - tsonika
+- unode
 - yochannah
 - yvanlebras
 experts-with-expertise:
@@ -327,11 +333,14 @@ possible-mentors:
 - hrhotz
 - jezcope
 - karvovskaya
+- meagdoh
 - malloryfreeberg
 - malvikasharan
 - pivg
 - prashbio
+- sgibson91
 - tobyhodges
+- unode
 - yochannah
 - yvanlebras
 possible-mentors-with-expertise:

--- a/_data/ols-3-metadata.yaml
+++ b/_data/ols-3-metadata.yaml
@@ -5,11 +5,14 @@
 # Ordering by expertise should be done by running the bin/sort-expertises.py script
 ---
 experts:
+- adam-gristwood
+- aidanbudd
 - alexwlchan
 - anenadic
 - ariellebl
 - bebatut
 - burkemlou
+- christinerogers
 - demellina
 - ealescak
 - estherplomp
@@ -25,6 +28,7 @@ experts:
 - martinagvilas
 - npalopoli
 - pivg
+- prashbio
 - profgiuseppe
 - rainsworth
 - thessaly
@@ -71,6 +75,8 @@ experts-with-expertise:
   - malvikasharan
   - rainsworth
   - yochannah
+  Community building.:
+  - aidanbudd
   Community consultation:
   - ariellebl
   Community goals:
@@ -163,6 +169,8 @@ experts-with-expertise:
   - jezcope
   Life Science:
   - burkemlou
+  Life science communications:
+  - adam-gristwood
   Linked data for community science:
   - thessaly
   Machine learning:
@@ -190,10 +198,6 @@ experts-with-expertise:
   - ariellebl
   No listed expertise:
   - alexwlchan
-  OLS co-lead:
-  - bebatut
-  - malvikasharan
-  - yochannah
   Open Science:
   - fpsom
   Open Science/Research:
@@ -238,7 +242,7 @@ experts-with-expertise:
   - estherplomp
   Parasitology:
   - burkemlou
-  'Pedagogical approaches to instructor training and curricula development ':
+  Pedagogical approaches to instructor training and curricula development:
   - anenadic
   Personal data:
   - gedankenstuecke
@@ -274,6 +278,8 @@ experts-with-expertise:
   - yochannah
   Structural bioinformatics:
   - npalopoli
+  'Systems Biology, Bioinformatics, Mentoring ':
+  - prashbio
   Teaching:
   - ealescak
   Teaching and organising workshops:
@@ -302,14 +308,18 @@ experts-with-expertise:
   - burkemlou
   eLearning:
   - burkemlou
+  neuroinformatics, open science, open source, research software:
+  - christinerogers
 organizers:
 - bebatut
 - malvikasharan
 - yochannah
 possible-mentors:
+- adam-gristwood
 - bebatut
 - bruno-soares
 - burkemlou
+- christinerogers
 - ealescak
 - estherplomp
 - fpsom
@@ -320,6 +330,7 @@ possible-mentors:
 - malloryfreeberg
 - malvikasharan
 - pivg
+- prashbio
 - tobyhodges
 - yochannah
 - yvanlebras
@@ -418,6 +429,8 @@ possible-mentors-with-expertise:
   - jezcope
   Life Science:
   - burkemlou
+  Life science communications:
+  - adam-gristwood
   Machine learning:
   - fpsom
   - harpreetsingh05
@@ -433,10 +446,6 @@ possible-mentors-with-expertise:
   - harpreetsingh05
   Next Generation Sequencing:
   - hrhotz
-  OLS co-lead:
-  - bebatut
-  - malvikasharan
-  - yochannah
   Ontologies:
   - malloryfreeberg
   Open Data:
@@ -488,6 +497,8 @@ possible-mentors-with-expertise:
   - malloryfreeberg
   Software development:
   - yochannah
+  'Systems Biology, Bioinformatics, Mentoring ':
+  - prashbio
   Teaching:
   - ealescak
   Teaching and organising workshops:
@@ -506,3 +517,5 @@ possible-mentors-with-expertise:
   - burkemlou
   eLearning:
   - burkemlou
+  neuroinformatics, open science, open source, research software:
+  - christinerogers

--- a/_data/ols-3-metadata.yaml
+++ b/_data/ols-3-metadata.yaml
@@ -6,30 +6,42 @@
 experts:
   - alexwlchan
   - anenadic
-  - ArielleBL
+  - ariellebl
   - bebatut
   - burkemlou
-  - Demellina
+  - demellina
+  - estherplomp
   - fpsom
   - gedankenstuecke
   - ivotron
+  - jezcope
   - karvovskaya
+  - lauracion
   - malvikasharan
   - martinagvilas
+  - npalopoli
+  - pivg
+  - profgiuseppe
   - rainsworth
   - thessaly
   - tobyhodges
   - tsonika
   - yochannah
+  - yvanlebras
 possible-mentors:
   - bebatut
+  - bruno-soares
   - burkemlou
+  - estherplomp
   - fpsom
   - hrhotz
+  - jezcope
   - karvovskaya
   - malvikasharan
+  - pivg
   - tobyhodges
   - yochannah
+  - yvanlebras
 organizers:
   - bebatut
   - malvikasharan

--- a/_data/ols-3-metadata.yaml
+++ b/_data/ols-3-metadata.yaml
@@ -4,153 +4,32 @@
 # People should be also in people.yaml file and linked using their GitHub username
 ---
 experts:
-  #- aath0
-  #- agbeltran
-  #- aidanbudd
-  #- ajstewartlang
-  #- alexwlchan
-  #- anenadic
-  #- anita-broellochs
-  #- annakrystalli # need to confirm
-  #- anneclinio # need to confirm
-  #- ArielleBL
-  #- bduckles
+  - alexwlchan
+  - anenadic
+  - ArielleBL
   - bebatut
-  #- bgruening
-  #- BhuvanaMeenakshiK # need to confirm
-  #- burkemlou
-  #- cassgvp
-  #- ChiaraBertipaglia
-  #- christinerogers
-  #- dasaderi
-  #- Demellina
-  #- emmyft
-  #- fpsom
-  #- gedankenstuecke
-  #- graciellehigino
-  #- ha0ye
-  #- hdinkel
-  #- InquisitiveVi # need to confirm
-  #- JasonJWilliamsNY
-  #- jcolomb
-  #- jezcope
-  #- kariljordan
-  #- klauer2207
-  #- katrinleinweber # need to confirm
-  #- kipkurui
-  #- KirstieJane
-  #- kswhitney # need to confirm
-  #- LangData
-  #- lauracion
-  #- luispedro
-  #- lwinfree
+  - burkemlou
+  - Demellina
+  - fpsom
+  - gedankenstuecke
+  - ivotron
+  - karvovskaya
   - malvikasharan
-  #- martenson
-  #- martinagvilas
-  #- mblue9
-  #- meagdoh
-  #- mkuzak
-  #- mruizvelley # need to confirm
-  #- mvdbeek # need to confirm
-  #- nerantzis
-  #- NPalopoli
-  #- npscience
-  #- nsoranzo # need to confirm
-  #- orchid00
-  #- paulvill
-  #- pherterich
-  #- profgiuseppe
-  #- rainsworth
-  #- rgaiacs
-  #- rossmounce
-  #- satagopam7 # need to confirm
-  #- SantosRAC
-  #- sdopoku
-  #- sgibson91
-  #- sofia-kirke-forslund
-  #- thessaly
-  #- TKlingstrom
-  #- tnabtaf
-  #- tobyhodges
-  #- tsonika
-  #- unode
-  #- vcheplygina
-  #- VickyNembaware
+  - martinagvilas
+  - rainsworth
+  - thessaly
+  - tobyhodges
+  - tsonika
   - yochannah
-  #- yvanlebras
-  #- Zebetus
 possible-mentors:
-  #- aidanbudd
-  #- ajstewartlang
-  #- anayan321 # ask later when OLS-2 launched, need to check with Holger
-  #- anelda
-  #- anita-broellochs
-  #- anjali-mazumder
-  #- annefou # need to confirm
-  #- ArielleBL
   - bebatut
-  #- bgruening
-  #- billbrod # ask later when OLS-2 launched, need to check with Rodrigo
-  #- bruno-soares
-  #- burkemlou
-  #- cassgvp # did not fill the form
-  #- christinerogers
-  #- dasaderi # need to confirm
-  #- davidviryachen # ask later when OLS-2 launched, need to check with Holger
-  #- Delphine-L
-  #- dlebauer # need to check with Katrin
-  #- emmyft
-  #- Fnyasimi
-  #- fpsom
-  #- ha0ye # ask later when OLS-2 launched
-  #- hdinkel
-  #- hrhotz
-  #- ivotron
-  #- jezcope
-  #- joelostblom # need to confirm
-  #- kariljordan
-  #- klauer2207
-  #- katrinleinweber # need to confirm
-  #- kibet-gilbert # recommended, need to ask
-  #- kipkurui
-  #- Kiragu-Mwaura
-  #- kswhitney # need to confirm
-  #- LandiMi2
-  #- LangData
-  #- Lilian9
-  #- lpantano
-  #- luispedro
-  #- MagicMilly # ask later when OLS-2 launched, need to check with Katrin
-  #- malloryfreeberg
+  - burkemlou
+  - fpsom
+  - hrhotz
+  - karvovskaya
   - malvikasharan
-  #- martinagvilas
-  #- mblue9
-  #- meagdoh
-  #- Megmugure
-  #- mesfind
-  #- MorphoFun # need to check with Fotis
-  #- mkuzak
-  #- mloning
-  #- mruizvelley # need to confirm
-  #- mvdbeek # need to confirm
-  #- npscience
-  #- nsoranzo # need to confirm
-  #- pherterich
-  #- piv-gopalasingam
-  #- rainsworth
-  #- rgaiacs
-  #- rodrigocam # need to confirm
-  #- rs_khetani
-  #- SamGuay
-  #- sdopoku
-  #- sgibson91
-  #- tnabtaf
-  #- tsonika
-  #- unode
-  #- VickyNembaware # need to confirm
+  - tobyhodges
   - yochannah
-  #- yvanlebras
-  #- Zebetus
 organizers:
   - bebatut
   - malvikasharan

--- a/_data/people.yaml
+++ b/_data/people.yaml
@@ -402,7 +402,8 @@ bebatut:
   email: berenice.batut@gmail.com
   expertise:
   - OLS co-lead
-  - Galaxy and Galaxy training
+  - Galaxy
+  - Galaxy training
   - Citizen science
   - Bioinformatics
   - High-throughput sequencing
@@ -706,10 +707,11 @@ demellina:
   country: United Kingdom
   email: demitra.ellina@f1000.com
   expertise:
-  - open science/research
-  - open access
-  - open peer review
-  - preprints
+  - Open science
+  - Open research
+  - Open access
+  - Open peer review
+  - Preprints
   first-name: Demitra
   last-name: Ellina
   pronouns: She/her
@@ -730,6 +732,32 @@ dylan-bastiaans:
   first-name: Dylan
   github: false
   last-name: Bastiaans
+ealescak:
+  affiliation: Code for Science and Society
+  bio: 'As the Data Science Community Conference and Events Fund Program Manager at
+    Code for Science and Society, I developed a transparent, community-driven program
+    that provides funding for research-driven open data science events. I have 10
+    years of experience working in research data science focused on population genetics,
+    evolution, and management of Alaskan fish populations as well as a strong background
+    in mentoring and leadership in science advocacy initiatives. '
+  city: Anchorage
+  country: USA
+  email: Emily@codeforsociety.org
+  expertise:
+  - Community building
+  - Communication
+  - Diversity
+  - Inclusion
+  - Event planning
+  - Leadership
+  - Research methods
+  - Teaching
+  first-name: Emily
+  last-name: Lescak
+  orcid: 0000-0002-6229-568X
+  pronouns: she, her
+  twitter: elescak
+  website: https://www.linkedin.com/in/emily-lescak-b4652446/
 ekaroune:
   country: UK
   email: ekaroune@googlemail.com
@@ -790,13 +818,13 @@ estherplomp:
   email: e.plomp@tudelft.nl
   expertise:
   - Open protocols
-  - open data
-  - research data management
+  - Open data
+  - Research data management
   - FAIR
-  - archaeology
-  - bioanthropology
-  - isotopes
-  - osteology
+  - Archaeology
+  - Bioanthropology
+  - Isotopes
+  - Osteology
   first-name: Esther
   last-name: Plomp
   orcid: 0000-0003-3625-1357
@@ -846,7 +874,7 @@ fpsom:
   email: fopsom@gmail.com
   expertise:
   - Bioinformatics
-  - Machine Learning
+  - Machine learning
   - Training
   - Open Science
   first-name: Fotis
@@ -874,12 +902,12 @@ gedankenstuecke:
   country: France
   email: bgreshake@googlemail.com
   expertise:
-  - bioinformatics
-  - citizen science
-  - web development
-  - python
-  - personal data
-  - community management
+  - Bioinformatics
+  - Citizen science
+  - Web development
+  - Python
+  - Personal data
+  - Community management
   first-name: Bastian
   last-name: Greshake Tzovaras
   orcid: 0000-0002-9925-9623
@@ -943,6 +971,21 @@ ha0ye:
   pronouns: he/him
   twitter: Hao_and_Y
   website: https://haoye.us
+harpreetsingh05:
+  affiliation: Hans Raj Mahila Maha Vidyalaya Jalandhar
+  bio: 'A Bioinformatician, who strongly believe in constant learning, collaboration,
+    and team work. '
+  city: Jalandhar
+  country: India
+  email: harpreetsingh05@gmail.com
+  expertise:
+  - Bioinformatics
+  - Molecular Modeling
+  - Machine learning
+  - R Programming
+  first-name: harpreet
+  last-name: Singh
+  orcid: https://orcid.org/0000-0001-7202-3912
 hdinkel:
   bio: 'Holger is the head of Core IT team at the Max Planck Institute for Biolological
     Cybernetics.
@@ -999,7 +1042,7 @@ hrhotz:
   - Bioconductor
   - PostgreSQL
   - Bioinformatics
-  - 'Next Generation Sequencing '
+  - Next Generation Sequencing
   first-name: Hans-Rudolf
   last-name: ' Hotz'
   orcid: 0000-0002-2799-424X
@@ -1264,9 +1307,9 @@ karvovskaya:
   country: Netherlands
   email: e.karvovskaya@vu.nl
   expertise:
-  - theoretical linguistics
-  - fieldwork
-  - research data management
+  - Theoretical linguistics
+  - Fieldwork
+  - Research data management
   first-name: Lena
   last-name: Karvovskaya
   orcid: 0000-0001-7777-5603
@@ -1420,6 +1463,22 @@ klauer2207:
   last-name: Lauer
   pronouns: she/her
   website: https://www.linkedin.com/in/katharina-lauer-33aa2674/
+kmexter:
+  affiliation: Flanders Marine Institute (VLIZ)
+  bio: 'Ex-astronomer, now data manager at a marine science data centre. Tackling
+    the challenges of moving to FAIR data and open science. '
+  city: Oostende
+  country: Belgium
+  email: katrina.exter@vliz.be
+  expertise:
+  - FAIR data
+  - Data management
+  - Open data
+  - Marine data
+  - Astrophysics
+  first-name: Katrina
+  last-name: Exter
+  orcid: 0000-0002-5911-1536
 koudyk:
   country: Canada
   email: kendra.oudyk@gmail.com
@@ -1619,41 +1678,36 @@ magicmilly:
   pronouns: she/her
   twitter: magic_milly
 malloryfreeberg:
-  affiliation: EMBL/EBI
-  bio: 'Mallory is a Project Lead at the European Genome-phenome Archive
-
-    supporting archiving and sharing of personally identifiable genetic and
-
-    phenotypic human data. Her academic background is in bioinformatics specifically
-
-    to study post-transcriptional gene regulation. She has worked with open science
-
-    projects like Galaxy Project and the Human Cell Atlas, and recently has become
-
-    passionate about promoting good metadata standards and practices.
-
-    '
+  affiliation: EMBL-EBI
+  bio: Mallory is a Project Lead at the EMBL-EBI European Genome-phenome Archive supporting
+    archiving and sharing of personally identifiable genetic and phenotypic human
+    data. Her academic background is in bioinformatics specifically to study post-transcriptional
+    gene regulation. She has worked with Open Science projects including the Galaxy
+    Project and the Human Cell Atlas, and is passionate about promoting metadata standards
+    and best practices.
+  city: Cambridge
   country: UK
   email: mfreeberg@ebi.ac.uk
   expertise:
   - Metadata
   - FAIR principles
   - Single cell sequencing
-  - RNA/small RNA biology
+  - RNA biology
   - Post-transcriptional gene regulation
   - Ontologies
   - Project management
   - Data management
   - Bioinformatics
   - Galaxy
-  - Python, R, SQL, Unix
+  - R
+  - SQL
   - GitHub
   - Human genomics and phenomics
   first-name: Mallory
   last-name: Freeberg
   orcid: 0000-0003-2949-3921
   pronouns: she/her
-  twitter: MalloryFreeberg
+  twitter: malloryfreeberg
 malvikasharan:
   bio: 'Malvika Sharan is the community manager of [_The Turing Way-](https://the-turing-way.netlify.com)
 
@@ -1687,7 +1741,9 @@ malvikasharan:
   - Mentorship
   - Data Science best practices
   - Inclusive and collaborative practices
-  - Python, Git, Unix
+  - Python
+  - Git
+  - Unix
   - Bioinformatics
   - Algorithm design
   first-name: Malvika
@@ -1727,10 +1783,10 @@ martinagvilas:
   country: Germany
   email: martinagonzalezvilas@gmail.com
   expertise:
-  - Open-source
-  - Open-source documentation
-  - Open-infrastructure
-  - Open-science communities
+  - Open source
+  - Open source documentation
+  - Open infrastructure
+  - Open science communities
   - Version control
   - Machine learning
   - Neuroimaging
@@ -1991,10 +2047,10 @@ npalopoli:
   email: nicopalo@gmail.com
   expertise:
   - Computational biology
-  - structural bioinformatics
-  - proteins
-  - molecular interactions
-  - education
+  - Structural bioinformatics
+  - Proteins
+  - Molecular interactions
+  - Education
   first-name: Nicolas
   last-name: Palopoli
   orcid: 0000-0001-7925-6436
@@ -2062,6 +2118,27 @@ nsoranzo:
   pronouns: he/him
   twitter: NicolaSoranzo
   website: https://www.earlham.ac.uk/nicola-soranzo
+? open and reproducible research best practices; training and teaching tech to researchers;
+  pedagogical approaches to instructor training and curricula development
+: affiliation: University of Manchester
+  bio: 'Software Sustainability Institute''s training lead. Over the past 5 years
+    committed to ongoing improvement of research software practice through training
+    and community engagement work. Driving the trends in training for researchers
+    and scientists in computational and data analysis skills forward and helping develop
+    new training curricula. '
+  city: Manchester
+  country: United Kingdom
+  email: a.nenadic@manchester.ac.uk
+  expertise:
+  - Open and reproducible research best practices
+  - Training and teaching tech to researchers
+  - 'Pedagogical approaches to instructor training and curricula development '
+  first-name: Aleksandra
+  last-name: Nenadic
+  orcid: 0000-0002-2269-3894
+  pronouns: she/her/hers
+  twitter: aleks_nenadic
+  website: https://anenadic.github.io/professional-cv/
 orchid00:
   bio: 'Paula is an Open Science advocate her passions are data management, data analytics,
 
@@ -2166,9 +2243,11 @@ pivg:
   country: United Kingdom
   email: piv@ebi.ac.uk
   expertise:
-  - Education and training
-  - course design and delivery
-  - science communication
+  - Education
+  - Training
+  - Course design
+  - Course delivery
+  - Science communication
   first-name: Piv
   last-name: Gopalasingam
   orcid: 0000-0001-5709-3373
@@ -2193,10 +2272,10 @@ profgiuseppe:
   email: profgiuseppe@gmail.com
   expertise:
   - Reproducible science
-  - git
-  - continuous integration
-  - automation
-  - open and public databases and sources.
+  - Git
+  - Continuous integration
+  - Automation
+  - Open and public databases and sources
   first-name: Giuseppe
   last-name: Profiti
   orcid: 0000-0001-6067-6174
@@ -2225,9 +2304,9 @@ rainsworth:
   - Astrophysics
   - Open Science/Research
   - Reproducibility
-  - Community Building
-  - Organising Events
-  - Virtual Events
+  - Community building
+  - Organising events
+  - Virtual events
   - GitHub
   first-name: Rachael
   last-name: Ainsworth
@@ -2560,9 +2639,10 @@ thessaly:
   country: Argentina
   email: jarancio@unsam.edu.ar
   expertise:
-  - open science hardware
-  - citizen/community science projects
-  - linked data for community science
+  - Open science hardware
+  - Citizen science
+  - Community science
+  - Linked data for community science
   - Science and tech democratization
   first-name: Julieta
   last-name: Arancio
@@ -2631,6 +2711,9 @@ tobyhodges:
   expertise:
   - Designing and developing training material
   - Collaborating with Git & GitHub/GitLab
+  - Git
+  - GitHub
+  - GitLab
   - Publishing web content with Wordpress or Jekyll and GitHub/GitLab Pages
   - Scientific community engagement
   - Teaching and organising workshops
@@ -2654,7 +2737,7 @@ tsonika:
   email: sonika.tyagi@monash.edu
   expertise:
   - Genomics
-  - Machine Learning
+  - Machine learning
   - Data Science
   - Computational Epigenomics
   - Transcriptomics

--- a/_data/people.yaml
+++ b/_data/people.yaml
@@ -88,7 +88,7 @@ aidanbudd:
   country: Germany
   email: aidan.budd@gmx.de
   expertise:
-  - Community building.
+  - Community building
   first-name: Aidan
   last-name: Budd
   orcid: 0000-0003-0196-9051
@@ -121,6 +121,31 @@ ajstewartlang:
   pronouns: he/him
   twitter: ajstewart_lang
   website: https://ajstewartlang.netlify.app
+alexandra-holinski:
+  affiliation: EMBL-EBI
+  bio: I am working as a Scientific Training Officer at EMBL-EBI and dedicate my work
+    time to developing and designing training in the field of biomedical sciences
+    and bioinformatics. In our training courses we encourage scientists to work according
+    to and advocate the principles of Open Science. I am not a bioinformatician myself,
+    but a chemist / biochemist by education, with several years of experience in scientific
+    research; mainly in the wet lab.
+  country: United Kingdom
+  email: aholinski@ebi.ac.uk
+  expertise:
+  - Scientific Education and Training
+  - Course development, design and delivery
+  - Methods of interactive delivery (face-to-face and virtual courses)
+  - Online training
+  - Community building
+  - Open Science
+  - FAIR principles
+  - Principles of FAIRification of (training) material
+  - Protein Biochemistry
+  first-name: Alexandra
+  github: false
+  last-name: Holinski
+  orcid: 0000-0003-2321-5568
+  pronouns: She/her
 alexwlchan:
   affiliation: Wellcome Collection
   country: United Kingdom
@@ -556,7 +581,10 @@ christinerogers:
   country: Canada
   email: christine.rogers@mcgill.ca
   expertise:
-  - neuroinformatics, open science, open source, research software
+  - Neuroinformatics
+  - Open science
+  - Open source
+  - Research software
   first-name: Christine
   last-name: Rogers
   orcid: christine.rogers@mcgill.ca
@@ -1348,23 +1376,28 @@ kristinariemer:
   pronouns: she/her
   twitter: KristinaRiemer
 kswhitney:
-  bio: Kaitlin is an assistant professor in the Science, Technology & Society department
-    at the Rochester Institute of Technology in Rochester, NY USA. She is also extended
-    program faculty in the Environmental Sciences Program.
-  country: Germany
+  affiliation: Rochester Institute of Technology
+  bio: Dr. Stack Whitney is an environmental studies professor at RIT in upstate NY,
+    USA. As a person whose teaching and work sits at the interface of environmental
+    science and environmental humanities, she's excited about "open" for all kinds
+    of teaching and research. However, she's also a critical advocate for ensuring
+    that "open" initiatives and products do not exclude disabled leaders and participants.
+  city: Rochester
+  country: USA
   email: kxwsbi@rit.edu
   expertise:
   - Accessibility
-  - Ethics
-  - Reproducible workflows
-  - Ecoinformatics
-  - Entomology/insect ecology
-  - Feminist biology
+  - Road ecology
+  - Novel ecosystems
+  - Insects
+  - Zines
+  - OER
   first-name: Kaitlin
   last-name: Stack Whitney
   orcid: 0000-0002-0815-5037
+  pronouns: she/her
   twitter: kstackwhitney
-  website: https://pht180.rit.edu/sweetlab/
+  website: https://rit.edu/sweetlab
 landimi2:
   affiliation: International Livestock Research Institute
   country: Kenya
@@ -1622,22 +1655,19 @@ mblue9:
   last-name: Doyle
   pronouns: she/her
 meagdoh:
-  bio: Meag is an open data advocate and product design leader. Most recently, she
-    mentored participants and co-hosted Mozilla''s Open Leaders program (Cohort 6
-    & 7). Currently, she leads product design strategy for data and tools at National
-    Institutes of Health All of Us Research Program.
-  country: USA
+  bio: A designer and open source advocate with experience building on and offline
+    communities in open government and health and life sciences
+  city: Washington
+  country: United States
   email: meagdoherty@gmail.com
   expertise:
-  - User research
   - Product strategy
-  - Experience analytics
-  - open research tools (https://www.researchallofus.org/)
+  - Go to market
+  - User research
   first-name: Meag
   last-name: Doherty
   pronouns: she/her
   twitter: emdohh
-  website: https://meagdoherty.io
 megmugure:
   affiliation: International Livestock Research Institute
   country: Kenya
@@ -1972,7 +2002,9 @@ prashbio:
   country: India
   email: prash@bioclues.org
   expertise:
-  - 'Systems Biology, Bioinformatics, Mentoring '
+  - Systems Biology
+  - Bioinformatics
+  - 'Mentoring '
   first-name: Prashanth N.
   last-name: Suravajhala
   orcid: https://orcid.org/0000-0002-8535-278X
@@ -2189,26 +2221,44 @@ sebastianeggert:
   last-name: Eggert
   pronouns: he/his
   twitter: se_eggert
-sgibson91:
-  affiliation: Alan Turing Institute
-  bio: Sarah is a Research Software Engineer at The Alan Turing Institute where she
-    implements software best practices to translate academic research into real world
-    solutions through the Turing''s collaborative network. Sarah is also an operator
-    and maintainer for the Binder project and runs a BinderHub cluster at the Turing
-    which receives traffic from mybinder.org. This year, she is also honoured to be
-    a Software Sustainability Institute Fellow and is using her Fellowship to nurture
-    and diversify the Binder community.
-  country: UK
-  email: sgibson@turing.ac.uk
+serahrono:
+  affiliation: The Carpentries
+  bio: Serah Rono is a computer scientist and writer with a knack and deep seated
+    interest in web development and accessibility, all things open and tech community
+    organising. Serah is currently the Director of Community at The Carpentries.
+  city: Tallinn
+  country: Estonia
+  email: serah@carpentries.org
   expertise:
-  - reproducibility
-  - cloud infrastructure
-  - Project Binder
-  - Effective and transparent communication of scientific analyses across a range
-    of domain
-  - Digital Humanities research into the Industrial Revolution
+  - Web development
+  - Open source
+  - Community building and sustainability
+  - Accessibility, Documentation
+  - Rsource development
+  - Communications
+  - Outreach
+  - Event planning
+  - Public speaking
+  first-name: 'Serah '
+  last-name: Rono
+  pronouns: she, her, hers
+  twitter: serahrono
+sgibson91:
+  affiliation: The Alan Turing Institute
+  bio: Sarah is a Research Software Engineer at the Alan Turing Institute helping
+    to solve real-world problems through cutting-edge techniques and software best
+    practices. She also helps run the mybinder.org platform and is a fellow of the
+    Software Sustainability Institute.
+  city: London
+  country: UK
+  email: drsarahlgibson@gmail.com
+  expertise:
+  - Cloud computing
+  - Reproducibility
+  - GitHub
   first-name: Sarah
   last-name: Gibson
+  orcid: 0000-0003-0356-2765
   pronouns: she/her
   twitter: drsarahlgibson
   website: https://sgibson91.github.io
@@ -2410,27 +2460,9 @@ tsonika:
   twitter: tsonika
   website: https://bioinformaticslab.erc.monash.edu
 unode:
-  affiliation: European Molecular Biology Laboratory (EMBL)
-  bio: Renato is a computational biologist with a background in evolution, genomics
-    and the microbiome. Currently project and community manager of the [EMBL Bio-IT
-    project](https://bio-it.embl.de/), supporting the local bio-computational community
-    through training, consulting and core resources. Open-source and scientific reproducibility
-    advocate. When not tanning in front of a screen you may find him wandering the
-    green and blue in Nature.
-  country: Germany
   email: renato.alves@embl.de
-  expertise:
-  - Full-stack developer
-  - Computational Training
-  - Reproducibility
-  - Computational biology
-  - Metagenomics
-  - Meta-transcriptomics
-  first-name: Renato
-  last-name: Alves
-  orcid: 0000-0002-7212-0234
-  pronouns: he/him
-  twitter: renato_alvs
+  first-name: null
+  last-name: null
 valerie-parent:
   affiliation: 'Law Faculty, Université de Montréal '
   country: Canada

--- a/_data/people.yaml
+++ b/_data/people.yaml
@@ -23,12 +23,9 @@
 # Mandatory: first-name, last-name, country
 ---
 aath0:
-  bio: 'Athina is a neuroscientist, with a background in electrical and computer engineering.
-
+  bio: Athina is a neuroscientist, with a background in electrical and computer engineering.
     Her research combines computational and electrophysiological techniques to study
     human cognition.
-
-    '
   country: Switzerland
   email: athina.tz@gmail.com
   expertise:
@@ -42,6 +39,22 @@ aath0:
   pronouns: she/her
   twitter: aath0
   website: https://aath0.github.io/
+adam-gristwood:
+  affiliation: Freelance science writer and communications trainer
+  bio: 'I am a freelance science writer and communications trainer, focused on life
+    science communications. I am currently spreading the word about the importance
+    and mystery of microbes living in the Ocean.  '
+  city: Heidelberg
+  country: 'Germany '
+  email: adamgristwood@gmail.com
+  expertise:
+  - Life science communications
+  first-name: Adam
+  github: false
+  last-name: Gristwood
+  orcid: 0000-0001-7513-4212
+  pronouns: he/him
+  twitter: gristwood
 agbeltran:
   bio: Alejandra is the Software Engineering Group Leader at the Science and Technology
     Facilities Council (STFC). STFC is part of UK Research and Innovation. Her focus
@@ -67,34 +80,21 @@ agbeltran:
   twitter: alegonbel
   website: https://agbeltran.github.io/
 aidanbudd:
-  bio: 'Aidan has worked in life science research in both the wet lab, and as a bioinformatician.
-
-    Since 2010 his focus has been on developing training and community for researchers,
-
-    while managing a range of life-science related networks and projects.
-
-    Starting in 2020 he has been working for EMBO Solutions GmbH as a trainer for
-    leadership for researchers.
-
-    He is an allocishet abled middle-class white man, and wants to do as much as he
-    can to promote a more inclusive society and academy.
-
-    '
+  affiliation: EMBO Solutions GmbH
+  bio: PhD with twenty years working around bioinformatics research, project-management,
+    and training. Currently working as a leadership trainer for postdocs and PIs.
+    For fun I enjoy painting, playing Dungeons and Dragons, and walking my dog.
+  city: Heidelberg
   country: Germany
   email: aidan.budd@gmx.de
   expertise:
-  - Community building
-  - Communications
-  - Inclusion and diversity
-  - Delivering events
-  - Leadership training
-  - Previous research, event organisation and planning, in bioinformatics
+  - Community building.
   first-name: Aidan
   last-name: Budd
   orcid: 0000-0003-0196-9051
   pronouns: he/him
-  twitter: AidanBudd
-  website: https://about.me/aidan.budd
+  twitter: aidanbudd
+  website: http://about.me/aidan.budd
 ajstewartlang:
   bio: 'Andrew is an experimental psychologist and data scientist interested in open
     and reproducible research - he coordinates the Manchester Open Research Working
@@ -106,9 +106,7 @@ ajstewartlang:
     is a fellow of the SSI and associate member of Carole Goble''s eScience lab group.
 
     All the research programmes he leads involve open data and open code - and everything
-    should be fully reproducible.
-
-    '
+    should be fully reproducible.'
   country: UK
   email: andrew.stewart@manchester.ac.uk
   expertise:
@@ -141,20 +139,13 @@ anayan321:
   twitter: pk_suta
 anelda:
   bio: 'Anelda is the founder of Talarify, a South Africa-based consultancy working
-    with researchers and postgraduates to help grow digital,
-
-    computational, and open science literacy. She has a formal background in bioinformatics,
-    but spend most of her time working in interdisciplinary
-
-    teams these days. She is currently formally involved in two projects: 1) afrimapr,
-    funded by Wellcome Open Research, where the team is working
-
-    with data science communities in Africa and beyond to help make African data more
-    accessible via the development of R building blocks; and 2)
-
-    Surveying Open Data Practices in 8 African countries, funded by the IDRC.
-
-    '
+    with researchers and postgraduates to help grow digital, computational, and open
+    science literacy. She has a formal background in bioinformatics, but spend most
+    of her time working in interdisciplinary teams these days. She is currently formally
+    involved in two projects: 1) afrimapr, funded by Wellcome Open Research, where
+    the team is working with data science communities in Africa and beyond to help
+    make African data more accessible via the development of R building blocks; and
+    2) Surveying Open Data Practices in 8 African countries, funded by the IDRC.'
   country: South Africa
   email: anelda@talarify.co.za
   expertise:
@@ -180,11 +171,12 @@ anenadic:
     new training curricula. '
   city: Manchester
   country: United Kingdom
-  email: a.nenadic@manchester.ac.uk
+  email: Open and reproducible research best practices; Training and teaching tech
+    to researchers; Pedagogical approaches to instructor training and curricula development
   expertise:
   - Open and reproducible research best practices
   - Training and teaching tech to researchers
-  - 'Pedagogical approaches to instructor training and curricula development '
+  - Pedagogical approaches to instructor training and curricula development
   first-name: Aleksandra
   last-name: Nenadic
   orcid: 0000-0002-2269-3894
@@ -193,12 +185,12 @@ anenadic:
   website: https://anenadic.github.io/professional-cv/
 anita-broellochs:
   affiliation: Protocols.io
-  bio: "Anita Br\xF6llochs is the Head of Outreach at protocols.io. She studied Life\
-    \ Science Engineering at the Friedrich-Alexander University in\nErlangen, Germany\
-    \ and her background is on optical clearing of skeletal muscle for multiphoton\
-    \ microscopy. Anita has a passion for open\nscience and is also the host of a\
-    \ science podcast called 'Minor Tweak, Major Impact' which is aiming to shine\
-    \ a spotlight on method development.\n"
+  bio: Anita Bröllochs is the Head of Outreach at protocols.io. She studied Life Science
+    Engineering at the Friedrich-Alexander University in Erlangen, Germany and her
+    background is on optical clearing of skeletal muscle for multiphoton microscopy.
+    Anita has a passion for open science and is also the host of a science podcast
+    called 'Minor Tweak, Major Impact' which is aiming to shine a spotlight on method
+    development.
   country: USA
   email: anita@protocols.io
   expertise:
@@ -211,25 +203,19 @@ anita-broellochs:
   - protocols.io which covers a large diversity of life science topics
   first-name: Anita
   github: false
-  last-name: "Br\xF6llochs"
+  last-name: Bröllochs
   pronouns: she/her
   twitter: AnitaBroellochs
   website: https://www.protocols.io
 anjali-mazumder:
   affiliation: Alan Turing Institute
-  bio: 'Anjali is the Thematic Lead on AI, Justice and Human Rights at the Alan Turing
-    Institute for Data Science and Artificial Intelligence (UK),
-
-    including projects on data science/AI to combat modern slavery and other exploitative
-    crimes (and co-organiser of Code 8.7), statistics and
-
-    the law, and bias measures/fairness methods in algorithms in justice. She is also
-    an Assistant Research Professor in the Department of
-
-    Statistics & Data Science and faculty affiliate in the Block Centre for Technology
-    and Society at Carnegie Mellon University.
-
-    '
+  bio: Anjali is the Thematic Lead on AI, Justice and Human Rights at the Alan Turing
+    Institute for Data Science and Artificial Intelligence (UK), including projects
+    on data science/AI to combat modern slavery and other exploitative crimes (and
+    co-organiser of Code 8.7), statistics and the law, and bias measures/fairness
+    methods in algorithms in justice. She is also an Assistant Research Professor
+    in the Department of Statistics & Data Science and faculty affiliate in the Block
+    Centre for Technology and Society at Carnegie Mellon University.
   country: UK
   email: amazumder@turing.ac.uk
   expertise:
@@ -245,14 +231,10 @@ anjali-mazumder:
   pronouns: she/her
   website: https://www.turing.ac.uk/people/researchers/anjali-mazumder
 annakrystalli:
-  bio: 'Anna is an ex-macroecologists who fell in love with R and open data science.
-
-    Now a Research Software Engineer at the University of Sheffield,
-
-    she is helping scientists do more with their code and data and build more open
-    collaborative communities.
-
-    '
+  bio: Anna is an ex-macroecologists who fell in love with R and open data science.
+    Now a Research Software Engineer at the University of Sheffield, she is helping
+    scientists do more with their code and data and build more open collaborative
+    communities.
   country: UK
   email: annakrystalli@googlemail.com
   expertise:
@@ -269,12 +251,9 @@ annakrystalli:
   pronouns: she/her
   twitter: annakrystalli
 anneclinio:
-  bio: 'Anne currently works at Oswald Cruz foundation with the development of a bottom
-    up open data policy. She is also part of a research group
-
-    dedicated to open science themes, especially social innovations.
-
-    '
+  bio: Anne currently works at Oswald Cruz foundation with the development of a bottom
+    up open data policy. She is also part of a research group dedicated to open science
+    themes, especially social innovations.
   country: Brazil
   email: anneclinio@gmail.com
   expertise:
@@ -288,10 +267,8 @@ anneclinio:
   twitter: anneclinio
   website: https://hcommons.org/members/anneclinio/
 annefou:
-  bio: 'Working in the field of Climate modelling, and interested in Open Science,
+  bio: Working in the field of Climate modelling, and interested in Open Science,
     Open Innovation and ICT. Trying to facilitate access and use of Climate Data.
-
-    '
   country: Norway
   email: annefou@geo.uio.no
   expertise:
@@ -306,10 +283,10 @@ annefou:
   twitter: AnneFouilloux
   website: https://annefou.github.io
 anproulx:
-  affiliation: "Universit\xE9 de Montr\xE9al"
+  affiliation: Université de Montréal
   country: Canada
   email: andreanne.proulx123@gmail.com
-  first-name: "Andr\xE9anne"
+  first-name: Andréanne
   last-name: Proulx
   twitter: AndreanneProulx
 ariellebl:
@@ -372,10 +349,10 @@ bduckles:
   twitter: bduckles
   website: https://bethduckles.com/
 beapdk:
-  affiliation: "Universit\xE9 de Montr\xE9al"
+  affiliation: Université de Montréal
   country: Canada
   email: bea.pdk@gmail.com
-  first-name: "B\xE9atrice"
+  first-name: Béatrice
   last-name: P.De Koninck
   twitter: B_DeKoninck
 beatrizserrano:
@@ -388,14 +365,13 @@ beatrizserrano:
   twitter: Birthae
 bebatut:
   affiliation: University of Freiburg
-  bio: "B\xE9r\xE9nice is a bioinformatician (post-doc in the [Freiburg Galaxy Team](https://galaxyproject.eu/freiburg/)),\n\
-    analyzing biological data and developing tools for data analysis, mainly via [Galaxy](https://galaxyproject.org/).\n\
-    \nB\xE9r\xE9nice is also passionate about training, regularly giving workshops\
-    \ (data analysis, tool development, etc).\nShe started and still co-leads the\
-    \ [Galaxy Training Material project](https://training.galaxyproject.org/).\nShe\
-    \ is a co-deputy training coordinator for ELIXIR Germany ([de.NBI](https://www.denbi.de/),\
-    \ and a founder of\n[Street Science Community](https://streetscience.community/),\
-    \ an outreach program.\n"
+  bio: Bérénice is a bioinformatician (post-doc in the [Freiburg Galaxy Team](https://galaxyproject.eu/freiburg/)),
+    analyzing biological data and developing tools for data analysis, mainly via [Galaxy](https://galaxyproject.org/).
+    Bérénice is also passionate about training, regularly giving workshops (data analysis,
+    tool development, etc). She started and still co-leads the [Galaxy Training Material
+    project](https://training.galaxyproject.org/). She is a co-deputy training coordinator
+    for ELIXIR Germany ([de.NBI](https://www.denbi.de/), and a founder of [Street
+    Science Community](https://streetscience.community/), an outreach program.
   country: Germany
   email: berenice.batut@gmail.com
   expertise:
@@ -405,7 +381,7 @@ bebatut:
   - Bioinformatics
   - High-throughput sequencing
   - Metagenomics
-  first-name: "B\xE9r\xE9nice"
+  first-name: Bérénice
   gitter: bebatut
   last-name: Batut
   orcid: 0000-0001-9852-1987
@@ -421,9 +397,9 @@ benkrikler:
   twitter: benkrikler
   website: https://krikler.be/
 bgruening:
-  bio: "Bj\xF6rn is working in the European Galaxy team and tries to help make science\
-    \ open wherever he can.\nHe is an expert in the topics related to Container, Conda,\
-    \ Galaxy, Python, reproducible research, and training.\n"
+  bio: Björn is working in the European Galaxy team and tries to help make science
+    open wherever he can. He is an expert in the topics related to Container, Conda,
+    Galaxy, Python, reproducible research, and training.
   country: Germany
   email: bjoern.gruening@gmail.com
   expertise:
@@ -436,19 +412,16 @@ bgruening:
   - Genome annotation
   - High-Throughput-Screening
   - Epigenetics
-  first-name: "Bj\xF6rn"
-  last-name: "Gr\xFCning"
+  first-name: Björn
+  last-name: Grüning
   orcid: 0000-0002-3079-6586
   pronouns: he/him
   twitter: bjoerngruening
   website: https://github.com/bgruening/
 bhuvanameenakshik:
-  bio: 'Bhuvana is a gender gap and Mixed Reality researcher trying to unfold the
-    ethics of technology in a more humane way.
-
-    Her expertise are in Gender gap, Mozilla technologies and Wikimedia projects.
-
-    '
+  bio: Bhuvana is a gender gap and Mixed Reality researcher trying to unfold the ethics
+    of technology in a more humane way. Her expertise are in Gender gap, Mozilla technologies
+    and Wikimedia projects.
   country: India
   email: bhuvanameenakshi@gmail.com
   expertise:
@@ -471,7 +444,7 @@ billbrod:
 boi-kone:
   country: Mali
   email: koneb.bk@gmail.com
-  first-name: "Bo\xEF"
+  first-name: Boï
   last-name: Kone
   twitter: boi_kone
 bonetcarne:
@@ -535,25 +508,15 @@ burkemlou:
   twitter: burkemlou
 cassgvp:
   affiliation: University of Oxford
-  bio: 'Cassandra worked for 10 years in magnetic resonance imaging, mainly with
-
-    clinical psychiatric populations. After discovering open science, it reignited
-
-    her passion and enthusiasm for the way research *could* be done, and she focused
-
-    a lot of her efforts into educating and training her team in programming,
-
-    reproducible and transparent methods. She was recently appointed Open Science
-
-    Community Engagement Coordinator for her department, one of only a few professional
-
-    open science roles in the UK. She is very proud to support her colleagues in the
-
-    transition towards working open, and doing so with the principles of open leadership
-
-    at the forefront of her work.
-
-    '
+  bio: Cassandra worked for 10 years in magnetic resonance imaging, mainly with clinical
+    psychiatric populations. After discovering open science, it reignited her passion
+    and enthusiasm for the way research *could* be done, and she focused a lot of
+    her efforts into educating and training her team in programming, reproducible
+    and transparent methods. She was recently appointed Open Science Community Engagement
+    Coordinator for her department, one of only a few professional open science roles
+    in the UK. She is very proud to support her colleagues in the transition towards
+    working open, and doing so with the principles of open leadership at the forefront
+    of her work.
   country: UK
   email: cassandra.gouldvanpraag@gmail.com
   expertise:
@@ -567,7 +530,7 @@ cassgvp:
   pronouns: she/her
   twitter: cassgvp
 chiarabertipaglia:
-  affiliation: "Columbia University\u2019s Zuckerman Institute"
+  affiliation: Columbia University | Zuckerman Institute
   country: USA
   expertise:
   - Neuroscience
@@ -584,21 +547,19 @@ christina-ambrosi:
   last-name: Ambrosi
   twitter: CAmbrosi4
 christinerogers:
-  affiliation: Montreal Neurological Institute, McGill University
-  bio: 'Project manager and data wrangler working in open-source neuroinformatics
-
-    '
+  affiliation: McGill University
+  bio: 'Project Officer and Technical lead in neuroscience software and infrastructure
+    to accelerate and open neuroinformatics research workflows, based at the Montreal
+    Neurological Institute. Mentor for Google Summer of Code and Season of Docs, and
+    past participant in OLS program. '
+  city: Montreal
   country: Canada
+  email: christine.rogers@mcgill.ca
   expertise:
-  - Data sharing
-  - Open science
-  - Software development
-  - Open source
-  - Neuroscience
-  - Interoperability
-  - Neuroinformatics
+  - neuroinformatics, open science, open source, research software
   first-name: Christine
   last-name: Rogers
+  orcid: christine.rogers@mcgill.ca
   pronouns: she/her
   twitter: xtinerogers
 coopersmout:
@@ -623,20 +584,16 @@ da5nsy:
   pronouns: he/his
   twitter: da5nsy
 dannycolin:
-  affiliation: "Universit\xE9 de Montr\xE9al"
+  affiliation: Université de Montréal
   country: Canada
   first-name: Danny
   last-name: Colin
   pronouns: he/him
   twitter: dannycolincom
 dasaderi:
-  bio: 'Daniela is a Neuroscientist with a passion for open, equitable, and transparent
-    scholarship. She is a former Mozilla Fellow,
-
-    and she now leads a project called PREreview to empower researchers to engage
-    with each other and review preprints.
-
-    '
+  bio: Daniela is a Neuroscientist with a passion for open, equitable, and transparent
+    scholarship. She is a former Mozilla Fellow, and she now leads a project called
+    PREreview to empower researchers to engage with each other and review preprints.
   country: USA
   email: daniela@prereview.org
   expertise:
@@ -666,15 +623,10 @@ davidviryachen:
   twitter: davidchenn
 delphine-l:
   affiliation: Penn State University
-  bio: 'Delphine am a post-doc at Penn State University and a member of Galaxy Project.
-    She works on developing analysis workflows
-
-    for bacterial genomics, mostly, but she also has project in other fields, like
-    functional annotation of SARS-2 Cov virus,
-
-    human methylation  analyses...
-
-    '
+  bio: Delphine am a post-doc at Penn State University and a member of Galaxy Project.
+    She works on developing analysis workflows for bacterial genomics, mostly, but
+    she also has project in other fields, like functional annotation of SARS-2 Cov
+    virus, human methylation  analyses...
   country: USA
   expertise:
   - Organization of open-source/collaborative projects
@@ -774,16 +726,10 @@ elsasci:
   pronouns: she/her
   twitter: elsasci
 emmyft:
-  bio: 'Emmy is the Innovation Community Manager at eLife, with a PhD in neuroscience.
-
+  bio: Emmy is the Innovation Community Manager at eLife, with a PhD in neuroscience.
     She loves research and is working to change the way that it''s shared, evaluated
-    and discovered;
-
-    while learning about open-source, open science and community building!
-
+    and discovered; while learning about open-source, open science and community building!
     Her expertise is in Community strategies, publishing and scholarly communication.
-
-    '
   country: The Netherlands
   email: e.tsang@elifesciences.org
   expertise:
@@ -836,13 +782,9 @@ ewuramaminka:
   twitter: eminka_da
 fnyasimi:
   affiliation: International Centre of Insect Physiology and Ecology (ICIPE)
-  bio: 'Festus is a bioinformatician interested in community outreach, open science
-    and networking.
-
-    He is actively engaged in training activities and he is the lead at the Bioinformatics
-    Hub of Kenya.
-
-    '
+  bio: Festus is a bioinformatician interested in community outreach, open science
+    and networking. He is actively engaged in training activities and he is the lead
+    at the Bioinformatics Hub of Kenya.
   country: Kenya
   expertise:
   - Bioinformatics
@@ -909,12 +851,8 @@ georgiahca:
   pronouns: she/her
 graciellehigino:
   affiliation: null
-  bio: 'All about theoretical ecology, the open movement and science communication!
-    Co-leads the open
-
-    SciComm training IGNITE.
-
-    '
+  bio: All about theoretical ecology, the open movement and science communication!
+    Co-leads the open SciComm training IGNITE.
   country: Brazil
   email: graciellehigino@gmail.com
   expertise:
@@ -928,18 +866,10 @@ graciellehigino:
   pronouns: she/her
 ha0ye:
   affiliation: University of Florida Health Science Center Libraries
-  bio: 'Hao is the Reproducibility Librarian at the University of Florida Health Science
-    Center Libraries.
-
-    His role is to promote research reproducibility and open science practices across
-    the entire UF
-
-    system. He is especially interested in how open practices can be leveraged to
-    promote equity and
-
-    inclusion in higher education.
-
-    '
+  bio: Hao is the Reproducibility Librarian at the University of Florida Health Science
+    Center Libraries. His role is to promote research reproducibility and open science
+    practices across the entire UF system. He is especially interested in how open
+    practices can be leveraged to promote equity and inclusion in higher education.
   country: USA
   email: hao.ye@weecology.org
   expertise:
@@ -974,17 +904,10 @@ harpreetsingh05:
   last-name: Singh
   orcid: https://orcid.org/0000-0001-7202-3912
 hdinkel:
-  bio: 'Holger is the head of Core IT team at the Max Planck Institute for Biolological
-    Cybernetics.
-
-    He enjoys the technical aspects of science - be it programming (Python), version
-    control (git),
-
-    web services (REST), or generally (self) organization and anti-procrastination.
-
-    His mission is to support scientists in all aspects IT.
-
-    '
+  bio: Holger is the head of Core IT team at the Max Planck Institute for Biolological
+    Cybernetics. He enjoys the technical aspects of science - be it programming (Python),
+    version control (git), web services (REST), or generally (self) organization and
+    anti-procrastination. His mission is to support scientists in all aspects IT.
   country: Germany
   email: holger.dinkel@posteo.de
   expertise:
@@ -1042,11 +965,8 @@ ibrahssali1:
   pronouns: he/him
   twitter: ibrahssali1
 inquisitivevi:
-  bio: 'Biomedical scientist and science communicator interested in
-
-    building effective outreach strategies for equitable access of research outputs.
-
-    '
+  bio: Biomedical scientist and science communicator interested in building effective
+    outreach strategies for equitable access of research outputs.
   country: Germany
   email: vinodh.ilangovan@gmail.com
   expertise:
@@ -1090,12 +1010,8 @@ ivotron:
   twitter: ivotron
   website: https://ivotron.me
 jasonjwilliamsny:
-  bio: 'Jason is a life scientist who spends most of his time working to help researchers
-    adopt
-
-    computational practices in research and education
-
-    '
+  bio: Jason is a life scientist who spends most of his time working to help researchers
+    adopt computational practices in research and education
   country: USA
   email: williams@cshl.edu
   expertise:
@@ -1111,21 +1027,12 @@ jasonjwilliamsny:
   twitter: JasonWilliamsNY
   website: https://lifescitrainers.org
 jcolomb:
-  bio: 'Former neuro-geneticist (10 year of research on fruit fly memory and behavior),
-    he has been more
-
-    recently interested in data analysis and management, as a specialisation for my
-    interests in open
-
-    science (open research). He is presently working on ways (technical and social)
-    to implement the
-
-    principles of FAIR and open data in the lab workflow and ways to foster collaboration
-    between
-
-    researchers via the SmartFigure Gallery project.
-
-    '
+  bio: Former neuro-geneticist (10 year of research on fruit fly memory and behavior),
+    he has been more recently interested in data analysis and management, as a specialisation
+    for my interests in open science (open research). He is presently working on ways
+    (technical and social) to implement the principles of FAIR and open data in the
+    lab workflow and ways to foster collaboration between researchers via the SmartFigure
+    Gallery project.
   country: Germany
   email: julien.colomb@fu-berlin.de
   expertise:
@@ -1146,16 +1053,16 @@ jelioth-muthoni:
   last-name: Muthoni
 jezcope:
   affiliation: The British Library
-  bio: "Jez is Data Services Lead in The British Library\u2019s Research Infrastructure\
-    \ Services team. He has over 8 years of experience developing and delivering research\
-    \ data management services and strategies at research-intensive higher education\
-    \ institutions in the UK, as part of a long-term goal to help communicate and\
-    \ collaborate more effectively using technology. He is an experienced teacher\
-    \ and is involved with The Carpentries as a Certified Instructor and early contributor\
-    \ to Library Carpentry. He is particularly interested in elevating the status\
-    \ of research software alongside research data in the scholarly record, and helping\
-    \ researchers develop the skills to make the most of this. He is a Fellow of the\
-    \ Software Sustainability Institute, 2020 intake."
+  bio: Jez is Data Services Lead in The British Library’s Research Infrastructure
+    Services team. He has over 8 years of experience developing and delivering research
+    data management services and strategies at research-intensive higher education
+    institutions in the UK, as part of a long-term goal to help communicate and collaborate
+    more effectively using technology. He is an experienced teacher and is involved
+    with The Carpentries as a Certified Instructor and early contributor to Library
+    Carpentry. He is particularly interested in elevating the status of research software
+    alongside research data in the scholarly record, and helping researchers develop
+    the skills to make the most of this. He is a Fellow of the Software Sustainability
+    Institute, 2020 intake.
   city: North Yorkshire
   country: United Kingdom
   email: j.cope@erambler.co.uk
@@ -1181,15 +1088,10 @@ joel-hancock:
   last-name: Hancock
   pronouns: he/his
 joelostblom:
-  bio: 'Joel is a Biomedical Engineering PhD student who enjoys learning and teaching
-
-    how to better understand data (and thus the world around us!).
-
-    He is also passionate about openness,  reproducibility, and data visualization,
-
-    both within science and in general.
-
-    '
+  bio: Joel is a Biomedical Engineering PhD student who enjoys learning and teaching
+    how to better understand data (and thus the world around us!). He is also passionate
+    about openness,  reproducibility, and data visualization, both within science
+    and in general.
   country: Canada
   email: joel.ostblom@gmail.com
   expertise:
@@ -1244,21 +1146,16 @@ karegapauline:
   twitter: KaregaP
 kariljordan:
   bio: 'Kari is the Senior Director of Equity and Assessment for The Carpentries,
-    Executive Director of the Engineer Like a Girl after-school program,
-
-    and a Zumba Fitness Instructor!
+    Executive Director of the Engineer Like a Girl after-school program, and a Zumba
+    Fitness Instructor!
 
     Kari''s background is mechanical engineering, and she earned a PhD in Engineering
-    Education from The Ohio State University. Her doctoral research
-
-    explored self-efficacy of underrepresented engineering students. After completing
-    a post-doc in the Engineering Fundamentals Department at
-
-    Embry-Riddle Aeronautical University, she was hired to lead The Carpentries assessment
-    efforts. In her current role, her focus is developing
-
-    programs through the lens of equity, and setting strategic efforts around assessment
-    that inform The Carpentries curriculum and other initiatives.
+    Education from The Ohio State University. Her doctoral research explored self-efficacy
+    of underrepresented engineering students. After completing a post-doc in the Engineering
+    Fundamentals Department at Embry-Riddle Aeronautical University, she was hired
+    to lead The Carpentries assessment efforts. In her current role, her focus is
+    developing programs through the lens of equity, and setting strategic efforts
+    around assessment that inform The Carpentries curriculum and other initiatives.
 
     '
   country: USA
@@ -1314,11 +1211,8 @@ katoss:
   last-name: Kloppenborg
   pronouns: she/her
 katrinleinweber:
-  bio: 'Studied biochemistry, arctic ecology & geology, PhDed in diatom biofilms.
-
-    Worked in tech support (Prezi), pharma-LIMS & OA data analysis.
-
-    '
+  bio: Studied biochemistry, arctic ecology & geology, PhDed in diatom biofilms. Worked
+    in tech support (Prezi), pharma-LIMS & OA data analysis.
   country: Germany
   email: leinweber.katrin@gmail.com
   expertise:
@@ -1341,14 +1235,9 @@ kevinxufs:
   last-name: Xu
   twitter: kevinzhangxu
 kipkurui:
-  bio: 'Caleb is a 19/20 Mozilla Fellow and a Bioinformatician,  interested in teaching,
-    open science,
-
-    reproducibility, machine learning, FAIR Genomics,
-
-    and community building.
-
-    '
+  bio: Caleb is a 19/20 Mozilla Fellow and a Bioinformatician,  interested in teaching,
+    open science, reproducibility, machine learning, FAIR Genomics, and community
+    building.
   country: Kenya
   email: ckibet@icipe.org
   expertise:
@@ -1375,32 +1264,21 @@ kiri93:
   pronouns: he/his
   twitter: my_kiri
 kirstiejane:
-  bio: 'Kirstie is a lead of the Tools, Practices and Systems research programme at
+  bio: Kirstie is a lead of the Tools, Practices and Systems research programme at
     the Alan Turing Institute (London, UK) and senior research associate in the Department
-    of Psychiatry at the
-
-    University of Cambridge. Her work covers a broad range of interests and methods,
-    but the driving principle is to improve the lives of neurodivergent
-
+    of Psychiatry at the University of Cambridge. Her work covers a broad range of
+    interests and methods, but the driving principle is to improve the lives of neurodivergent
     people and people with mental health conditions. Dr Whitaker uses magnetic resonance
-    imaging to study child and adolescent brain development and
-
-    participatory citizen science to educate non-autistic people about how they can
-    better support autistic friends and colleagues. She is the lead developer
-
-    of The Turing Way, an openly developed educational resource to enable more reproducible
-    data science. Kirstie is a passionate advocate for making science
-
-    ''open for all'' by promoting equity and inclusion for people from diverse backgrounds,
-    and by changing the academic incentive structure to reward collaborative
-
-    working. She is the chair of the Turing Institute''s Ethics Advisory Group, a
-    Fulbright scholarship alumna and was a 2016/17 Mozilla Fellow for Science. Kirstie
-
-    was named, with her collaborator Petra Vertes, as a 2016 Global Thinker by Foreign
-    Policy magazine.
-
-    '
+    imaging to study child and adolescent brain development and participatory citizen
+    science to educate non-autistic people about how they can better support autistic
+    friends and colleagues. She is the lead developer of The Turing Way, an openly
+    developed educational resource to enable more reproducible data science. Kirstie
+    is a passionate advocate for making science ''open for all'' by promoting equity
+    and inclusion for people from diverse backgrounds, and by changing the academic
+    incentive structure to reward collaborative working. She is the chair of the Turing
+    Institute''s Ethics Advisory Group, a Fulbright scholarship alumna and was a 2016/17
+    Mozilla Fellow for Science. Kirstie was named, with her collaborator Petra Vertes,
+    as a 2016 Global Thinker by Foreign Policy magazine.
   country: UK
   email: kwhitaker@turing.ac.uk
   expertise:
@@ -1417,21 +1295,14 @@ kirstiejane:
   twitter: kirstie_j
   website: https://whitakerlab.github.io/
 klauer2207:
-  bio: 'Kathi is charge of implementing and driving ELIXIR''s industry Programme.
-    ELIXIR is an intergovernmental organisation with over 220 bioinformatics
-
-    research centres in 22 countries and the EMBL-EBI with open science at the core.
-    ELIXIR is active in the areas of data, compute, interoperability,
-
-    tools and training in the data driven life science sector. Kathi is further involved
-    developing and delivering initiatives to support Cambridge
-
-    researchers in their pursuit of business and entrepreneurial ventures through
-    the Entrepreneurial Postdocs of Cambridge University. Prior to her
-
-    current role Kathi worked as a researcher in vaccines & virology.
-
-    '
+  bio: Kathi is charge of implementing and driving ELIXIR''s industry Programme. ELIXIR
+    is an intergovernmental organisation with over 220 bioinformatics research centres
+    in 22 countries and the EMBL-EBI with open science at the core. ELIXIR is active
+    in the areas of data, compute, interoperability, tools and training in the data
+    driven life science sector. Kathi is further involved developing and delivering
+    initiatives to support Cambridge researchers in their pursuit of business and
+    entrepreneurial ventures through the Entrepreneurial Postdocs of Cambridge University.
+    Prior to her current role Kathi worked as a researcher in vaccines & virology.
   country: UK
   email: katharina.lauer@elixir-europe.org
   expertise:
@@ -1477,14 +1348,9 @@ kristinariemer:
   pronouns: she/her
   twitter: KristinaRiemer
 kswhitney:
-  bio: 'Kaitlin is an assistant professor in the Science, Technology & Society department
-    at the
-
-    Rochester Institute of Technology in Rochester, NY USA. She is also
-
-    extended program faculty in the Environmental Sciences Program.
-
-    '
+  bio: Kaitlin is an assistant professor in the Science, Technology & Society department
+    at the Rochester Institute of Technology in Rochester, NY USA. She is also extended
+    program faculty in the Environmental Sciences Program.
   country: Germany
   email: kxwsbi@rit.edu
   expertise:
@@ -1530,7 +1396,7 @@ lauracion:
   - Open education
   - Community building
   first-name: Laura
-  last-name: "Aci\xF3n"
+  last-name: Ación
   orcid: 0000-0001-5213-6012
   pronouns: she/her
   twitter: _lacion_
@@ -1557,21 +1423,11 @@ lilian9:
   pronouns: she/her
 lpantano:
   affiliation: CRG, Barcelona
-  bio: 'Computational biologist focused on genomic regulation and data integration.
-    12 years of
-
-    experience in biological data analysis using the most well-established tools and
-    contributing
-
-    to novel algorithms to improve the quantification and visualization of genomic
-    data. She approaches
-
-    scientific challenges with passion and believes that a collaboration and not an
-    individual alone
-
-    can successfully conquer them.
-
-    '
+  bio: Computational biologist focused on genomic regulation and data integration.
+    12 years of experience in biological data analysis using the most well-established
+    tools and contributing to novel algorithms to improve the quantification and visualization
+    of genomic data. She approaches scientific challenges with passion and believes
+    that a collaboration and not an individual alone can successfully conquer them.
   country: Spain
   email: lpantano@iscb.org
   expertise:
@@ -1588,15 +1444,9 @@ lpantano:
   twitter: lopantano
   website: https://lpantano.github.com
 luispedro:
-  bio: 'Luis is Junior PI at Fudan University in Shanghai.
-
-    His work in computational biology focus on the global microbiome.
-
-    He has written several open source scientific software packages
-
-    and organized and taught at multiple Software Carpentry workshops.
-
-    '
+  bio: Luis is Junior PI at Fudan University in Shanghai. His work in computational
+    biology focus on the global microbiome. He has written several open source scientific
+    software packages and organized and taught at multiple Software Carpentry workshops.
   country: China
   email: luis@luispedro.org
   expertise:
@@ -1611,17 +1461,11 @@ luispedro:
   website: http://luispedro.org
 lwinfree:
   affiliation: Open Knowledge Foundation
-  bio: 'Lilly works on open source software for open science as the product
-
-    manager for the Frictionless Data for Reproducible Research project
-
-    at Open Knowledge Foundation. Lilly has her PhD in neuroscience from
-
-    Oregon Health and Science University, where she researched brain injury
-
-    in fruit flies and became an advocate for open science and open data.
-
-    '
+  bio: Lilly works on open source software for open science as the product manager
+    for the Frictionless Data for Reproducible Research project at Open Knowledge
+    Foundation. Lilly has her PhD in neuroscience from Oregon Health and Science University,
+    where she researched brain injury in fruit flies and became an advocate for open
+    science and open data.
   country: USA
   email: lilly.winfree@okfn.org
   expertise:
@@ -1683,29 +1527,19 @@ malloryfreeberg:
   twitter: malloryfreeberg
 malvikasharan:
   bio: 'Malvika Sharan is the community manager of [_The Turing Way-](https://the-turing-way.netlify.com)
-
     at [The Alan Turing Institute](https://turing.ac.uk).
 
     Malvika works with its community of diverse members to develop resources and ways
-    that
-
-    can make data science accessible for a wider audience.
+    that can make data science accessible for a wider audience.
 
     Malvika has a PhD in Bioinformatics and she worked at  [European Molecular Biology
-    Laboratory](http://embl.org),
+    Laboratory](http://embl.org), Germany, that helped her solidify her values as
+    an Open Researcher and community builder.
 
-    Germany, that helped her solidify her values as an Open Researcher and community
-    builder.
-
-    She is a co-founder of the Open Life Science program, a fellow of
-
-    [Software Sustainability Institute](https://software.ac.uk/about/fellows/malvika-sharan),
-
-    a board member of [Open Bioinformatics Foundation](https://www.open-bio.org/board/),
-
-    and a contributing member of [The Carpentries](https://carpentries.org/) community.
-
-    '
+    She is a co-founder of the Open Life Science program, a fellow of [Software Sustainability
+    Institute](https://software.ac.uk/about/fellows/malvika-sharan), a board member
+    of [Open Bioinformatics Foundation](https://www.open-bio.org/board/), and a contributing
+    member of [The Carpentries](https://carpentries.org/) community.'''
   country: UK
   email: malvikasharan@gmail.com
   expertise:
@@ -1725,12 +1559,8 @@ malvikasharan:
   pronouns: she/her
   twitter: MalvikaSharan
 martenson:
-  bio: 'Martin is a computer fellow with an interest to help scientists tackle heaps
-    of data.
-
-    Spent last 7 years working on Galaxy project core codebases.
-
-    '
+  bio: Martin is a computer fellow with an interest to help scientists tackle heaps
+    of data. Spent last 7 years working on Galaxy project core codebases.
   country: Czech Republic
   email: cech.marten@gmail.com
   expertise:
@@ -1743,7 +1573,7 @@ martenson:
   - Multi-omics
   - Frameworks behind the software aspects of the science.
   first-name: Martin
-  last-name: "\u010Cech"
+  last-name: Čech
   pronouns: he/him
 martinagvilas:
   affiliation: Max-Planck-Institute AE
@@ -1772,22 +1602,16 @@ martinagvilas:
 matuskalas:
   affiliation: University of Bergen
   country: Norway
-  first-name: "Mat\xFA\u0161"
-  last-name: "Kala\u0161"
+  first-name: Matúš
+  last-name: Kalaš
   pronouns: he/him
   twitter: matuskalas
 mblue9:
   affiliation: Peter MacCallum Cancer Centre
-  bio: 'Maria is the Application and Training Specialist for Research Computing at
-    the Peter MacCallum Cancer Centre in
-
-    Melbourne, Australia. She specialises in bioinformatics and data science education
-    and training. She is
-
-    passionate about supporting researchers, reproducible research, knowledge sharing
-    and working collaboratively.
-
-    '
+  bio: Maria is the Application and Training Specialist for Research Computing at
+    the Peter MacCallum Cancer Centre in Melbourne, Australia. She specialises in
+    bioinformatics and data science education and training. She is passionate about
+    supporting researchers, reproducible research, knowledge sharing and working collaboratively.
   country: Australia
   email: maria.doyle@petermac.org
   expertise:
@@ -1798,15 +1622,10 @@ mblue9:
   last-name: Doyle
   pronouns: she/her
 meagdoh:
-  bio: 'Meag is an open data advocate and product design leader. Most recently, she
-    mentored participants and co-hosted Mozilla''s
-
-    Open Leaders program (Cohort 6 & 7). Currently, she leads product design strategy
-    for data and tools at National Institutes
-
-    of Health All of Us Research Program.
-
-    '
+  bio: Meag is an open data advocate and product design leader. Most recently, she
+    mentored participants and co-hosted Mozilla''s Open Leaders program (Cohort 6
+    & 7). Currently, she leads product design strategy for data and tools at National
+    Institutes of Health All of Us Research Program.
   country: USA
   email: meagdoherty@gmail.com
   expertise:
@@ -1828,18 +1647,11 @@ megmugure:
   twitter: meg_wanjiku
 mesfind:
   affiliation: Addis Ababa University
-  bio: 'Mesfin Diro is a faculity at Addis Ababa University, Ethiopia. Currently,
-    He''s a PhD student at his home
-
-    institute on Redox Flow Batteries in the area of nanotechnology. He has high enthusiasm
-    in expanding
-
-    comutatational and data science skills for better research outputs. He is also
-    passionate and advocate
-
-    of open source, open access and open scientific.
-
-    '
+  bio: Mesfin Diro is a faculity at Addis Ababa University, Ethiopia. Currently, He''s
+    a PhD student at his home institute on Redox Flow Batteries in the area of nanotechnology.
+    He has high enthusiasm in expanding comutatational and data science skills for
+    better research outputs. He is also passionate and advocate of open source, open
+    access and open scientific.
   country: Ethiopia
   email: mesfindiro@gmail.com
   expertise:
@@ -1874,11 +1686,8 @@ mkuzak:
   twitter: matkuzak
 mloning:
   affiliation: University College London
-  bio: 'Markus is a PhD student at UCL and he is one of the core developers of sktime,
-
+  bio: Markus is a PhD student at UCL and he is one of the core developers of sktime,
     a toolbox for machine learning with time series.
-
-    '
   country: UK
   email: Markus.loning@gmail.com
   expertise:
@@ -1892,7 +1701,7 @@ mloning:
   - Applied machine learning projects in biochemical engineering, health and agricultural
     research
   first-name: Markus
-  last-name: "L\xF6ning"
+  last-name: Löning
   pronouns: he/him
   twitter: mm_loening
   website: https://www.linkedin.com/in/mloning/
@@ -1904,15 +1713,10 @@ morphofun:
   pronouns: she/her
   twitter: MorphoFun
 mruizvelley:
-  bio: 'Mariana is a molecular biologist by training and a scientist by heart.
-
-    Recently, she has been diving into the data science and biostatistics world
-
-    in the search of contributing to sustainability and digitalization of science.
-
-    Her expertise are in Epigenetics, genomics, and molecular biology.
-
-    '
+  bio: Mariana is a molecular biologist by training and a scientist by heart. Recently,
+    she has been diving into the data science and biostatistics world in the search
+    of contributing to sustainability and digitalization of science. Her expertise
+    are in Epigenetics, genomics, and molecular biology.
   country: Germany
   email: mruizvelley@gmail.com
   expertise:
@@ -1935,15 +1739,9 @@ muhammetcelik:
   last-name: Celik
   pronouns: he/him
 mvdbeek:
-  bio: 'Marius is a core Galaxy developer since 2015 and working full time on Galaxy
-    since 2019.
-
-    He has learned programming during my PhD in developmental biology, and quickly
-    shifted
-
-    towards data analysis and Galaxy development after that.
-
-    '
+  bio: Marius is a core Galaxy developer since 2015 and working full time on Galaxy
+    since 2019. He has learned programming during my PhD in developmental biology,
+    and quickly shifted towards data analysis and Galaxy development after that
   country: France
   email: m.vandenbeek@gmail.com
   expertise:
@@ -1958,15 +1756,15 @@ mvdbeek:
   pronouns: he/him
   twitter: mariusvdbeek
 myreille-larouche:
-  affiliation: "Institute for Research in Immunology and Cancer of the Universit\xE9\
-    \ de Montr\xE9al"
+  affiliation: Institute for Research in Immunology and Cancer of the Université de
+    Montréal
   country: Canada
   email: myreille.larouche@gmail.com
   first-name: Myreille
   github: false
   last-name: Larouche
 naralb:
-  affiliation: "Museu Paraense Em\xEDlio Goeldi"
+  affiliation: Museu Pará Emílio Goeldi
   country: Brazil
   first-name: Naraiana
   last-name: Loureiro Benone
@@ -1987,9 +1785,7 @@ nehamoopen:
   pronouns: she/her
   twitter: NehaMoopen
 nerantzis:
-  bio: 'Physicist, Teacher, Mozillian
-
-    '
+  bio: Physicist, Teacher, Mozillian
   country: Greece
   email: ScienceBrainFun@gmail.com
   expertise:
@@ -2022,24 +1818,14 @@ npalopoli:
   twitter: npalopoli
 npscience:
   bio: 'Naomi is motivated by people who are empowered to participate in knowledge
-    and discovery for improvement of the
-
-    world around them. She is learning how to support communities and be an ally for
-    under-represented minorities and
-
-    under-powered peers. She enjoys working backstage on engaging, participatory,
-    inclusive and productive online
-
-    events and collaborations. Her lens is influenced by her experiences: she is European,
-    an OpenCon alumnus, MozFest
-
-    facilitator, an advisor to PREreview, on the board of directors for Dryad, a CSCCE
-    scientific community engagement
-
-    fellow (#CEFP2019), organiser of #eLifeSprint 2018, and a human continually practising
-    balance and kindness.
-
-    '
+    and discovery for improvement of the world around them. She is learning how to
+    support communities and be an ally for under-represented minorities and under-powered
+    peers. She enjoys working backstage on engaging, participatory, inclusive and
+    productive online events and collaborations. Her lens is influenced by her experiences:
+    she is European, an OpenCon alumnus, MozFest facilitator, an advisor to PREreview,
+    on the board of directors for Dryad, a CSCCE scientific community engagement fellow
+    (#CEFP2019), organiser of #eLifeSprint 2018, and a human continually practising
+    balance and kindness.'
   country: UK
   email: naomi.penfold@asapbio.org
   expertise:
@@ -2054,18 +1840,11 @@ npscience:
   twitter: npscience
   website: https://npscience.github.io
 nsoranzo:
-  bio: 'Nicola works at the Earlham Institute, where he manages and supports a Galaxy
-    web server
-
-    to run large-scale analyses in an accessible and reproducible way.
-
+  bio: Nicola works at the Earlham Institute, where he manages and supports a Galaxy
+    web server to run large-scale analyses in an accessible and reproducible way.
     He also collaborates on the open source development of the Galaxy platform and
-    its tools.
-
-    Nicola is a Carpentries Instructor and a Galaxy trainer. He is currently the Technical
-    Coordinator for ELIXIR-UK.
-
-    '
+    its tools. Nicola is a Carpentries Instructor and a Galaxy trainer. He is currently
+    the Technical Coordinator for ELIXIR-UK.
   country: UK
   email: nicola.soranzo@gmail.com
   expertise:
@@ -2082,40 +1861,12 @@ nsoranzo:
   pronouns: he/him
   twitter: NicolaSoranzo
   website: https://www.earlham.ac.uk/nicola-soranzo
-? open and reproducible research best practices; training and teaching tech to researchers;
-  pedagogical approaches to instructor training and curricula development
-: affiliation: University of Manchester
-  bio: 'Software Sustainability Institute''s training lead. Over the past 5 years
-    committed to ongoing improvement of research software practice through training
-    and community engagement work. Driving the trends in training for researchers
-    and scientists in computational and data analysis skills forward and helping develop
-    new training curricula. '
-  city: Manchester
-  country: United Kingdom
-  email: a.nenadic@manchester.ac.uk
-  expertise:
-  - Open and reproducible research best practices
-  - Training and teaching tech to researchers
-  - 'Pedagogical approaches to instructor training and curricula development '
-  first-name: Aleksandra
-  last-name: Nenadic
-  orcid: 0000-0002-2269-3894
-  pronouns: she/her/hers
-  twitter: aleks_nenadic
-  website: https://anenadic.github.io/professional-cv/
 orchid00:
-  bio: 'Paula is an Open Science advocate her passions are data management, data analytics,
-
-    research, and diversity. She is a computer scientist who
-
-    has worked on data intensive bioinformatics and data management. She has also
-    collaborated
-
-    on community projects such as The Carpentries, rOpenSci,
-
-    RLadies. Currently she works for the National Imaging Facility in Australia.
-
-    '
+  bio: Paula is an Open Science advocate her passions are data management, data analytics,
+    research, and diversity. She is a computer scientist who has worked on data intensive
+    bioinformatics and data management. She has also collaborated on community projects
+    such as The Carpentries, rOpenSci, RLadies. Currently she works for the National
+    Imaging Facility in Australia.
   country: Australia
   email: p.martinez@uq.edu.au
   expertise:
@@ -2128,7 +1879,7 @@ orchid00:
   orcid: 0000-0002-8990-1985
   pronouns: she/her
 paulineligonie:
-  affiliation: "Universit\xE9 de Montr\xE9al"
+  affiliation: Université de Montréal
   country: Canada
   email: pauline-ligonie@orange.fr
   first-name: Pauline
@@ -2142,15 +1893,10 @@ paulowoicho:
   pronouns: he/him
   twitter: N/A
 paulvill:
-  bio: 'Paul is group Leader in Machine Leader and Developmental Biology at the Turing
-    Center for
-
-    Living Systems in Marseille (France). He is leading the open science project "the
-    digital embryo
-
-    atlas" and was several times mentor in Mozilla Open Leadership''s program.
-
-    '
+  bio: Paul is group Leader in Machine Leader and Developmental Biology at the Turing
+    Center for Living Systems in Marseille (France). He is leading the open science
+    project "the digital embryo atlas" and was several times mentor in Mozilla Open
+    Leadership''s program.
   country: France
   expertise:
   - Machine learning
@@ -2167,24 +1913,13 @@ paulvill:
   twitter: paulvilloutreix
   website: https://paulcinq.wordpress.com
 pherterich:
-  bio: 'Patricia is currently a Research Data Specialist working at the Digital
-
-    Curation Centre at the University of Edinburgh working on the FAIRsFAIR
-
-    project aiming at fostering Fair Data Practices in Europe.
-
-    Before joining the DCC, she was the Research Repository Advisor at the University
-    of
-
-    Birmingham and have previously worked as a data librarian at CERN''s
-
-    Scientific Information Service working closely with software developers to
-
-    deliver data and code sharing solutions. She loves collaborating openly
-
-    and making projects welcoming to new comers.
-
-    '
+  bio: Patricia is currently a Research Data Specialist working at the Digital Curation
+    Centre at the University of Edinburgh working on the FAIRsFAIR project aiming
+    at fostering Fair Data Practices in Europe. Before joining the DCC, she was the
+    Research Repository Advisor at the University of Birmingham and have previously
+    worked as a data librarian at CERN''s Scientific Information Service working closely
+    with software developers to deliver data and code sharing solutions. She loves
+    collaborating openly and making projects welcoming to new comers.
   country: UK
   expertise:
   - Data management
@@ -2225,6 +1960,25 @@ pradeep-eranti:
   last-name: Eranti
   pronouns: he/his
   twitter: pradeeperanti
+prashbio:
+  affiliation: Bioclues.org, India and  BISR, Jaipur
+  bio: I am a Senior Scientist in Systems Biology at Birla Institute of Scientific
+    Research (BISR), Jaipur, India. I obtained my PhD from Aalborg University, Denmark
+    after having worked in Lene Juel Rasmussen's lab. I went on to gain seven years
+    of post-doctoral experience and sabbatical visits in various laboratories before
+    taking up the current position. I love traveling and had been to over 70+ countries.
+    I love mentoring! https://www.bioinformatics.org/wiki/Prash
+  city: Jaipur
+  country: India
+  email: prash@bioclues.org
+  expertise:
+  - 'Systems Biology, Bioinformatics, Mentoring '
+  first-name: Prashanth N.
+  last-name: Suravajhala
+  orcid: https://orcid.org/0000-0002-8535-278X
+  pronouns: He
+  twitter: prashbio
+  website: https://www.bioinformatics.org/wiki/Prash
 profgiuseppe:
   affiliation: Biodec S.r.l.
   bio: After leaving the university, where I taught programming in an international
@@ -2279,15 +2033,9 @@ rainsworth:
   twitter: rachaelevelyn
   website: https://rainsworth.github.io/
 rgaiacs:
-  bio: 'Raniere is a PhD student at Department of Infectious Diseases and Public Health,
-    City
-
-    University of Hong Kong. He worked with the Software Sustainability Institute
-    in the
-
-    UK as community officer.
-
-    '
+  bio: Raniere is a PhD student at Department of Infectious Diseases and Public Health,
+    City University of Hong Kong. He worked with the Software Sustainability Institute
+    in the UK as community officer.
   country: Brazil
   email: raniere@rgaiacs.com
   expertise:
@@ -2303,8 +2051,8 @@ rgaiacs:
   twitter: rgaiacs
   website: https://rgaiacs.com
 rodrigocam:
-  bio: "Software Engineering Student at University of Bras\xEDlia, open source developer,\n\
-    python programmer, functional languages lover!\n"
+  bio: Software Engineering Student at University of Brasilia, open source developer,
+    python programmer, functional languages lover!
   country: Brazil
   email: rodrigo.redcode@gmail.com
   expertise:
@@ -2317,13 +2065,9 @@ rodrigocam:
   last-name: Oliveira Campos
   twitter: sayadiguin
 rossmounce:
-  bio: 'A biodiversity scientist who wants to liberate research from the constraints
-
-    imposed by paywalls & PDFs. Also a Lubuntu user and Software Sustainability
-
-    Fellow (2016 Inauguration).
-
-    '
+  bio: A biodiversity scientist who wants to liberate research from the constraints
+    imposed by paywalls & PDFs. Also a Lubuntu user and Software Sustainability Fellow
+    (2016 Inauguration).
   country: UK
   email: ross.mounce@gmail.com
   expertise:
@@ -2337,21 +2081,12 @@ rossmounce:
   website: http://rossmounce.co.uk/
 rs_khetani:
   affiliation: Harvard T.H. Chan School of Public Health
-  bio: 'Radhika is the training director at the bioinformatics core at the Harvard
-    T.H. Chan School
-
-    of Public Health - they run regular workshops to enable wet lab biologists to
-    perform analysis
-
-    on NGS data using best practices (including FAIR data practices). Her doctoral
-    training is in
-
-    the wet lab, but she transitioned to dry lab work in 2009 and landed in an environment
-    (thankfully)
-
-    that was focused on open science and open data.
-
-    '
+  bio: Radhika is the training director at the bioinformatics core at the Harvard
+    T.H. Chan School of Public Health - they run regular workshops to enable wet lab
+    biologists to perform analysis on NGS data using best practices (including FAIR
+    data practices). Her doctoral training is in the wet lab, but she transitioned
+    to dry lab work in 2009 and landed in an environment (thankfully) that was focused
+    on open science and open data.
   country: USA
   email: khetani.r@gmail.com
   expertise:
@@ -2364,12 +2099,12 @@ rs_khetani:
   pronouns: she/her
   twitter: rs_khetani
 samguay:
-  affiliation: "Universit\xE9 de Montr\xE9al"
-  bio: "While completing his PhD in cognitive neuroscience at the Universit\xE9 de\
-    \ Montr\xE9al,\nSamuel organizes training events to equip his peers to make science\
-    \ more robust,\naccessible, and inclusive to all. He is the cofounder of Open\
-    \ Science UMontreal,\nan initiative that aims to facilitate the transition to\
-    \ a more open and transparent\nway of doing science.\n"
+  affiliation: Université de Montréal
+  bio: While completing his PhD in cognitive neuroscience at the Université de Montréal,
+    Samuel organizes training events to equip his peers to make science more robust,
+    accessible, and inclusive to all. He is the cofounder of Open Science UMontreal,
+    an initiative that aims to facilitate the transition to a more open and transparent
+    way of doing science.
   country: Canada
   email: samuel.guay@umontreal.ca
   expertise:
@@ -2396,42 +2131,28 @@ samvanstroud:
   first-name: Samuel
   last-name: van Stroud
 santosrac:
-  bio: 'Bioinformatician working on genomics and transcriptomics of ascomycete and
-    basidiomycete fungi. Interested in
-
-    education, teaching programming skills to bioscientists, and in open science.
-
-    '
+  bio: Bioinformatician working on genomics and transcriptomics of ascomycete and
+    basidiomycete fungi. Interested in education, teaching programming skills to bioscientists,
+    and in open science.
   country: Brazil
   email: renatoacsantos@gmail.com
   expertise:
   - Bioinformatics
   - Introduction to programming skills (Python or Perl)
   - Fungal Biology
-  first-name: "Renato Augusto Corr\xEAa"
+  first-name: Renato Augusto Corrêa
   last-name: dos Santos
   pronouns: he/him
   twitter: CorreaSantosRA
 satagopam7:
-  bio: 'Venkata is a Bioinformatician, a Senior Researcher at Bioinformatics core
-    facility,
-
+  bio: Venkata is a Bioinformatician, a Senior Researcher at Bioinformatics core facility,
     and Deputy Head of the BioMedical Informatics Department, LCSB, University of
-    Luxembourg.
-
-    He is also Technical Coordinator (TeC) of ELIXIR-Luxembourg Node and CTO & Co-founder
-    ITTM S.A. Luxembourg.
-
-    He has around two decades of working experience in various bioinformatics fields
-    including
-
-    Data Integration and Knowledge Management; Clinical and Translational Data Curation,
-
-    Harmonisation, Integration and Analysis; Dynamic Visual Analytics; Text-mining;
-
-    Deep learning and advanced machine learning technologies.
-
-    '
+    Luxembourg. He is also Technical Coordinator (TeC) of ELIXIR-Luxembourg Node and
+    CTO & Co-founder ITTM S.A. Luxembourg. He has around two decades of working experience
+    in various bioinformatics fields including Data Integration and Knowledge Management;
+    Clinical and Translational Data Curation, Harmonisation, Integration and Analysis;
+    Dynamic Visual Analytics; Text-mining; Deep learning and advanced machine learning
+    technologies.
   country: Luxembourg
   email: venkata.satagopam@uni.lu
   expertise:
@@ -2445,23 +2166,12 @@ satagopam7:
   pronouns: he/him
   website: https://wwwen.uni.lu/lcsb/people/venkata_satagopam
 sdopoku:
-  bio: 'David is a "self-designated" Data Plumber from Ghana working to build technical
-    and data
-
-    capacity for low-income individuals, organisations and communities. His background
-    is in
-
-    Biology and Computer Science and has worked with journalists, advocacy organisations,
-
-    research institutions, government officials and private businesses in over 30
-    countries
-
-    across 5 continents. Currently, he leads data research at Growing Gold Farms,
-    a food startup
-
-    in Tema, Ghana.
-
-    '
+  bio: David is a "self-designated" Data Plumber from Ghana working to build technical
+    and data capacity for low-income individuals, organisations and communities. His
+    background is in Biology and Computer Science and has worked with journalists,
+    advocacy organisations, research institutions, government officials and private
+    businesses in over 30 countries across 5 continents. Currently, he leads data
+    research at Growing Gold Farms, a food startup in Tema, Ghana.
   country: Ghana
   email: david@adoore.org
   expertise:
@@ -2481,22 +2191,13 @@ sebastianeggert:
   twitter: se_eggert
 sgibson91:
   affiliation: Alan Turing Institute
-  bio: 'Sarah is a Research Software Engineer at The Alan Turing Institute where she
-    implements software
-
-    best practices to translate academic research into real world solutions through
-    the Turing''s collaborative
-
-    network. Sarah is also an operator and maintainer for the Binder project and runs
-    a BinderHub cluster at
-
-    the Turing which receives traffic from mybinder.org. This year, she is also honoured
-    to be a Software
-
-    Sustainability Institute Fellow and is using her Fellowship to nurture and diversify
-    the Binder community.
-
-    '
+  bio: Sarah is a Research Software Engineer at The Alan Turing Institute where she
+    implements software best practices to translate academic research into real world
+    solutions through the Turing''s collaborative network. Sarah is also an operator
+    and maintainer for the Binder project and runs a BinderHub cluster at the Turing
+    which receives traffic from mybinder.org. This year, she is also honoured to be
+    a Software Sustainability Institute Fellow and is using her Fellowship to nurture
+    and diversify the Binder community.
   country: UK
   email: sgibson@turing.ac.uk
   expertise:
@@ -2525,11 +2226,11 @@ sk-sahu:
   pronouns: he/him
   twitter: sangram_ksahu
 sofia-kirke-forslund:
-  bio: "Swedish-born computational biologist, since 2018 heading systems medicine\
-    \ (host-microbiome focus,\n \"association hunting\") lab in Berlin, interested\
-    \ in too many things. AMR,\n metabolic/inflammatory/cardiovascular diseases, drug-microbiome\
-    \ interactions, confounder analysis,\n gene family evolution. Queer, transgender\
-    \ woman and intersectional feminist.\n"
+  bio: Swedish-born computational biologist, since 2018 heading systems medicine (host-microbiome
+    focus, 'association hunting') lab in Berlin, interested in too many things. AMR,
+    metabolic/inflammatory/cardiovascular diseases, drug-microbiome interactions,
+    confounder analysis, gene family evolution. Queer, transgender woman and intersectional
+    feminist.
   country: Berlin
   email: Sofia.Forslund@mdc-berlin.de
   expertise:
@@ -2582,18 +2283,18 @@ sudarshangc:
 tai-rocha:
   country: Brazil
   email: taina013@gmail.com
-  first-name: "Tain\xE1"
+  first-name: Tainá
   last-name: Rocha
   twitter: Tai_Rocha_
 thessaly:
   affiliation: CENIT-UNSAM
-  bio: "Julieta is a PhD candidate on social studies of science & technology, with\
-    \ a background in environmental science. Her research asks how open science hardware\
-    \ can contribute to democratize science and tech in the \u2018global south\u2019\
-    \ and what it means in each context. She co-founded \u2018Open Hardware Makers\u2019\
-    , a mentorship program like OpenLifeSci but for Hardware; she\u2019s part of the\
-    \ Global Open Science Hardware (GOSH) community and loves tinkering with hardware\
-    \ and data for community science."
+  bio: Julieta is a PhD candidate on social studies of science & technology, with
+    a background in environmental science. Her research asks how open science hardware
+    can contribute to democratize science and tech in the ‘global south’ and what
+    it means in each context. She co-founded ‘Open Hardware Makers’, a mentorship
+    program like OpenLifeSci but for Hardware; she’s part of the Global Open Science
+    Hardware (GOSH) community and loves tinkering with hardware and data for community
+    science.
   city: Buenos Aires
   country: Argentina
   email: jarancio@unsam.edu.ar
@@ -2610,10 +2311,8 @@ thessaly:
   website: julieta.aranc.io
 tklingstrom:
   affiliation: Swedish University of Agricultural Sciences
-  bio: 'Biotechnician turned bioinformatician turned animal scientist trying to standardise
+  bio: Biotechnician turned bioinformatician turned animal scientist trying to standardise
     workflows using Galaxy
-
-    '
   country: Sweden
   email: tomas.klingstrom@slu.se
   expertise:
@@ -2625,7 +2324,7 @@ tklingstrom:
   - Ethics
   - Cattle genomics
   first-name: Tomas
-  last-name: "Klingstr\xF6m"
+  last-name: Klingström
   pronouns: he/him
   website: https://www.slu.se/en/ew-cv/tomas-klingstrom/
 tlaguna:
@@ -2636,15 +2335,10 @@ tlaguna:
   twitter: teresa__laguna
 tnabtaf:
   affiliation: Galaxy Project, Johns Hopkins University
-  bio: 'Dave coordinates training and outreach for the Galaxy Project. He has been
-    a community person in life sciences
-
-    for 13 years. Before that he worked in biological databases for 7 years. His training
-    is in Computer Science,
-
-    with an emphasis on databases.
-
-    '
+  bio: Dave coordinates training and outreach for the Galaxy Project. He has been
+    a community person in life sciences for 13 years. Before that he worked in biological
+    databases for 7 years. His training is in Computer Science, with an emphasis on
+    databases.
   country: USA
   email: clements@galaxyproject.org
   expertise:
@@ -2684,8 +2378,8 @@ tobyhodges:
   website: https://tbyhdgs.info
 trallard:
   affiliation: Microsoft
-  country: UK
   city: Manchester
+  country: UK
   email: trallard@bitsandchips.me
   first-name: Tania
   last-name: Allard
@@ -2717,20 +2411,12 @@ tsonika:
   website: https://bioinformaticslab.erc.monash.edu
 unode:
   affiliation: European Molecular Biology Laboratory (EMBL)
-  bio: 'Renato is a computational biologist with a background in evolution, genomics
-    and the microbiome.
-
-    Currently project and community manager of the [EMBL Bio-IT project](https://bio-it.embl.de/),
-
-    supporting the local bio-computational community through training, consulting
-    and core resources.
-
-    Open-source and scientific reproducibility advocate.
-
-    When not tanning in front of a screen you may find him wandering the green and
-    blue in Nature.
-
-    '
+  bio: Renato is a computational biologist with a background in evolution, genomics
+    and the microbiome. Currently project and community manager of the [EMBL Bio-IT
+    project](https://bio-it.embl.de/), supporting the local bio-computational community
+    through training, consulting and core resources. Open-source and scientific reproducibility
+    advocate. When not tanning in front of a screen you may find him wandering the
+    green and blue in Nature.
   country: Germany
   email: renato.alves@embl.de
   expertise:
@@ -2746,22 +2432,16 @@ unode:
   pronouns: he/him
   twitter: renato_alvs
 valerie-parent:
-  affiliation: "Law Faculty, Universit\xE9 de Montr\xE9al "
+  affiliation: 'Law Faculty, Université de Montréal '
   country: Canada
   email: valerie.m.parent@gmail.com
   first-name: Valerie
   github: false
   last-name: Parent
 vcheplygina:
-  bio: 'Veronika''s research area is machine learning in medical imaging. She is an
-    now
-
-    assistant professor but will be leaving her position soon. She is blogging about
-    this
-
-    and other academia-related topics on her website veronikach.com
-
-    '
+  bio: Veronika''s research area is machine learning in medical imaging. She is an
+    now assistant professor but will be leaving her position soon. She is blogging
+    about this and other academia-related topics on her website veronikach.com
   country: The Netherlands
   email: veronika@veronikach.com
   expertise:
@@ -2779,24 +2459,14 @@ vickynembaware:
   bio: 'Vicky has a PhD in Bioinformatics and an MPhil in Monitoring and Evaluation.
 
     Her research experience (qualitative and quantitative) spans Genomics and Public
-    Health.
-
-    She is currently a Project Coordinator for the Sickle Africa Data Coordinating
-    Center at
-
-    the University of Cape Town. She also coordinates several other groups and projects
-
-    including the African Genomic Medicine Training Initiative (AGMT),
-
+    Health. She is currently a Project Coordinator for the Sickle Africa Data Coordinating
+    Center at the University of Cape Town. She also coordinates several other groups
+    and projects including the African Genomic Medicine Training Initiative (AGMT),
     Sickle Cell Disease Ontology Working Group (SCDO) and mGenAfrica.
 
     She is the current secretary of the African Society of Human Genetics (AfSHG).
-
-    She is passionate about building research capacity, mentoring
-
-    young investigators and translational research.
-
-    '
+    She is passionate about building research capacity, mentoring young investigators
+    and translational research. '
   country: South Africa
   email: vnembaware@gmail.com
   expertise:
@@ -2818,22 +2488,14 @@ wasifarahman:
   first-name: Wasifa
   last-name: Rahman
 yochannah:
-  bio: 'Yo is a [Software Sustainability Institute Fellow](https://software.ac.uk/about/fellows/yo-yehudi),
-
-    founder of [Code is Science](http://www.codeisscience.com/manifesto),
-
-    [EngD student at the University of Manchester](https://www.research.manchester.ac.uk/portal/yochannah.yehudi-postgrad.html)
-
-    studying the effects of community and usabilty on open source software,
-
-    editor for the [PLOS Open Source Toolkit](https://channels.plos.org/open-source-toolkit),
-
+  bio: Yo is a [Software Sustainability Institute Fellow](https://software.ac.uk/about/fellows/yo-yehudi),
+    founder of [Code is Science](http://www.codeisscience.com/manifesto), [EngD student
+    at the University of Manchester](https://www.research.manchester.ac.uk/portal/yochannah.yehudi-postgrad.html)
+    studying the effects of community and usabilty on open source software, editor
+    for the [PLOS Open Source Toolkit](https://channels.plos.org/open-source-toolkit),
     board member of the [Open Bioinformatics Foundation](https://www.open-bio.org/board/),
-
     and a software developer at the University of Cambridge, working on an open source
     biological data warehouse called [InterMine](http://intermine.org/).
-
-    '
   country: UK
   email: yoyehudi@gmail.com
   expertise:
@@ -2863,10 +2525,8 @@ yvanlebras:
   twitter: Yvan2935
   website: https://yvanlebras.fr
 zebetus:
-  bio: 'A mentor for many previous waves of open leaders, who is currently studying
+  bio: A mentor for many previous waves of open leaders, who is currently studying
     for their PhD at UCL.
-
-    '
   country: UK
   email: haz.zebetus@gmail.com
   expertise:

--- a/_data/people.yaml
+++ b/_data/people.yaml
@@ -23,21 +23,16 @@
 # Mandatory: first-name, last-name, country
 ---
 ArielleBL:
+  affiliation: The Alan Turing Institute
   bio: 'Arielle has spent her career to date working in research-adjacent fields,
-    starting with a stint at open access
-
-    publisher PLOS, where she learnt the importance (and challenges) of open science,
-    code, and data. Currently
-
-    coordinating neuroscience communities at University of Cambridge, she was a CSCCE
-    Community Engagement Fellow
-
-    in 2019 and continues to be actively involved in the community. She is a contributor
-    to the Turing Way project.
-
-    '
-  country: UK
-  email: ab833@cam.ac.uk
+    starting with a stint at open access publisher PLOS, where she learnt the importance
+    (and challenges) of open science, code, and data. Currently the Research Project
+    Manager on the Tools, Practices & Systems programme at The Alan Turing Institute,
+    she was a CSCCE Community Engagement Fellow in 2019 and continues to be actively
+    involved in the community. She is a contributor to the Turing Way project. '
+  city: London
+  country: United Kingdom
+  email: ariellebennettlovell@gmail.com
   expertise:
   - Road mapping and strategy planning
   - Community consultation
@@ -137,29 +132,21 @@ Delphine-L:
   twitter: ddlariviere
   website: https://observablehq.com/@delphine-l
 Demellina:
-  bio: 'Demitra is the Editorial Community Manager at F1000 which she joined in 2017
-    after working in journal development at Springer Nature.
-
-    She is a strong advocate of Open Research and engages with the research community
-    to raise awareness of the F1000 publishing platforms.
-
-    In her role, she supports the development of funder-specific platforms, particularly
-    Wellcome Open Research. These platforms aim to transform the
-
-    way science is communicated and provides researchers with innovative solutions
-    for how their research is shared, used and reused.
-
-    '
-  country: UK
-  email: Demitra.Ellina@f1000.com
+  affiliation: F1000Research
+  bio: 'Demitra Ellina is the Editorial Community Manager at F1000Research. She is
+    a strong advocate of Open Research and engages with the research community to
+    raise awareness of the F1000Research publishing platforms. '
+  city: London
+  country: United Kingdom
+  email: demitra.ellina@f1000.com
   expertise:
-  - Open Research practises
-  - Open data
-  - Open peer review models
-  - Open access publishing
+  - open science/research
+  - open access
+  - open peer review
+  - preprints
   first-name: Demitra
   last-name: Ellina
-  pronouns: she/her
+  pronouns: She/her
   twitter: j_ellina
 EKaroune:
   country: UK
@@ -168,14 +155,6 @@ EKaroune:
   last-name: Karoune
   pronouns: she/her
   website: ekaroune
-ekeluv:
-  affiliation: Medical biosciences UWC
-  country: South Africa
-  email: nwanyiomadiuko@gmail.com
-  first-name: Ekeoma
-  last-name: Festus
-  pronouns: they/them # TBC
-  twitter: ekeluv
 EvaCHerbst:
   country: Switzerland
   email: eva.herbst@pim.uzh.ch
@@ -233,14 +212,6 @@ InquisitiveVi:
   orcid: 0000-0002-3445-5383
   pronouns: he/him
   twitter: I_Vinodh
-ibrahssali1:
-  affiliation: Muni University
-  country: Uganda
-  email: i.ssali@muni.ac.ug
-  first-name: Ibrahim
-  last-name: Ssali
-  pronouns: he/him
-  twitter: ibrahssali1
 Ismael-KG:
   affiliation: The Alan Turing Institute
   country: UK
@@ -353,30 +324,6 @@ LandiMi2:
   last-name: Kofia Landi
   pronouns: he/him
   twitter: CofiaLandy
-LangData:
-  affiliation: Free University of Amsterdam
-  bio: 'Lena am a linguist by training, currently working as community manager RDM
-    at the
-
-    library of the VU Amsterdam. She enjoys being involved in research projects and
-    being
-
-    part of a team contributing to a larger goal.
-
-    '
-  country: The Netherlands
-  email: e.karvovskaya@vu.nl
-  expertise:
-  - Research data management
-  - Data stewardship
-  - FAIR principles
-  - Community building
-  - Life sciences
-  - Community of research supporterss
-  first-name: Lena
-  last-name: Karvovskaya
-  pronouns: she/her
-  twitter: LangData
 LauraCarter:
   affiliation: University of Essex
   country: UK
@@ -466,6 +413,13 @@ NaraLB:
   last-name: Loureiro Benone
   pronouns: she/her
   twitter: nlbenone
+NehaMoopen:
+  country: The Netherlands
+  email: neha.moopen@gmail.com
+  first-name: Neha
+  last-name: Moopen
+  pronouns: she/her
+  twitter: NehaMoopen
 SamGuay:
   affiliation: "Universit\xE9 de Montr\xE9al"
   bio: "While completing his PhD in cognitive neuroscience at the Universit\xE9 de\
@@ -621,6 +575,30 @@ aath0:
   pronouns: she/her
   twitter: aath0
   website: https://aath0.github.io/
+agbeltran:
+  bio: Alejandra is the Software Engineering Group Leader at the Science and Technology
+    Facilities Council (STFC). STFC is part of UK Research and Innovation. Her focus
+    is around software management, which includes supporting the software developmnt
+    process, and data management projects, which include the development of bespoke
+    software systems to manage the experimental data produced by the large scale scientific
+    facilities at STFC. Before joining STFC she was a Research Lecturer at the University
+    of Oxford. Her research interests are around developing models, methods, and software
+    tools for data science and innovative scholarly communication with the aim of
+    enabling Findable, Accessible, Interoperable and Reusable (FAIR) data, research
+    reproducibility and aggregation of research results.
+  country: UK
+  email: alejandra.gonzalez-beltran@stfc.ac.uk
+  expertise:
+  - Software Engineering
+  - Data Management
+  - Data and Software Publication and Citation
+  - Semantic Web / Linked Data
+  - Research Reproducbility
+  first-name: Alejandra
+  last-name: Gonzalez-Beltran
+  orcid: 0000-0003-3499-8262
+  twitter: alegonbel
+  website: https://agbeltran.github.io/
 aidanbudd:
   bio: 'Aidan has worked in life science research in both the wet lab, and as a bioinformatician.
 
@@ -650,27 +628,6 @@ aidanbudd:
   pronouns: he/him
   twitter: AidanBudd
   website: https://about.me/aidan.budd
-agbeltran:
-  bio: 'Alejandra is the Software Engineering Group Leader at the Science and Technology Facilities Council (STFC). 
-    STFC is part of UK Research and Innovation. Her focus is around software management, which includes supporting 
-    the software developmnt process, and data management projects, which include the development of bespoke 
-    software systems to manage the experimental data produced by the large scale scientific facilities at STFC. Before joining
-    STFC she was a Research Lecturer at the University of Oxford. Her research interests are around developing models, methods, 
-    and software tools for data science and innovative scholarly communication with the aim of enabling Findable, Accessible, 
-    Interoperable and Reusable (FAIR) data, research reproducibility and aggregation of research results.'
-  country: UK
-  email: alejandra.gonzalez-beltran@stfc.ac.uk
-  expertise:
-  - Software Engineering
-  - Data Management
-  - Data and Software Publication and Citation
-  - Semantic Web / Linked Data 
-  - Research Reproducbility
-  first-name: Alejandra
-  last-name: Gonzalez-Beltran
-  orcid: 0000-0003-3499-8262
-  twitter: alegonbel
-  website: https://agbeltran.github.io/
 ajstewartlang:
   bio: 'Andrew is an experimental psychologist and data scientist interested in open
     and reproducible research - he coordinates the Manchester Open Research Working
@@ -700,14 +657,14 @@ ajstewartlang:
   twitter: ajstewart_lang
   website: https://ajstewartlang.netlify.app
 alexwlchan:
-  affiliation: Wellcome Trust
+  affiliation: Wellcome Collection
   country: UK
   email: alex@alexwlchan.net
   first-name: Alex
   last-name: Chan
-  pronouns: she/her/they/them
+  pronouns: they/she
   twitter: alexwlchan
-  website: https://alexwlchan.net/
+  website: https://alexwlchan.net
 anayan321:
   affiliation: Mahidol University
   country: Thailand
@@ -750,40 +707,25 @@ anelda:
   twitter: aneldavdw
   website: http://www.talarify.co.za
 anenadic:
-  bio: 'Over the past 5 years committed to ongoing improvement of research software
-    practice through training and community engagement work
-
-    in UK''s Software Sustainability Institute and ELIXIR EU Life Sciences Infrastructure
-    Project. Driving the training trends forward by
-
-    helping communities roll out new training strategies and curricula for research
-    in individual domains. Maintained UK''s pivotal role
-
-    within the international Carpentries community delivering Software, Data, Library
-    and HPC Carpentry training, drove key strategic decisions
-
-    and handled international collaborations and outreach with training communities.
-    Organised CarpentryConnect Manchester 2019 for over 70
-
-    attendees from the Carpentry and other training communities. Carpentries instructor
-    (since 2014) and instructor trainer (since 2017).
-
-    '
-  country: UK
+  affiliation: University of Manchester
+  bio: 'Software Sustainability Institute''s training lead. Over the past 5 years
+    committed to ongoing improvement of research software practice through training
+    and community engagement work. Driving the trends in training for researchers
+    and scientists in computational and data analysis skills forward and helping develop
+    new training curricula. '
+  city: Manchester
+  country: United Kingdom
   email: a.nenadic@manchester.ac.uk
   expertise:
-  - Teaching pedagogy and instructor training
-  - Programming
-  - GitHub, Version control
-  - Website and Frameworks
-  - Carpentry community
-  - Event hosting and organisation.
+  - Open and reproducible research best practices
+  - Training and teaching tech to researchers
+  - 'Pedagogical approaches to instructor training and curricula development '
   first-name: Aleksandra
   last-name: Nenadic
   orcid: 0000-0002-2269-3894
-  pronouns: she/her
+  pronouns: she/her/hers
   twitter: aleks_nenadic
-  website: https://www.software.ac.uk/about/staff/person/aleksandra-nenadic
+  website: https://anenadic.github.io/professional-cv/
 anita-broellochs:
   affiliation: Protocols.io
   bio: "Anita Br\xF6llochs is the Head of Outreach at protocols.io. She studied Life\
@@ -907,7 +849,7 @@ anproulx:
   twitter: AndreanneProulx
 babasaraki:
   affiliation: Universiti Putra Malaysia
-  country: Malaysia 
+  country: Malaysia
   email: babasaraki@yahoo.co.uk
   first-name: Umar
   last-name: Ahmad
@@ -1035,40 +977,31 @@ bruno-soares:
   twitter: Bruno_E_Soares
   website: https://sites.google.com/view/bruno-eleres-soares
 burkemlou:
-  bio: 'Melissa is a Scientific Training Officer within the Training team at EMBL-EBI.
-    She has a PhD in
-
-    Molecular Parasitology. She has also worked as a Scientific Curator for ArrayExpress/Expression
-    Atlas
-
-    at the EMBL-EBI and as a postdoctoral researcher specialising in the functional
-    genomics of infectious
-
-    diseases. Some of the open-science related projects that she has been involved
-    in include applying FAIR
-
-    principles to training materials and showing researchers how they can get the
-    most out of their data by
-
-    teaching best practice in data management and the FAIR principles.
-
-    '
+  affiliation: Australian BioCommons
+  bio: Melissa is the Training and Communications Officer with Australian BioCommons.
+    She previously worked at EMBL-EBI and has extensive experience in developing,
+    organising, delivering and running face-to-face and online workshops and webinars.
+    She has a PhD in Molecular Parasitology and has worked as a Scientific Curator
+    through which first became interested in open science practices. Some of the open-science
+    related projects that she has been involved in include applying FAIR principles
+    to training materials and showing researchers how they can get the most out of
+    their data by teaching best practice in data management and the FAIR principles.
+  city: Brisbane
   country: Australia
   email: mlouburke@gmail.com
   expertise:
   - Training
-  - Functional genomics
-  - Data management basics
-  - E-learning
-  - Infectious diseases
-  - Molecular biology
+  - FAIR training materials
   - Bioinformatics
+  - Life Science
+  - eLearning
+  - Webinar and workshop development
+  - Functional genomics
   - Parasitology
-  - Microbiology
-  - Host-pathogen interactions
   first-name: Melissa
   last-name: Burke
-  pronouns: she/her
+  orcid: 0000-0002-5571-8664
+  pronouns: She/Her
   twitter: burkemlou
 cassgvp:
   affiliation: University of Oxford
@@ -1207,6 +1140,14 @@ dylan-bastiaans:
   first-name: Dylan
   github: false
   last-name: Bastiaans
+ekeluv:
+  affiliation: Medical biosciences UWC
+  country: South Africa
+  email: nwanyiomadiuko@gmail.com
+  first-name: Ekeoma
+  last-name: Festus
+  pronouns: they/them
+  twitter: ekeluv
 elsasci:
   affiliation: eLife
   country: UK
@@ -1250,57 +1191,42 @@ ewuramaminka:
   pronouns: she/her
   twitter: eminka_da
 fpsom:
-  bio: 'Fotis is an assistant research professor at the Institute of Applied Biosciences
-    (INAB) at the Centre for Research and Technology
-
-    Hellas (CERTH), with a primary focus on bioinformatics workflows and computational
-    analysis of large bio-datasets using machine learning.
-
-    He is trying to be an advocate of Open Science through my activities, both in
-    the context of e-infrastructures (such as ELIXIR) as well
-
-    as within the communities I am a part of (such as RDA). Additionally, he is trying
-    to create a positive effect in the research culture within
-
-    his country, both through increasing awareness of Open Science via training events,
-    as well as by engaging with similarly-minded people
-
-    (the nascent Carpentries community in Greece being an excellent example of this).
-
-    '
+  affiliation: Institute of Applied Biosciences, Centre for Research and Technology
+    Hellas
+  bio: A researcher, doing a little bit of bioinformatics, a dash of machine learning,
+    and a lot of Open Science.
+  city: Thessaloniki
   country: Greece
-  email: fpsom@certh.gr
+  email: fopsom@gmail.com
   expertise:
-  - Open Software
-  - Software Management
-  - Reproducible workflows
-  - E-Infrastructures (ELIXIR, EOSC)
-  - RDA
+  - Bioinformatics
   - Machine Learning
-  - Algorithm design and implementation
-  - Bioinformatics (NGS data analysis, Data Integration)
+  - Training
+  - Open Science
   first-name: Fotis
   last-name: Psomopoulos
   orcid: 0000-0002-0222-4273
-  pronouns: he/him
+  pronouns: He/him
   twitter: fopsom
   website: https://fpsom.github.io/
 gedankenstuecke:
-  bio: 'Research Fellow at the Center for Research & Interdisciplinarity in Paris.
-    Co-Founder of openSNP,
-
-    Director of Research at Open Humans.
-
-    Does all things community science and loves open(science|culture|.*)
-
-    '
+  affiliation: Center for Research & Interdisciplinarity
+  bio: Bastian is a long-term research fellow at the Center for Research & Interdisciplinarity
+    in Paris, where he studies how bottom-up communities in citizen science can peer-produce
+    knowledge. He's also the Director of Research for the Open Humans Foundation,
+    an online platform & community around empowering individuals to learn from their
+    personal data. He started his academic career in evolutionary biology & genomics
+    and has a PhD in Bioinformatics.
+  city: Paris
   country: France
   email: bgreshake@googlemail.com
   expertise:
-  - Citizen science
-  - Open source
-  - Genomics
-  - Bioinformatics
+  - bioinformatics
+  - citizen science
+  - web development
+  - python
+  - personal data
+  - community management
   first-name: Bastian
   last-name: Greshake Tzovaras
   orcid: 0000-0002-9925-9623
@@ -1401,58 +1327,51 @@ homo-sapiens34:
   last-name: Chervontseva
   pronouns: she/her
 hrhotz:
-  affiliation: Friedrich Miescher Institute
-  bio: "Hans-Rudolf is a Molecular Biologist turned Bioinformatician who is working\
-    \ in the Computational\nBiology facility at the Friedrich Miescher Institute in\
-    \ Basel Switzerland. Before, he was leading\n the Bioinformatics Core group at\
-    \ the Sanger Institute in Cambridge UK.\n"
+  affiliation: Friedrich Miescher Institute for Biomedical Research
+  bio: Hans-Rudolf is a Molecular Biologist turned Bioinformatician who is working
+    in the Computational Biology facility at the Friedrich Miescher Institute in Basel
+    Switzerland. Before, he was leading the Bioinformatics Core group at the Sanger
+    Institute in Cambridge UK.
+  city: Basel
   country: Switzerland
   email: hrhotz@googlemail.com
   expertise:
   - Galaxy
   - Bioconductor
-  - Perl, Python
   - PostgreSQL
   - Bioinformatics
-  - Next Generation Sequencing
+  - 'Next Generation Sequencing '
   first-name: Hans-Rudolf
-  last-name: Hotz
-  pronouns: he/him
+  last-name: ' Hotz'
+  orcid: 0000-0002-2799-424X
   twitter: hrhotz
-  website: https://www.fmi.ch
+  website: https://www.fmi.ch/
+ibrahssali1:
+  affiliation: Muni University
+  country: Uganda
+  email: i.ssali@muni.ac.ug
+  first-name: Ibrahim
+  last-name: Ssali
+  pronouns: he/him
+  twitter: ibrahssali1
 ivotron:
   affiliation: UC Santa Cruz
-  bio: 'Ivo is a Research Scientist at UC Santa Cruz, Incubator Fellow at the UC Santa
-    Cruz
-
+  bio: Research Scientist at UC Santa Cruz, Incubator Fellow at the UC Santa Cruz
     Center for Research on Open Source Software (CROSS); Adjunct Professor at University
-
-    of Sonora. Interested in large-scale distributed data management systems, applied
-
-    aspects of data science, and reproducibility. His 2019 PhD dissertation focused
-    on
-
-    the practical aspects in the reproducible evaluation of systems research, work
-    for
-
-    which he was awarded the 2018 Better Scientific Software Fellowship. He is currently
-
-    working on Popper, as part of the CROSS Incubator Program.
-
-    '
-  country: USA
+    of Sonora (Mexico). Interested in large-scale distributed data management systems,
+    applied aspects of data science, and reproducibility. I am currently working on
+    Popper (https://getpopper.io), as part of the CROSS Incubator Program.
+  city: Hermosillo
+  country: Mexico
   email: ivo.jimenez@gmail.com
   expertise:
-  - Reproducibility
-  - Open science
-  - Open data
-  - Working open
-  - Automation
-  - Large-scale data management
-  - General aspects of applying ML, Kubernetes, DevOps in scientific projects
-  - Genomics, and bioinformatics in general
+  - Computer Science
+  - Open infrastructure for science
+  - DevOps for science
+  - Best software delivery practices applied in scientific contexts
   first-name: Ivo
   last-name: Jimenez
+  orcid: 0000-0002-2222-1985
   pronouns: he/him
   twitter: ivotron
   website: https://ivotron.me
@@ -1553,24 +1472,35 @@ joelostblom:
   orcid: 0000-0003-0051-3239
   pronouns: he/him
   website: https://joelostblom.com
+jonny-heath:
+  bio: 'I am a poet and performance artist. One of my main practices is ''empathic
+    literature'', in which a conversation with an individual leads to my creating
+    a unique piece of poetic writing for them, with the aim of reflecting their perspective
+    back to them in a novel way, as a tool for new insights. I am a graduate of philosophy
+    specialising in scientific representation. '
+  city: Brighton
+  country: United Kingdom
+  email: jonnywriteswords@gmail.com
+  expertise:
+  - Poetry
+  - Philosophy of scientific representation
+  first-name: Jonny
+  github: false
+  last-name: Heath
+  pronouns: He/him
+  website: instagram.com/jonnywriteswords/
 joshsimmons:
   country: USA
   first-name: Josh
   last-name: Simmons
   twitter: joshsimmons
 joyceykao:
-  country: Switzerland 
+  country: Switzerland
   email: joyce.kao@biol.ethz.ch
   first-name: Joyce
   last-name: Kao
   pronouns: she/her
   twitter: joyceykao
-katoss:
-  country: France
-  email: katharina.kloppenborg@gmail.com
-  first-name: Katharina
-  last-name: Kloppenborg
-  pronouns: she/her
 karegapauline:
   country: Kenya
   email: karegapaul@gmail.com
@@ -1618,6 +1548,31 @@ karinlag:
   last-name: Lagesen
   pronouns: she/her
   twitter: karinlag
+karvovskaya:
+  affiliation: VU Amsterdam
+  bio: I am a theoretical linguist turned into an RDM expert and a community manager.
+    In my work I try to bring together the support personnel at my university and
+    the researchers who are interested in data management, data sharing and Open Science.
+    I would be thrilled to use my newly acquired skills to help linguistic projects.
+  city: Amsterdam
+  country: Netherlands
+  email: e.karvovskaya@vu.nl
+  expertise:
+  - linguistics
+  - fieldwork
+  - research data management (RDM)
+  - community management
+  first-name: Lena
+  last-name: Karvovskaya
+  orcid: 000-0001-7777-5603
+  pronouns: she/her
+  twitter: LangData
+katoss:
+  country: France
+  email: katharina.kloppenborg@gmail.com
+  first-name: Katharina
+  last-name: Kloppenborg
+  pronouns: she/her
 katrinleinweber:
   bio: 'Studied biochemistry, arctic ecology & geology, PhDed in diatom biofilms.
 
@@ -1961,18 +1916,12 @@ martenson:
   last-name: "\u010Cech"
   pronouns: he/him
 martinagvilas:
-  bio: 'Martina is currently working at the Max-Planck-Institute AE, doing cognitive
-    neuroscience research using computational
-
-    modeling techniques. She is an open-science advocate who enjoys programming and
-    contributing to open-source projects
-
-    and communities. She is currently mentoring people from underrepresented groups
-    in technology on their first open-source
-
-    contribution, and provide infrastructure support for The Turing Way project.
-
-    '
+  affiliation: Max-Planck-Institute AE
+  bio: Martina is currently working at the Max-Planck-Institute AE, doing cognitive
+    neuroscience research using computational modeling techniques. She is an open-science
+    advocate who enjoys programming and contributing to open-source projects and communities.
+    She provides infrastructure support for The Turing Way project as a core contributor.
+  city: Frankfurt am Main
   country: Germany
   email: martinagonzalezvilas@gmail.com
   expertise:
@@ -1986,9 +1935,10 @@ martinagvilas:
   - Neuroscience
   first-name: Martina
   last-name: Vilas
-  pronouns: she/her
+  orcid: https://orcid.org/0000-0002-1097-8534
+  pronouns: She/her
   twitter: martinagvilas
-  website: https://www.martinagvilas.github.io
+  website: https://martinagvilas.github.io/
 matuskalas:
   affiliation: University of Bergen
   country: Norway
@@ -2189,13 +2139,6 @@ nerantzis:
   pronouns: he/him
   twitter: nerantzis
   website: https://4myfiles.wordpress.com
-NehaMoopen:
-  country: The Netherlands
-  email: neha.moopen@gmail.com
-  first-name: Neha
-  last-name: Moopen
-  pronouns: she/her
-  twitter: NehaMoopen
 npscience:
   bio: 'Naomi is motivated by people who are empowered to participate in knowledge
     and discovery for improvement of the
@@ -2295,7 +2238,7 @@ paulowoicho:
   first-name: Paul
   last-name: Owoicho
   pronouns: he/him
-  twitter: N/A  
+  twitter: N/A
 paulvill:
   bio: 'Paul is group Leader in Machine Leader and Developmental Biology at the Turing
     Center for
@@ -2427,26 +2370,23 @@ pvanheus:
   pronouns: he/him
   twitter: pvanheus
 rainsworth:
-  bio: 'Rachael is a Research Software Community Manager for the Software
-
-    Sustainability Institute and Open Science advocate at the University of Manchester.
-
-    She is passionate about openness, transparency, reproducibility,
-
-    wellbeing and inclusion in research. She was a project lead in Round 4 and Mentor
-
-    and Cohort Host in Round 5 of Mozilla Open Leaders, and organises a
-
-    women in data meetup group in Manchester called HER+Data MCR.
-
-    '
-  country: UK
-  email: rainswor@gmail.com
+  affiliation: Software Sustainability Institute
+  bio: Rachael is the Research Software Community Manager for the Software Sustainability
+    Institute and Open Research advocate at the University of Manchester. She is passionate
+    about openness, transparency, reproducibility, wellbeing and inclusion in research.
+    She was a project lead in Round 4 and Mentor and Cohort Host in Round 5 of Mozilla
+    Open Leaders, and organises a women in data meetup group in Manchester called
+    HER+Data MCR.
+  city: Manchester
+  country: United Kingdom
+  email: rachael.ainsworth@manchester.ac.uk
   expertise:
+  - Astrophysics
   - Open Science/Research
   - Reproducibility
-  - Organising events
-  - Community building
+  - Community Building
+  - Organising Events
+  - Virtual Events
   - GitHub
   first-name: Rachael
   last-name: Ainsworth
@@ -2709,34 +2649,27 @@ sudarshangc:
   pronouns: he/him
   twitter: Sudarsh07847591
 thessaly:
-  bio: 'Julieta is a PhD candidate on social studies of science, with a background
-    in environmental science.
-
-    Her research asks how open science hardware can contribute to democratize science
-    and tech in the ''global south'' and what it means in each context.
-
-    She co-funded ''Open Hardware Makers'', a mentorship program like OpenLifeSci
-    but for Hardware; she''s part of the Global Open Science Hardware (GOSH)
-
-    community and loves tinkering with linked data for community science.
-
-    '
+  affiliation: CENIT-UNSAM
+  bio: "Julieta is a PhD candidate on social studies of science & technology, with\
+    \ a background in environmental science. Her research asks how open science hardware\
+    \ can contribute to democratize science and tech in the \u2018global south\u2019\
+    \ and what it means in each context. She co-founded \u2018Open Hardware Makers\u2019\
+    , a mentorship program like OpenLifeSci but for Hardware; she\u2019s part of the\
+    \ Global Open Science Hardware (GOSH) community and loves tinkering with hardware\
+    \ and data for community science."
+  city: Buenos Aires
   country: Argentina
   email: jarancio@unsam.edu.ar
   expertise:
-  - Hardware prototypes
-  - Contributing and using open science hardware
-  - Inclusive citizen/community science projects
-  - Wikidata and other linked data tools
-  - Open science in Latin America
-  - Science and knowledge democratization
-  - Open science hardware inside/outside the lab
+  - open science hardware
+  - citizen/community science projects
+  - linked data for community science
+  - Science and tech democratization
   first-name: Julieta
   last-name: Arancio
-  orcid: 0000-0002-8624-4182
-  pronouns: she/her
+  pronouns: she-her
   twitter: cassandreces
-  website: https://julieta.aranc.io/
+  website: julieta.aranc.io
 tlaguna:
   country: Spain
   email: teresa.laguna@imdea.org
@@ -2767,30 +2700,21 @@ tnabtaf:
   twitter: tnabtaf
   website: https://galaxyproject.org/people/dave-clements/
 tobyhodges:
-  bio: 'Toby is the Curriculum Community Developer at The Carpentries, a community
-    of practice
-
-    building global capacity in essential data and computational skills for conducting
-    efficient,
-
-    open, and reproducible research. Before that, he was a community manager for EMBL
-    Bio-IT, a
-
-    community of bioinformaticians/computational biologists at the European Molecular
-    Biology Laboratory.
-
-    '
+  affiliation: The Carpentries
+  bio: Toby is the Curriculum Community Developer at The Carpentries, a community
+    of practice building global capacity in essential data and computational skills
+    for conducting efficient, open, and reproducible research. Before that, he was
+    a CSCCE CEFP2019 Fellow and community manager for EMBL Bio-IT, a community of
+    bioinformaticians/computational biologists at the European Molecular Biology Laboratory.
+  city: Heidelberg
   country: Germany
   email: tbyhdgs@gmail.com
   expertise:
-  - Designing training material
+  - Designing and developing training material
   - Collaborating with Git & GitHub/GitLab
-  - Publishing web content, either with GitHub/GitLab Pages or Wordpress
-  - Community engagement
+  - Publishing web content with Wordpress or Jekyll and GitHub/GitLab Pages
+  - Scientific community engagement
   - Teaching and organising workshops
-  - Resources for learning bioinformatics
-  - Supporting computational biology across a wide range of fields
-  - Taxonomic classification of high-throughput DNA/RNA sequencing data
   first-name: Toby
   last-name: Hodges
   orcid: 0000-0003-1766-456X
@@ -2799,22 +2723,14 @@ tobyhodges:
   website: https://tbyhdgs.info
 tsonika:
   affiliation: Monash University Melbourne
-  bio: 'Sonika has a Ph.D. in Bioinformatics and over 15 y of work experience in academia
-    & industry. She is
-
-    currently Bioinformatics senior lecturer and research group head at Monash University
-    Melbourne, Australia.
-
-    Her expertise is in developing novel Bioinformatics and machine learning methods
-    and applying them to solve
-
-    biological research questions. In the past, she has worked in collaboration with
-    the Australian bioinformatics
-
-    network and EMBL-EBI on developing and delivering bioinformatics workshops for
-    biologists and bioinformaticians.
-
-    '
+  bio: Sonika has a Ph.D. in Bioinformatics and over 15 y of work experience in academia
+    & industry. She is currently Bioinformatics senior lecturer and research group
+    head at Monash University Melbourne, Australia. Her expertise is in developing
+    novel Bioinformatics and machine learning methods and applying them to solve biological
+    research questions. In the past, she has worked in collaboration with the Australian
+    bioinformatics network and EMBL-EBI on developing and delivering bioinformatics
+    workshops for biologists and bioinformaticians.
+  city: Melbourne
   country: Australia
   email: sonika.tyagi@monash.edu
   expertise:

--- a/_data/people.yaml
+++ b/_data/people.yaml
@@ -22,569 +22,6 @@
 #
 # Mandatory: first-name, last-name, country
 ---
-ariellebl:
-  affiliation: The Alan Turing Institute
-  bio: 'Arielle has spent her career to date working in research-adjacent fields,
-    starting with a stint at open access publisher PLOS, where she learnt the importance
-    (and challenges) of open science, code, and data. Currently the Research Project
-    Manager on the Tools, Practices & Systems programme at The Alan Turing Institute,
-    she was a CSCCE Community Engagement Fellow in 2019 and continues to be actively
-    involved in the community. She is a contributor to the Turing Way project. '
-  city: London
-  country: United Kingdom
-  email: ariellebennettlovell@gmail.com
-  expertise:
-  - Road mapping and strategy planning
-  - Community consultation
-  - Culture change
-  - Code of conducts
-  - Community goals
-  - Drug discovery
-  - Computational biology
-  - Neuroscience.
-  first-name: Arielle
-  last-name: Bennett
-  pronouns: she/her
-  twitter: biotechchat
-Banshee1221:
-  affiliation: CHPC Ace Lab
-  country: South Africa
-  email: eugene@debeste.co.za
-  first-name: Eugene
-  last-name: de Beste
-  twitter: edebeste
-BhuvanaMeenakshiK:
-  bio: 'Bhuvana is a gender gap and Mixed Reality researcher trying to unfold the
-    ethics of technology in a more humane way.
-
-    Her expertise are in Gender gap, Mozilla technologies and Wikimedia projects.
-
-    '
-  country: India
-  email: bhuvanameenakshi@gmail.com
-  expertise:
-  - Gender gap and bias
-  - Mozilla technologies
-  - Wikimedia projects
-  - Ethical technology praactices
-  first-name: Bhuvana
-  last-name: Meenakshi Koteeswaran
-  pronouns: she/her
-  twitter: bhuvanakotees1
-  website: https://www.linkedin.com/in/bhuvana-meenakshi-koteeswaran-a67b58103/
-Boi-KONE:
-  country: Mali
-  email: koneb.bk@gmail.com
-  first-name: "Bo\xEF"
-  last-name: Kone
-  twitter: boi_kone
-BrainonSilicon:
-  affiliation: University of Leeds
-  country: New Zealand
-  email: sophiasmbatchelor@icloud.com
-  first-name: Sophia
-  last-name: Batchelor
-  pronouns: she/her
-  twitter: brainonsilicon
-ChiaraBertipaglia:
-  affiliation: "Columbia University\u2019s Zuckerman Institute"
-  country: USA
-  expertise:
-  - OLS-1 project lead
-  - Neuroscience
-  first-name: Chiara
-  last-name: Bertipaglia
-  pronouns: she/her
-  twitter: ChiaBertipaglia
-DavidBeavan:
-  affiliation: The Alan Turing Institute
-  country: UK
-  email: dbeavan@turing.ac.uk
-  first-name: David
-  last-name: Beavan
-  twitter: DavidBeavan
-Delphine-L:
-  affiliation: Penn State University
-  bio: 'Delphine am a post-doc at Penn State University and a member of Galaxy Project.
-    She works on developing analysis workflows
-
-    for bacterial genomics, mostly, but she also has project in other fields, like
-    functional annotation of SARS-2 Cov virus,
-
-    human methylation  analyses...
-
-    '
-  country: USA
-  expertise:
-  - Organization of open-source/collaborative projects
-  - Github
-  - Zenodo
-  - Publishing tools in Galaxy
-  - Writing documentation
-  - Construction of analysis workflow
-  - Handling data format
-  - Quality control
-  - Genomics analyses
-  - Statistical analyses
-  first-name: Delphine
-  last-name: Lariviere
-  pronouns: she/her
-  twitter: ddlariviere
-  website: https://observablehq.com/@delphine-l
-Demellina:
-  affiliation: F1000Research
-  bio: 'Demitra Ellina is the Editorial Community Manager at F1000Research. She is
-    a strong advocate of Open Research and engages with the research community to
-    raise awareness of the F1000Research publishing platforms. '
-  city: London
-  country: United Kingdom
-  email: demitra.ellina@f1000.com
-  expertise:
-  - open science/research
-  - open access
-  - open peer review
-  - preprints
-  first-name: Demitra
-  last-name: Ellina
-  pronouns: She/her
-  twitter: j_ellina
-EKaroune:
-  country: UK
-  email: ekaroune@googlemail.com
-  first-name: Emma
-  last-name: Karoune
-  pronouns: she/her
-  website: ekaroune
-EstherPlomp:
-  affiliation: Delft University of Technology - Faculty of Applied Sciences
-  bio: Esther works as a Data Steward at Delft University of Technology (Faculty of
-    Applied Sciences) in the Netherlands. As a Data Steward she supports researchers
-    with their data/code management and with sharing their research. Before this,
-    Esther did a PhD in bioanthropology, studying the isotopic composition of human
-    teeth to determine where they grew up.
-  city: The Hague
-  country: The Netherlands
-  email: e.plomp@tudelft.nl
-  expertise:
-  - Open protocols
-  - open data
-  - research data management
-  - FAIR
-  - archaeology
-  - bioanthropology
-  - isotopes
-  - 'osteology, '
-  first-name: Esther
-  last-name: Plomp
-  orcid: 0000-0003-3625-1357
-  pronouns: she/her/hers
-  twitter: PhDToothFAIRy
-EvaCHerbst:
-  country: Switzerland
-  email: eva.herbst@pim.uzh.ch
-  first-name: Eva
-  last-name: Herbst
-  pronouns: she/her
-  twitter: EvaCHerbst
-Fnyasimi:
-  affiliation: International Centre of Insect Physiology and Ecology (ICIPE)
-  bio: 'Festus is a bioinformatician interested in community outreach, open science
-    and networking.
-
-    He is actively engaged in training activities and he is the lead at the Bioinformatics
-    Hub of Kenya.
-
-    '
-  country: Kenya
-  expertise:
-  - OLS-1 project lead
-  - Bioinformatics
-  - Biomedical Research
-  first-name: Festus
-  last-name: Nyasimi
-  pronouns: he/him
-  twitter: Festus_nyasimi
-GanleyEmma:
-  affiliation: protocols.io
-  country: UK
-  email: emma@protocols.io
-  first-name: Emma
-  last-name: Ganley
-  twitter: GanleyEmma
-GeorgiaHCA:
-  country: UK
-  email: gaitkenhead@turing.ac.uk
-  first-name: Georgia
-  last-name: Aitkenhead
-  pronouns: she/her
-InquisitiveVi:
-  bio: 'Biomedical scientist and science communicator interested in
-
-    building effective outreach strategies for equitable access of research outputs.
-
-    '
-  country: Germany
-  email: vinodh.ilangovan@gmail.com
-  expertise:
-  - Community building
-  - Equity diversity and inclusion
-  - Circadian rhythms
-  - Behavioral Neuroscience
-  - Genetics
-  first-name: Vinodh
-  last-name: Ilangovan
-  orcid: 0000-0002-3445-5383
-  pronouns: he/him
-  twitter: I_Vinodh
-Ismael-KG:
-  affiliation: The Alan Turing Institute
-  country: UK
-  email: ikherroubi@turing.ac.uk
-  first-name: Ismael
-  last-name: Kherroubi Garcia
-  pronouns: he/his
-  twitter: ismaelkhergar
-JasonJWilliamsNY:
-  bio: 'Jason is a life scientist who spends most of his time working to help researchers
-    adopt
-
-    computational practices in research and education
-
-    '
-  country: USA
-  email: williams@cshl.edu
-  expertise:
-  - Education and training
-  - Life Science Education
-  - Management and leadership
-  - Bioinformatics
-  - Molecular biology
-  first-name: Jason
-  last-name: Williams
-  orcid: 0000-0003-3049-2010
-  pronouns: he/him
-  twitter: JasonWilliamsNY
-  website: https://lifescitrainers.org
-Karvovskaya:
-  affiliation: VU Amsterdam
-  bio: I am a linguist turned into a research data management specialist and community
-    manager at the VU Amsterdam library. I am interested in languages and would love
-    to support community-oriented projects in this area. I am also keen on getting
-    in touch with people from Russia and supporting projects for Russian audience.
-  city: Amsterdam
-  country: Netherlands
-  email: e.karvovskaya@vu.nl
-  expertise:
-  - theoretical linguistics
-  - fieldwork
-  - research data management
-  first-name: Lena
-  last-name: Karvovskaya
-  orcid: 0000-0001-7777-5603
-  pronouns: she/her
-  twitter: LangData
-KateSimpson:
-  country: UK
-  email: kate.simpson@imperial.ac.uk
-  first-name: Kate
-  last-name: Simpson
-  pronouns: she/her
-  twitter: Dr_KateSimpson
-Kevinxufs:
-  affiliation: Civil Service
-  country: UK
-  email: kevin.xu@faststream.civilservice.gov.uk
-  first-name: Kevin
-  last-name: Xu
-  twitter: kevinzhangxu
-Kiragu-Mwaura:
-  affiliation: Institute of Primate Research
-  country: Kenya
-  expertise:
-  - OLS-1 project lead
-  first-name: David
-  last-name: Kiragu Mwaura
-  pronouns: he/him
-  twitter: MwauraKiragu
-KirstieJane:
-  bio: 'Kirstie is a lead of the Tools, Practices and Systems research programme at
-    the Alan Turing Institute (London, UK) and senior research associate in the Department
-    of Psychiatry at the
-
-    University of Cambridge. Her work covers a broad range of interests and methods,
-    but the driving principle is to improve the lives of neurodivergent
-
-    people and people with mental health conditions. Dr Whitaker uses magnetic resonance
-    imaging to study child and adolescent brain development and
-
-    participatory citizen science to educate non-autistic people about how they can
-    better support autistic friends and colleagues. She is the lead developer
-
-    of The Turing Way, an openly developed educational resource to enable more reproducible
-    data science. Kirstie is a passionate advocate for making science
-
-    ''open for all'' by promoting equity and inclusion for people from diverse backgrounds,
-    and by changing the academic incentive structure to reward collaborative
-
-    working. She is the chair of the Turing Institute''s Ethics Advisory Group, a
-    Fulbright scholarship alumna and was a 2016/17 Mozilla Fellow for Science. Kirstie
-
-    was named, with her collaborator Petra Vertes, as a 2016 Global Thinker by Foreign
-    Policy magazine.
-
-    '
-  country: UK
-  email: kwhitaker@turing.ac.uk
-  expertise:
-  - Open research
-  - Reproducibility
-  - Community building
-  - Citizen science
-  - Equity and inclusion
-  - Human brain imaging (neuroscience)
-  first-name: Kirstie
-  last-name: Whitaker
-  orcid: 0000-0001-8498-4059
-  pronouns: she/her
-  twitter: kirstie_j
-  website: https://whitakerlab.github.io/
-KristinaRiemer:
-  affiliation: University of Arizona
-  country: USA
-  expertise:
-  - OLS-1 project lead
-  first-name: Kristina
-  last-name: Riemer
-  pronouns: she/her
-  twitter: KristinaRiemer
-LandiMi2:
-  affiliation: International Livestock Research Institute
-  country: Kenya
-  expertise:
-  - OLS-1 project lead
-  first-name: Michael
-  last-name: Kofia Landi
-  pronouns: he/him
-  twitter: CofiaLandy
-LauraCarter:
-  affiliation: University of Essex
-  country: UK
-  email: laura.carter@essex.ac.uk
-  first-name: Laura
-  last-name: Carter
-  pronouns: she/her
-  twitter: LauraC_rter
-Lilian9:
-  affiliation: Information Training and Outreach Centre for Africa
-  country: Kenya
-  expertise:
-  - OLS-1 project lead
-  first-name: Lilian
-  last-name: Juma
-  pronouns: she/her
-MagicMilly:
-  affiliation: University of Arizona
-  country: USA
-  expertise:
-  - OLS-1 project lead
-  first-name: Emily
-  last-name: Cain
-  pronouns: she/her
-  twitter: magic_milly
-Megmugure:
-  affiliation: International Livestock Research Institute
-  country: Kenya
-  expertise:
-  - OLS-1 project lead
-  first-name: Margaret
-  last-name: Wanjiku
-  pronouns: she/her
-  twitter: meg_wanjiku
-MorphoFun:
-  affiliation: The George Washington University
-  country: USA
-  expertise:
-  - OLS-1 project lead
-  first-name: Sandy
-  last-name: Kawano
-  pronouns: she/her
-  twitter: MorphoFun
-MuhammetCelik:
-  country: Turkey
-  email: a.muhammetcelik@gmail.com
-  first-name: Muhammet
-  last-name: Celik
-  pronouns: he/him
-NaraLB:
-  affiliation: "Museu Paraense Em\xEDlio Goeldi"
-  country: Brazil
-  expertise:
-  - OLS-1 project lead
-  first-name: Naraiana
-  last-name: Loureiro Benone
-  pronouns: she/her
-  twitter: nlbenone
-NehaMoopen:
-  country: The Netherlands
-  email: neha.moopen@gmail.com
-  first-name: Neha
-  last-name: Moopen
-  pronouns: she/her
-  twitter: NehaMoopen
-PivG:
-  affiliation: EMBL-EBI (European Bioinformatics Institute)
-  bio: I am a scientific training officer at the European Bioinformatics Institute
-    (EMBL-EBI) where I mainly coordinate and support training in Latin America via
-    the CABANA project (http://cabana.online/). My background lies in structural biology
-    and biomedical sciences, and I am passionate about science communication, equity
-    and inclusion.
-  city: Cambridge
-  country: United Kingdom
-  email: piv@ebi.ac.uk
-  expertise:
-  - Education and training
-  - course design and delivery
-  - science communication
-  first-name: Piv
-  last-name: Gopalasingam
-  orcid: 0000-0001-5709-3373
-  pronouns: he/him
-  twitter: cascade21
-SamGuay:
-  affiliation: "Universit\xE9 de Montr\xE9al"
-  bio: "While completing his PhD in cognitive neuroscience at the Universit\xE9 de\
-    \ Montr\xE9al,\nSamuel organizes training events to equip his peers to make science\
-    \ more robust,\naccessible, and inclusive to all. He is the cofounder of Open\
-    \ Science UMontreal,\nan initiative that aims to facilitate the transition to\
-    \ a more open and transparent\nway of doing science.\n"
-  country: Canada
-  email: samuel.guay@umontreal.ca
-  expertise:
-  - OLS-1 project lead
-  - Open Science
-  - Building website with Hugo
-  - Reproducible reports
-  - Clinical neuroscience
-  first-name: Samuel
-  last-name: Guay
-  pronouns: he/him
-  twitter: SamGuay_
-  website: https://openscience.ca
-SantosRAC:
-  bio: 'Bioinformatician working on genomics and transcriptomics of ascomycete and
-    basidiomycete fungi. Interested in
-
-    education, teaching programming skills to bioscientists, and in open science.
-
-    '
-  country: Brazil
-  email: renatoacsantos@gmail.com
-  expertise:
-  - Bioinformatics
-  - Introduction to programming skills (Python or Perl)
-  - Fungal Biology
-  first-name: "Renato Augusto Corr\xEAa"
-  last-name: dos Santos
-  pronouns: he/him
-  twitter: CorreaSantosRA
-SebastianEggert:
-  country: Germany
-  email: se.eggert@outlook.com
-  first-name: Sebastian
-  last-name: Eggert
-  pronouns: he/his
-  twitter: se_eggert
-Sithyphus:
-  affiliation: University of Arizona
-  country: USA
-  expertise:
-  - OLS-1 project lead
-  first-name: Jorge
-  last-name: Barrios
-  pronouns: he/him
-TKlingstrom:
-  affiliation: Swedish University of Agricultural Sciences
-  bio: 'Biotechnician turned bioinformatician turned animal scientist trying to standardise
-    workflows using Galaxy
-
-    '
-  country: Sweden
-  email: tomas.klingstrom@slu.se
-  expertise:
-  - Bioinformatics
-  - Figuring out the social aspects of collaborations
-  - Thinking about stakeholder needs
-  - Bioinformatics
-  - Biobanking
-  - Ethics
-  - Cattle genomics
-  first-name: Tomas
-  last-name: "Klingstr\xF6m"
-  pronouns: he/him
-  website: https://www.slu.se/en/ew-cv/tomas-klingstrom/
-Tai-Rocha:
-  country: Brazil
-  email: taina013@gmail.com
-  first-name: "Tain\xE1"
-  last-name: Rocha
-  twitter: Tai_Rocha_
-VickyNembaware:
-  bio: 'Vicky has a PhD in Bioinformatics and an MPhil in Monitoring and Evaluation.
-
-    Her research experience (qualitative and quantitative) spans Genomics and Public
-    Health.
-
-    She is currently a Project Coordinator for the Sickle Africa Data Coordinating
-    Center at
-
-    the University of Cape Town. She also coordinates several other groups and projects
-
-    including the African Genomic Medicine Training Initiative (AGMT),
-
-    Sickle Cell Disease Ontology Working Group (SCDO) and mGenAfrica.
-
-    She is the current secretary of the African Society of Human Genetics (AfSHG).
-
-    She is passionate about building research capacity, mentoring
-
-    young investigators and translational research.
-
-    '
-  country: South Africa
-  email: vnembaware@gmail.com
-  expertise:
-  - Bioinformatics
-  - Genomics and Genomic Medicine
-  - Training
-  - Public Engagement
-  - Sickle Cell Disease
-  - Bioinformatics
-  first-name: Vicky
-  github: false
-  last-name: Nembaware
-  orcid: 0000-0001-7966-4042
-  pronouns: she/her
-  twitter: VickyNembaware
-WasifaRahman:
-  country: Bangladesh
-  email: shreyoshirahman@gmail.com
-  first-name: Wasifa
-  last-name: Rahman
-Zebetus:
-  bio: 'A mentor for many previous waves of open leaders, who is currently studying
-    for their PhD at UCL.
-
-    '
-  country: UK
-  email: haz.zebetus@gmail.com
-  expertise:
-  - Community Organisation
-  - Event organising
-  - Communication
-  - Physics (Quantum Nanowires)
-  first-name: Harry
-  last-name: Smith
-  twitter: Zebetus
 aath0:
   bio: 'Athina is a neuroscientist, with a background in electrical and computer engineering.
 
@@ -921,6 +358,13 @@ bakary-n'tji diallo:
   first-name: Bakary
   github: false
   last-name: N'tji Diallo
+banshee1221:
+  affiliation: CHPC Ace Lab
+  country: South Africa
+  email: eugene@debeste.co.za
+  first-name: Eugene
+  last-name: de Beste
+  twitter: edebeste
 bduckles:
   country: USA
   email: beth@duckles.com
@@ -992,6 +436,25 @@ bgruening:
   pronouns: he/him
   twitter: bjoerngruening
   website: https://github.com/bgruening/
+bhuvanameenakshik:
+  bio: 'Bhuvana is a gender gap and Mixed Reality researcher trying to unfold the
+    ethics of technology in a more humane way.
+
+    Her expertise are in Gender gap, Mozilla technologies and Wikimedia projects.
+
+    '
+  country: India
+  email: bhuvanameenakshi@gmail.com
+  expertise:
+  - Gender gap and bias
+  - Mozilla technologies
+  - Wikimedia projects
+  - Ethical technology praactices
+  first-name: Bhuvana
+  last-name: Meenakshi Koteeswaran
+  pronouns: she/her
+  twitter: bhuvanakotees1
+  website: https://www.linkedin.com/in/bhuvana-meenakshi-koteeswaran-a67b58103/
 billbrod:
   affiliation: New York University
   country: USA
@@ -1001,6 +464,12 @@ billbrod:
   last-name: (William) Broderick
   pronouns: he/him
   twitter: wfbroderick
+boi-kone:
+  country: Mali
+  email: koneb.bk@gmail.com
+  first-name: "Bo\xEF"
+  last-name: Kone
+  twitter: boi_kone
 bonetcarne:
   affiliation: BCNatal Fetal Medicine Research Center
   country: Spain
@@ -1010,6 +479,14 @@ bonetcarne:
   last-name: Bonet-Carne
   pronouns: she/her
   twitter: bonetcarne
+brainonsilicon:
+  affiliation: University of Leeds
+  country: New Zealand
+  email: sophiasmbatchelor@icloud.com
+  first-name: Sophia
+  last-name: Batchelor
+  pronouns: she/her
+  twitter: brainonsilicon
 bruno-soares:
   affiliation: Universidade Federal do Rio de Janeiro
   bio: Bruno is a Brazilian ecologist working on a more collaborative and open science.
@@ -1088,6 +565,16 @@ cassgvp:
   last-name: Gould van Praag
   pronouns: she/her
   twitter: cassgvp
+chiarabertipaglia:
+  affiliation: "Columbia University\u2019s Zuckerman Institute"
+  country: USA
+  expertise:
+  - OLS-1 project lead
+  - Neuroscience
+  first-name: Chiara
+  last-name: Bertipaglia
+  pronouns: she/her
+  twitter: ChiaBertipaglia
 christina-ambrosi:
   affiliation: University of Zurich
   country: Switzerland
@@ -1166,6 +653,13 @@ dasaderi:
   pronouns: she/her
   twitter: Neurosarda
   website: https://v2.prereview.org
+davidbeavan:
+  affiliation: The Alan Turing Institute
+  country: UK
+  email: dbeavan@turing.ac.uk
+  first-name: David
+  last-name: Beavan
+  twitter: DavidBeavan
 davidviryachen:
   affiliation: Osaka University
   country: Japan
@@ -1175,6 +669,34 @@ davidviryachen:
   last-name: Chentanaman
   pronouns: he/him
   twitter: davidchenn
+delphine-l:
+  affiliation: Penn State University
+  bio: 'Delphine am a post-doc at Penn State University and a member of Galaxy Project.
+    She works on developing analysis workflows
+
+    for bacterial genomics, mostly, but she also has project in other fields, like
+    functional annotation of SARS-2 Cov virus,
+
+    human methylation  analyses...
+
+    '
+  country: USA
+  expertise:
+  - Organization of open-source/collaborative projects
+  - Github
+  - Zenodo
+  - Publishing tools in Galaxy
+  - Writing documentation
+  - Construction of analysis workflow
+  - Handling data format
+  - Quality control
+  - Genomics analyses
+  - Statistical analyses
+  first-name: Delphine
+  last-name: Lariviere
+  pronouns: she/her
+  twitter: ddlariviere
+  website: https://observablehq.com/@delphine-l
 demellina:
   affiliation: F1000Research
   bio: 'Demitra Ellina is the Editorial Community Manager at F1000Research. She is
@@ -1208,6 +730,13 @@ dylan-bastiaans:
   first-name: Dylan
   github: false
   last-name: Bastiaans
+ekaroune:
+  country: UK
+  email: ekaroune@googlemail.com
+  first-name: Emma
+  last-name: Karoune
+  pronouns: she/her
+  website: ekaroune
 ekeluv:
   affiliation: Medical biosciences UWC
   country: South Africa
@@ -1273,6 +802,13 @@ estherplomp:
   orcid: 0000-0003-3625-1357
   pronouns: she/her/hers
   twitter: PhDToothFAIRy
+evacherbst:
+  country: Switzerland
+  email: eva.herbst@pim.uzh.ch
+  first-name: Eva
+  last-name: Herbst
+  pronouns: she/her
+  twitter: EvaCHerbst
 ewuramaminka:
   affiliation: University of Manchester
   country: UK
@@ -1282,6 +818,24 @@ ewuramaminka:
   last-name: Akuoko
   pronouns: she/her
   twitter: eminka_da
+fnyasimi:
+  affiliation: International Centre of Insect Physiology and Ecology (ICIPE)
+  bio: 'Festus is a bioinformatician interested in community outreach, open science
+    and networking.
+
+    He is actively engaged in training activities and he is the lead at the Bioinformatics
+    Hub of Kenya.
+
+    '
+  country: Kenya
+  expertise:
+  - OLS-1 project lead
+  - Bioinformatics
+  - Biomedical Research
+  first-name: Festus
+  last-name: Nyasimi
+  pronouns: he/him
+  twitter: Festus_nyasimi
 fpsom:
   affiliation: Institute of Applied Biosciences, Centre for Research and Technology
     Hellas
@@ -1301,6 +855,13 @@ fpsom:
   pronouns: He/him
   twitter: fopsom
   website: https://fpsom.github.io/
+ganleyemma:
+  affiliation: protocols.io
+  country: UK
+  email: emma@protocols.io
+  first-name: Emma
+  last-name: Ganley
+  twitter: GanleyEmma
 gedankenstuecke:
   affiliation: Center for Research & Interdisciplinarity
   bio: Bastian is a long-term research fellow at the Center for Research & Interdisciplinarity
@@ -1325,6 +886,12 @@ gedankenstuecke:
   pronouns: he/him
   twitter: gedankenstuecke
   website: https://tzovar.as
+georgiahca:
+  country: UK
+  email: gaitkenhead@turing.ac.uk
+  first-name: Georgia
+  last-name: Aitkenhead
+  pronouns: she/her
 graciellehigino:
   affiliation: null
   bio: 'All about theoretical ecology, the open movement and science communication!
@@ -1446,6 +1013,33 @@ ibrahssali1:
   last-name: Ssali
   pronouns: he/him
   twitter: ibrahssali1
+inquisitivevi:
+  bio: 'Biomedical scientist and science communicator interested in
+
+    building effective outreach strategies for equitable access of research outputs.
+
+    '
+  country: Germany
+  email: vinodh.ilangovan@gmail.com
+  expertise:
+  - Community building
+  - Equity diversity and inclusion
+  - Circadian rhythms
+  - Behavioral Neuroscience
+  - Genetics
+  first-name: Vinodh
+  last-name: Ilangovan
+  orcid: 0000-0002-3445-5383
+  pronouns: he/him
+  twitter: I_Vinodh
+ismael-kg:
+  affiliation: The Alan Turing Institute
+  country: UK
+  email: ikherroubi@turing.ac.uk
+  first-name: Ismael
+  last-name: Kherroubi Garcia
+  pronouns: he/his
+  twitter: ismaelkhergar
 ivotron:
   affiliation: UC Santa Cruz
   bio: Research Scientist at UC Santa Cruz, Incubator Fellow at the UC Santa Cruz
@@ -1467,6 +1061,27 @@ ivotron:
   pronouns: he/him
   twitter: ivotron
   website: https://ivotron.me
+jasonjwilliamsny:
+  bio: 'Jason is a life scientist who spends most of his time working to help researchers
+    adopt
+
+    computational practices in research and education
+
+    '
+  country: USA
+  email: williams@cshl.edu
+  expertise:
+  - Education and training
+  - Life Science Education
+  - Management and leadership
+  - Bioinformatics
+  - Molecular biology
+  first-name: Jason
+  last-name: Williams
+  orcid: 0000-0003-3049-2010
+  pronouns: he/him
+  twitter: JasonWilliamsNY
+  website: https://lifescitrainers.org
 jcolomb:
   bio: 'Former neuro-geneticist (10 year of research on fruit fly memory and behavior),
     he has been more
@@ -1657,6 +1272,13 @@ karvovskaya:
   orcid: 0000-0001-7777-5603
   pronouns: she/her
   twitter: LangData
+katesimpson:
+  country: UK
+  email: kate.simpson@imperial.ac.uk
+  first-name: Kate
+  last-name: Simpson
+  pronouns: she/her
+  twitter: Dr_KateSimpson
 katoss:
   country: France
   email: katharina.kloppenborg@gmail.com
@@ -1683,6 +1305,13 @@ katrinleinweber:
   last-name: Leinweber
   orcid: 0000-0001-5135-5758
   pronouns: she/her
+kevinxufs:
+  affiliation: Civil Service
+  country: UK
+  email: kevin.xu@faststream.civilservice.gov.uk
+  first-name: Kevin
+  last-name: Xu
+  twitter: kevinzhangxu
 kipkurui:
   bio: 'Caleb is a 19/20 Mozilla Fellow and a Bioinformatician,  interested in teaching,
     open science,
@@ -1703,6 +1332,15 @@ kipkurui:
   last-name: Kibet
   pronouns: he/him
   twitter: calkibet
+kiragu-mwaura:
+  affiliation: Institute of Primate Research
+  country: Kenya
+  expertise:
+  - OLS-1 project lead
+  first-name: David
+  last-name: Kiragu Mwaura
+  pronouns: he/him
+  twitter: MwauraKiragu
 kiri93:
   country: Switzerland
   email: mk.youssef@hotmail.com
@@ -1710,6 +1348,48 @@ kiri93:
   last-name: Kirolos Youssef
   pronouns: he/his
   twitter: my_kiri
+kirstiejane:
+  bio: 'Kirstie is a lead of the Tools, Practices and Systems research programme at
+    the Alan Turing Institute (London, UK) and senior research associate in the Department
+    of Psychiatry at the
+
+    University of Cambridge. Her work covers a broad range of interests and methods,
+    but the driving principle is to improve the lives of neurodivergent
+
+    people and people with mental health conditions. Dr Whitaker uses magnetic resonance
+    imaging to study child and adolescent brain development and
+
+    participatory citizen science to educate non-autistic people about how they can
+    better support autistic friends and colleagues. She is the lead developer
+
+    of The Turing Way, an openly developed educational resource to enable more reproducible
+    data science. Kirstie is a passionate advocate for making science
+
+    ''open for all'' by promoting equity and inclusion for people from diverse backgrounds,
+    and by changing the academic incentive structure to reward collaborative
+
+    working. She is the chair of the Turing Institute''s Ethics Advisory Group, a
+    Fulbright scholarship alumna and was a 2016/17 Mozilla Fellow for Science. Kirstie
+
+    was named, with her collaborator Petra Vertes, as a 2016 Global Thinker by Foreign
+    Policy magazine.
+
+    '
+  country: UK
+  email: kwhitaker@turing.ac.uk
+  expertise:
+  - Open research
+  - Reproducibility
+  - Community building
+  - Citizen science
+  - Equity and inclusion
+  - Human brain imaging (neuroscience)
+  first-name: Kirstie
+  last-name: Whitaker
+  orcid: 0000-0001-8498-4059
+  pronouns: she/her
+  twitter: kirstie_j
+  website: https://whitakerlab.github.io/
 klauer2207:
   bio: 'Kathi is charge of implementing and driving ELIXIR''s industry Programme.
     ELIXIR is an intergovernmental organisation with over 220 bioinformatics
@@ -1747,6 +1427,15 @@ koudyk:
   last-name: Oudyk
   pronouns: she/her
   twitter: koudyk_
+kristinariemer:
+  affiliation: University of Arizona
+  country: USA
+  expertise:
+  - OLS-1 project lead
+  first-name: Kristina
+  last-name: Riemer
+  pronouns: she/her
+  twitter: KristinaRiemer
 kswhitney:
   bio: 'Kaitlin is an assistant professor in the Science, Technology & Society department
     at the
@@ -1770,6 +1459,23 @@ kswhitney:
   orcid: 0000-0002-0815-5037
   twitter: kstackwhitney
   website: https://pht180.rit.edu/sweetlab/
+landimi2:
+  affiliation: International Livestock Research Institute
+  country: Kenya
+  expertise:
+  - OLS-1 project lead
+  first-name: Michael
+  last-name: Kofia Landi
+  pronouns: he/him
+  twitter: CofiaLandy
+lauracarter:
+  affiliation: University of Essex
+  country: UK
+  email: laura.carter@essex.ac.uk
+  first-name: Laura
+  last-name: Carter
+  pronouns: she/her
+  twitter: LauraC_rter
 lauracion:
   affiliation: University of Buenos Aires - CONICET
   bio: I am a tenured adjunct researcher leading a health data science group. I also
@@ -1807,6 +1513,14 @@ lazycipher:
   last-name: Singh
   pronouns: he/him
   twitter: lazycipher
+lilian9:
+  affiliation: Information Training and Outreach Centre for Africa
+  country: Kenya
+  expertise:
+  - OLS-1 project lead
+  first-name: Lilian
+  last-name: Juma
+  pronouns: she/her
 lpantano:
   affiliation: CRG, Barcelona
   bio: 'Computational biologist focused on genomic regulation and data integration.
@@ -1895,6 +1609,15 @@ lwinfree:
   pronouns: she/her
   twitter: lilscientista
   website: https://lwinfree.github.io/
+magicmilly:
+  affiliation: University of Arizona
+  country: USA
+  expertise:
+  - OLS-1 project lead
+  first-name: Emily
+  last-name: Cain
+  pronouns: she/her
+  twitter: magic_milly
 malloryfreeberg:
   affiliation: EMBL/EBI
   bio: 'Mallory is a Project Lead at the European Genome-phenome Archive
@@ -2070,6 +1793,15 @@ meagdoh:
   pronouns: she/her
   twitter: emdohh
   website: https://meagdoherty.io
+megmugure:
+  affiliation: International Livestock Research Institute
+  country: Kenya
+  expertise:
+  - OLS-1 project lead
+  first-name: Margaret
+  last-name: Wanjiku
+  pronouns: she/her
+  twitter: meg_wanjiku
 mesfind:
   affiliation: Addis Ababa University
   bio: 'Mesfin Diro is a faculity at Addis Ababa University, Ethiopia. Currently,
@@ -2140,6 +1872,15 @@ mloning:
   pronouns: he/him
   twitter: mm_loening
   website: https://www.linkedin.com/in/mloning/
+morphofun:
+  affiliation: The George Washington University
+  country: USA
+  expertise:
+  - OLS-1 project lead
+  first-name: Sandy
+  last-name: Kawano
+  pronouns: she/her
+  twitter: MorphoFun
 mruizvelley:
   bio: 'Mariana is a molecular biologist by training and a scientist by heart.
 
@@ -2165,6 +1906,12 @@ mruizvelley:
   orcid: 0000-0002-9248-1280
   pronouns: she/her
   twitter: mruizvelley
+muhammetcelik:
+  country: Turkey
+  email: a.muhammetcelik@gmail.com
+  first-name: Muhammet
+  last-name: Celik
+  pronouns: he/him
 mvdbeek:
   bio: 'Marius is a core Galaxy developer since 2015 and working full time on Galaxy
     since 2019.
@@ -2196,6 +1943,15 @@ myreille-larouche:
   first-name: Myreille
   github: false
   last-name: Larouche
+naralb:
+  affiliation: "Museu Paraense Em\xEDlio Goeldi"
+  country: Brazil
+  expertise:
+  - OLS-1 project lead
+  first-name: Naraiana
+  last-name: Loureiro Benone
+  pronouns: she/her
+  twitter: nlbenone
 natty2012:
   country: Kenya
   email: nattybona2012@gmail.com
@@ -2203,6 +1959,13 @@ natty2012:
   last-name: Natabona Mukhongo
   pronouns: she/her
   twitter: hnatabona
+nehamoopen:
+  country: The Netherlands
+  email: neha.moopen@gmail.com
+  first-name: Neha
+  last-name: Moopen
+  pronouns: she/her
+  twitter: NehaMoopen
 nerantzis:
   bio: 'Physicist, Teacher, Mozillian
 
@@ -2557,6 +2320,26 @@ rs_khetani:
   last-name: Khetani
   pronouns: she/her
   twitter: rs_khetani
+samguay:
+  affiliation: "Universit\xE9 de Montr\xE9al"
+  bio: "While completing his PhD in cognitive neuroscience at the Universit\xE9 de\
+    \ Montr\xE9al,\nSamuel organizes training events to equip his peers to make science\
+    \ more robust,\naccessible, and inclusive to all. He is the cofounder of Open\
+    \ Science UMontreal,\nan initiative that aims to facilitate the transition to\
+    \ a more open and transparent\nway of doing science.\n"
+  country: Canada
+  email: samuel.guay@umontreal.ca
+  expertise:
+  - OLS-1 project lead
+  - Open Science
+  - Building website with Hugo
+  - Reproducible reports
+  - Clinical neuroscience
+  first-name: Samuel
+  last-name: Guay
+  pronouns: he/him
+  twitter: SamGuay_
+  website: https://openscience.ca
 samuelorion:
   country: Canada
   email: smoburke@gmail.com
@@ -2570,6 +2353,23 @@ samvanstroud:
   email: sam.vanstroud.18@ucl.ac.uk
   first-name: Samuel
   last-name: van Stroud
+santosrac:
+  bio: 'Bioinformatician working on genomics and transcriptomics of ascomycete and
+    basidiomycete fungi. Interested in
+
+    education, teaching programming skills to bioscientists, and in open science.
+
+    '
+  country: Brazil
+  email: renatoacsantos@gmail.com
+  expertise:
+  - Bioinformatics
+  - Introduction to programming skills (Python or Perl)
+  - Fungal Biology
+  first-name: "Renato Augusto Corr\xEAa"
+  last-name: dos Santos
+  pronouns: he/him
+  twitter: CorreaSantosRA
 satagopam7:
   bio: 'Venkata is a Bioinformatician, a Senior Researcher at Bioinformatics core
     facility,
@@ -2630,6 +2430,13 @@ sdopoku:
   last-name: Selassie Opoku
   pronouns: he/him
   twitter: sdopoku
+sebastianeggert:
+  country: Germany
+  email: se.eggert@outlook.com
+  first-name: Sebastian
+  last-name: Eggert
+  pronouns: he/his
+  twitter: se_eggert
 sgibson91:
   affiliation: Alan Turing Institute
   bio: 'Sarah is a Research Software Engineer at The Alan Turing Institute where she
@@ -2662,6 +2469,14 @@ sgibson91:
   pronouns: she/her
   twitter: drsarahlgibson
   website: https://sgibson91.github.io
+sithyphus:
+  affiliation: University of Arizona
+  country: USA
+  expertise:
+  - OLS-1 project lead
+  first-name: Jorge
+  last-name: Barrios
+  pronouns: he/him
 sk-sahu:
   country: India
   email: sangramsahu15@gmail.com
@@ -2726,6 +2541,12 @@ sudarshangc:
   last-name: GC
   pronouns: he/him
   twitter: Sudarsh07847591
+tai-rocha:
+  country: Brazil
+  email: taina013@gmail.com
+  first-name: "Tain\xE1"
+  last-name: Rocha
+  twitter: Tai_Rocha_
 thessaly:
   affiliation: CENIT-UNSAM
   bio: "Julieta is a PhD candidate on social studies of science & technology, with\
@@ -2748,6 +2569,26 @@ thessaly:
   pronouns: she-her
   twitter: cassandreces
   website: julieta.aranc.io
+tklingstrom:
+  affiliation: Swedish University of Agricultural Sciences
+  bio: 'Biotechnician turned bioinformatician turned animal scientist trying to standardise
+    workflows using Galaxy
+
+    '
+  country: Sweden
+  email: tomas.klingstrom@slu.se
+  expertise:
+  - Bioinformatics
+  - Figuring out the social aspects of collaborations
+  - Thinking about stakeholder needs
+  - Bioinformatics
+  - Biobanking
+  - Ethics
+  - Cattle genomics
+  first-name: Tomas
+  last-name: "Klingstr\xF6m"
+  pronouns: he/him
+  website: https://www.slu.se/en/ew-cv/tomas-klingstrom/
 tlaguna:
   country: Spain
   email: teresa.laguna@imdea.org
@@ -2883,6 +2724,48 @@ vcheplygina:
   pronouns: she/her
   twitter: DrVeronikaCH
   website: https://www.veronikach.com
+vickynembaware:
+  bio: 'Vicky has a PhD in Bioinformatics and an MPhil in Monitoring and Evaluation.
+
+    Her research experience (qualitative and quantitative) spans Genomics and Public
+    Health.
+
+    She is currently a Project Coordinator for the Sickle Africa Data Coordinating
+    Center at
+
+    the University of Cape Town. She also coordinates several other groups and projects
+
+    including the African Genomic Medicine Training Initiative (AGMT),
+
+    Sickle Cell Disease Ontology Working Group (SCDO) and mGenAfrica.
+
+    She is the current secretary of the African Society of Human Genetics (AfSHG).
+
+    She is passionate about building research capacity, mentoring
+
+    young investigators and translational research.
+
+    '
+  country: South Africa
+  email: vnembaware@gmail.com
+  expertise:
+  - Bioinformatics
+  - Genomics and Genomic Medicine
+  - Training
+  - Public Engagement
+  - Sickle Cell Disease
+  - Bioinformatics
+  first-name: Vicky
+  github: false
+  last-name: Nembaware
+  orcid: 0000-0001-7966-4042
+  pronouns: she/her
+  twitter: VickyNembaware
+wasifarahman:
+  country: Bangladesh
+  email: shreyoshirahman@gmail.com
+  first-name: Wasifa
+  last-name: Rahman
 yochannah:
   bio: 'Yo is a [Software Sustainability Institute Fellow](https://software.ac.uk/about/fellows/yo-yehudi),
 
@@ -2929,3 +2812,18 @@ yvanlebras:
   pronouns: He
   twitter: Yvan2935
   website: https://yvanlebras.fr
+zebetus:
+  bio: 'A mentor for many previous waves of open leaders, who is currently studying
+    for their PhD at UCL.
+
+    '
+  country: UK
+  email: haz.zebetus@gmail.com
+  expertise:
+  - Community Organisation
+  - Event organising
+  - Communication
+  - Physics (Quantum Nanowires)
+  first-name: Harry
+  last-name: Smith
+  twitter: Zebetus

--- a/_data/people.yaml
+++ b/_data/people.yaml
@@ -22,7 +22,7 @@
 #
 # Mandatory: first-name, last-name, country
 ---
-ArielleBL:
+ariellebl:
   affiliation: The Alan Turing Institute
   bio: 'Arielle has spent her career to date working in research-adjacent fields,
     starting with a stint at open access publisher PLOS, where she learnt the importance
@@ -155,6 +155,30 @@ EKaroune:
   last-name: Karoune
   pronouns: she/her
   website: ekaroune
+EstherPlomp:
+  affiliation: Delft University of Technology - Faculty of Applied Sciences
+  bio: Esther works as a Data Steward at Delft University of Technology (Faculty of
+    Applied Sciences) in the Netherlands. As a Data Steward she supports researchers
+    with their data/code management and with sharing their research. Before this,
+    Esther did a PhD in bioanthropology, studying the isotopic composition of human
+    teeth to determine where they grew up.
+  city: The Hague
+  country: The Netherlands
+  email: e.plomp@tudelft.nl
+  expertise:
+  - Open protocols
+  - open data
+  - research data management
+  - FAIR
+  - archaeology
+  - bioanthropology
+  - isotopes
+  - 'osteology, '
+  first-name: Esther
+  last-name: Plomp
+  orcid: 0000-0003-3625-1357
+  pronouns: she/her/hers
+  twitter: PhDToothFAIRy
 EvaCHerbst:
   country: Switzerland
   email: eva.herbst@pim.uzh.ch
@@ -241,6 +265,24 @@ JasonJWilliamsNY:
   pronouns: he/him
   twitter: JasonWilliamsNY
   website: https://lifescitrainers.org
+Karvovskaya:
+  affiliation: VU Amsterdam
+  bio: I am a linguist turned into a research data management specialist and community
+    manager at the VU Amsterdam library. I am interested in languages and would love
+    to support community-oriented projects in this area. I am also keen on getting
+    in touch with people from Russia and supporting projects for Russian audience.
+  city: Amsterdam
+  country: Netherlands
+  email: e.karvovskaya@vu.nl
+  expertise:
+  - theoretical linguistics
+  - fieldwork
+  - research data management
+  first-name: Lena
+  last-name: Karvovskaya
+  orcid: 0000-0001-7777-5603
+  pronouns: she/her
+  twitter: LangData
 KateSimpson:
   country: UK
   email: kate.simpson@imperial.ac.uk
@@ -373,37 +415,6 @@ MuhammetCelik:
   first-name: Muhammet
   last-name: Celik
   pronouns: he/him
-NPalopoli:
-  affiliation: Universidad Nacional de Quilmes & CONICET
-  bio: 'Nicolas is a computational biologist interested in understanding the structural
-    properties, biological
-
-    function and evolutionary relationships of proteins. His current research focus
-    are protein
-
-    disorder and protein interactions mediated by Short Linear Motifs (SLiMs). He''s
-    seeking to make a
-
-    positive impact through teaching at all levels, mentoring students, taking part
-    in professional
-
-    communities and supporting projects that do good.
-
-    '
-  country: Argentina
-  email: nicopalo@gmail.com
-  expertise:
-  - Bioinformatics and Computational Biology
-  - Molecular Biology
-  - Protein sequence, structure, evolution and interactions
-  - Molecular interactions
-  - Molecular evolution
-  first-name: Nicolas
-  last-name: Palopoli
-  orcid: 0000-0001-7925-6436
-  pronouns: he/him
-  twitter: npalopoli
-  website: http://about.me/npalopoli
 NaraLB:
   affiliation: "Museu Paraense Em\xEDlio Goeldi"
   country: Brazil
@@ -420,6 +431,25 @@ NehaMoopen:
   last-name: Moopen
   pronouns: she/her
   twitter: NehaMoopen
+PivG:
+  affiliation: EMBL-EBI (European Bioinformatics Institute)
+  bio: I am a scientific training officer at the European Bioinformatics Institute
+    (EMBL-EBI) where I mainly coordinate and support training in Latin America via
+    the CABANA project (http://cabana.online/). My background lies in structural biology
+    and biomedical sciences, and I am passionate about science communication, equity
+    and inclusion.
+  city: Cambridge
+  country: United Kingdom
+  email: piv@ebi.ac.uk
+  expertise:
+  - Education and training
+  - course design and delivery
+  - science communication
+  first-name: Piv
+  last-name: Gopalasingam
+  orcid: 0000-0001-5709-3373
+  pronouns: he/him
+  twitter: cascade21
 SamGuay:
   affiliation: "Universit\xE9 de Montr\xE9al"
   bio: "While completing his PhD in cognitive neuroscience at the Universit\xE9 de\
@@ -658,7 +688,7 @@ ajstewartlang:
   website: https://ajstewartlang.netlify.app
 alexwlchan:
   affiliation: Wellcome Collection
-  country: UK
+  country: United Kingdom
   email: alex@alexwlchan.net
   first-name: Alex
   last-name: Chan
@@ -847,6 +877,30 @@ anproulx:
   first-name: "Andr\xE9anne"
   last-name: Proulx
   twitter: AndreanneProulx
+ariellebl:
+  affiliation: The Alan Turing Institute
+  bio: 'Arielle has spent her career to date working in research-adjacent fields,
+    starting with a stint at open access publisher PLOS, where she learnt the importance
+    (and challenges) of open science, code, and data. Currently the Research Project
+    Manager on the Tools, Practices & Systems programme at The Alan Turing Institute,
+    she was a CSCCE Community Engagement Fellow in 2019 and continues to be actively
+    involved in the community. She is a contributor to the Turing Way project. '
+  city: London
+  country: United Kingdom
+  email: ariellebennettlovell@gmail.com
+  expertise:
+  - Road mapping and strategy planning
+  - Community consultation
+  - Culture change
+  - Code of conducts
+  - Community goals
+  - Drug discovery
+  - Computational biology
+  - Neuroscience.
+  first-name: Arielle
+  last-name: Bennett
+  pronouns: she/her
+  twitter: biotechchat
 babasaraki:
   affiliation: Universiti Putra Malaysia
   country: Malaysia
@@ -958,22 +1012,19 @@ bonetcarne:
   twitter: bonetcarne
 bruno-soares:
   affiliation: Universidade Federal do Rio de Janeiro
-  bio: 'Bruno is a Brazilian ecologist working on a more collaborative and open
-
-    science.
-
-    '
+  bio: Bruno is a Brazilian ecologist working on a more collaborative and open science.
+  city: Rio de Janeiro
   country: Brazil
+  email: soares.e.bruno@gmail.com
   expertise:
-  - OLS-1 project lead
   - SciComm
   - Community building
   - Open Data
   - Biodiversity
   first-name: Bruno
-  last-name: Eleres Soares
+  last-name: Soares
   orcid: 0000-0001-5678-0403
-  pronouns: he/him/she/her
+  pronouns: He/Him
   twitter: Bruno_E_Soares
   website: https://sites.google.com/view/bruno-eleres-soares
 burkemlou:
@@ -1124,6 +1175,23 @@ davidviryachen:
   last-name: Chentanaman
   pronouns: he/him
   twitter: davidchenn
+demellina:
+  affiliation: F1000Research
+  bio: 'Demitra Ellina is the Editorial Community Manager at F1000Research. She is
+    a strong advocate of Open Research and engages with the research community to
+    raise awareness of the F1000Research publishing platforms. '
+  city: London
+  country: United Kingdom
+  email: demitra.ellina@f1000.com
+  expertise:
+  - open science/research
+  - open access
+  - open peer review
+  - preprints
+  first-name: Demitra
+  last-name: Ellina
+  pronouns: She/her
+  twitter: j_ellina
 dlebauer:
   affiliation: University of Arizona
   country: USA
@@ -1181,6 +1249,30 @@ emmyft:
   pronouns: she/her
   twitter: emmy_ft
   website: https://elifesci.org/labs
+estherplomp:
+  affiliation: Delft University of Technology - Faculty of Applied Sciences
+  bio: Esther works as a Data Steward at Delft University of Technology (Faculty of
+    Applied Sciences) in the Netherlands. As a Data Steward she supports researchers
+    with their data/code management and with sharing their research. Before this,
+    Esther did a PhD in bioanthropology, studying the isotopic composition of human
+    teeth to determine where they grew up.
+  city: The Hague
+  country: The Netherlands
+  email: e.plomp@tudelft.nl
+  expertise:
+  - Open protocols
+  - open data
+  - research data management
+  - FAIR
+  - archaeology
+  - bioanthropology
+  - isotopes
+  - osteology
+  first-name: Esther
+  last-name: Plomp
+  orcid: 0000-0003-3625-1357
+  pronouns: she/her/hers
+  twitter: PhDToothFAIRy
 ewuramaminka:
   affiliation: University of Manchester
   country: UK
@@ -1412,33 +1504,32 @@ jelioth-muthoni:
 jezcope:
   affiliation: The British Library
   bio: "Jez is Data Services Lead in The British Library\u2019s Research Infrastructure\
-    \ Services team.\nHe has over 8 years of experience developing and delivering\
-    \ research data management services and\nstrategies at research-intensive higher\
-    \ education institutions in the UK, as part of a long-term\ngoal to help communicate\
-    \ and collaborate more effectively using technology; previous roles include\n\
-    research data management at University of Sheffield, Imperial College London and\
-    \ University of Bath.\nHe graduated from Imperial College London with an MSci\
-    \ in Joint Mathematics & Computing. He is an\nexperienced teacher and is involved\
-    \ with grassroots-driven data & software skills training organisation\nThe Carpentries,\
-    \ as a Certified Instructor and early contributor to Library Carpentry. He is\
-    \ particularly\ninterested in elevating the status of research software alongside\
-    \ research data in the scholarly record,\nand helping researchers develop the\
-    \ skills to make the most of this. He is a Fellow of the Software\nSustainability\
-    \ Institute, 2020 intake.\n"
-  country: UK
+    \ Services team. He has over 8 years of experience developing and delivering research\
+    \ data management services and strategies at research-intensive higher education\
+    \ institutions in the UK, as part of a long-term goal to help communicate and\
+    \ collaborate more effectively using technology. He is an experienced teacher\
+    \ and is involved with The Carpentries as a Certified Instructor and early contributor\
+    \ to Library Carpentry. He is particularly interested in elevating the status\
+    \ of research software alongside research data in the scholarly record, and helping\
+    \ researchers develop the skills to make the most of this. He is a Fellow of the\
+    \ Software Sustainability Institute, 2020 intake."
+  city: North Yorkshire
+  country: United Kingdom
   email: j.cope@erambler.co.uk
   expertise:
-  - Research data management
-  - Open access publishing
-  - Research software sharing
-  - Learning & teaching
   - Libraries
+  - Data management
+  - Digital preservation
+  - Open source
+  - Open access publishing
+  - Git
+  - Web
   first-name: Jez
   last-name: Cope
-  orcid: https://orcid.org/0000-0003-3629-1383
+  orcid: 0000-0003-3629-1383
   pronouns: he/him
   twitter: jezcope
-  website: https://erambler.co.uk
+  website: https://erambler.co.uk/
 joel-hancock:
   country: Austria
   email: jhancock@cemm.at
@@ -1550,21 +1641,20 @@ karinlag:
   twitter: karinlag
 karvovskaya:
   affiliation: VU Amsterdam
-  bio: I am a theoretical linguist turned into an RDM expert and a community manager.
-    In my work I try to bring together the support personnel at my university and
-    the researchers who are interested in data management, data sharing and Open Science.
-    I would be thrilled to use my newly acquired skills to help linguistic projects.
+  bio: I am a linguist turned into a research data management specialist and community
+    manager at the VU Amsterdam library. I am interested in languages and would love
+    to support community-oriented projects in this area. I am also keen on getting
+    in touch with people from Russia and supporting projects for Russian audience.
   city: Amsterdam
   country: Netherlands
   email: e.karvovskaya@vu.nl
   expertise:
-  - linguistics
+  - theoretical linguistics
   - fieldwork
-  - research data management (RDM)
-  - community management
+  - research data management
   first-name: Lena
   last-name: Karvovskaya
-  orcid: 000-0001-7777-5603
+  orcid: 0000-0001-7777-5603
   pronouns: she/her
   twitter: LangData
 katoss:
@@ -1681,23 +1771,15 @@ kswhitney:
   twitter: kstackwhitney
   website: https://pht180.rit.edu/sweetlab/
 lauracion:
-  affiliation: University of Buenos Aires-CONICET
-  bio: 'I am a tenured adjunct researcher leading a health data science group. I also
-    work to
-
-    improve data analysis teaching and practice. One of the roles I enjoy most is
-    mentoring and
-
-    teaching others. I am part of the R-Ladies Global leadership team and a trainer
-    and instructor
-
-    for The Carpentries. In 2020, I co-founded MetaDocencia, an open, volunteer-led,
-    collaborative,
-
-    and Spanish-speaking education community.
-
-    '
+  affiliation: University of Buenos Aires - CONICET
+  bio: I am a tenured adjunct researcher leading a health data science group. I also
+    work to improve data analysis teaching and practice. One of the roles I enjoy
+    most is mentoring and teaching others. I am a trainer and instructor for The Carpentries.
+    In 2020, I co-founded MetaDocencia, an open, collaborative, and Spanish-speaking
+    education community.
+  city: Buenos Aires
   country: Argentina
+  email: lacion@gmail.com
   expertise:
   - Health data science and artificial intelligence/Biostatistics
   - Addiction research
@@ -1705,9 +1787,6 @@ lauracion:
   - Community building
   first-name: Laura
   last-name: "Aci\xF3n"
-  life-science-expertise: 'Once upon a time I was a molecular biologist.
-
-    '
   orcid: 0000-0001-5213-6012
   pronouns: she/her
   twitter: _lacion_
@@ -1935,7 +2014,7 @@ martinagvilas:
   - Neuroscience
   first-name: Martina
   last-name: Vilas
-  orcid: https://orcid.org/0000-0002-1097-8534
+  orcid: 0000-0002-1097-8534
   pronouns: She/her
   twitter: martinagvilas
   website: https://martinagvilas.github.io/
@@ -2139,6 +2218,25 @@ nerantzis:
   pronouns: he/him
   twitter: nerantzis
   website: https://4myfiles.wordpress.com
+npalopoli:
+  affiliation: Universidad Nacional de Quilmes & CONICET
+  bio: Computational biologist interested in understanding the functional nature of
+    macromolecules, with a special focus on their evolutionary relationships and their
+    interactions within biological systems.
+  city: Bernal
+  country: Argentina
+  email: nicopalo@gmail.com
+  expertise:
+  - Computational biology
+  - structural bioinformatics
+  - proteins
+  - molecular interactions
+  - education
+  first-name: Nicolas
+  last-name: Palopoli
+  orcid: 0000-0001-7925-6436
+  pronouns: He/him
+  twitter: npalopoli
 npscience:
   bio: 'Naomi is motivated by people who are empowered to participate in knowledge
     and discovery for improvement of the
@@ -2294,31 +2392,23 @@ pherterich:
   orcid: 0000-0002-4542-9906
   pronouns: she/her
   twitter: pherterich
-piv-gopalasingam:
-  affiliation: EMBL-EBI
-  bio: 'Piv is a scientific training officer at the European Bioinformatics Institute
-    (EMBL-EBI)
-
-    where he mainly coordinates and supports training in Latin America via the [CABANA
-    project](http://cabana.online/).
-
-    His background lies in structural biology and biomedical sciences, and he is passionate
-    about science communication,
-
-    equity and inclusion.
-
-    '
-  country: UK
+pivg:
+  affiliation: EMBL-EBI (European Bioinformatics Institute)
+  bio: I am a scientific training officer at the European Bioinformatics Institute
+    (EMBL-EBI) where I mainly coordinate and support training in Latin America via
+    the CABANA project (http://cabana.online/). My background lies in structural biology
+    and biomedical sciences, and I am passionate about science communication, equity
+    and inclusion.
+  city: Cambridge
+  country: United Kingdom
   email: piv@ebi.ac.uk
   expertise:
   - Education and training
-  - Course design and delivery
-  - Science communication
-  - Structural biology
-  - Biomedical sciences
+  - course design and delivery
+  - science communication
   first-name: Piv
-  github: false
   last-name: Gopalasingam
+  orcid: 0000-0001-5709-3373
   pronouns: he/him
   twitter: cascade21
 pradeep-eranti:
@@ -2330,37 +2420,25 @@ pradeep-eranti:
   pronouns: he/his
   twitter: pradeeperanti
 profgiuseppe:
-  bio: 'Giuseppe was a researcher in bioinformatics and teacher of programming in
-    an international MSc degree.
-
-    After moving to industry, he is focusing on devops, reproducible science and the
-    creation of databases
-
-    and tools for research institutions, hospitals and companies.
-
-    Wikimedian at heart, he loves when knowledge is open and shareable. Former university
-    researcher. Software
-
-    carpentry instructor. IT specialist for R&D
-
-    '
+  affiliation: Biodec S.r.l.
+  bio: After leaving the university, where I taught programming in an international
+    bioinformatics course, I started working as an IT specialist helping research
+    centers, hospitals and companies in the development of reproducible analysis environments
+    and software. Always Wikimedian, Software Carpentry instructor when I can.
+  city: Bologna
   country: Italy
   email: profgiuseppe@gmail.com
   expertise:
-  - Devops - Continuous Integration/Deployment
-  - Reproducible environments
-  - Best practices in research software
-  - Wikidata, Wikipedia
   - Reproducible science
-  - Git
-  - Automation
-  - Open and public databases and sources
-  - Bioinformatics
-  - Computational biology
+  - git
+  - continuous integration
+  - automation
+  - open and public databases and sources.
   first-name: Giuseppe
   last-name: Profiti
   orcid: 0000-0001-6067-6174
   pronouns: he/him
+  twitter: GProfiti
   website: https://sites.google.com/site/peppeprofiti
 pvanheus:
   country: South Africa
@@ -2836,17 +2914,18 @@ yochannah:
   pronouns: they/them
   twitter: yoyehudi
 yvanlebras:
-  affiliation: "Mus\xE9um national d'Histoire naturelle"
-  bio: 'Yvan is data management and analysis lover, for life science, health and environment
-
-    '
+  affiliation: French Museum of Natural History
+  bio: Yvan is data management and analysis lover, for life science, health and environment
+  city: Concarneau
   country: France
   email: yvan.le-bras@mnhn.fr
   expertise:
-  - Galaxy power user
-  - Life science data analysis
   - Ecology
+  - Data management
+  - Data analysis
   first-name: Yvan
   last-name: Le Bras
-  pronouns: he/him
+  orcid: 0000-0002-8504-068X
+  pronouns: He
   twitter: Yvan2935
+  website: https://yvanlebras.fr

--- a/bin/extract-people.py
+++ b/bin/extract-people.py
@@ -94,4 +94,4 @@ if __name__ == '__main__':
         people_f.write('#\n')
         people_f.write('# Mandatory: first-name, last-name, country\n')
         people_f.write('---\n')
-        people_f.write(yaml.dump(people))
+        people_f.write(yaml.dump(people, allow_unicode=True))

--- a/bin/extract-people.py
+++ b/bin/extract-people.py
@@ -20,9 +20,10 @@ def extract_people_info(row):
         'website': row['Website'],
         'orcid': row['ORCID'],
         'affiliation': row['Affiliation'],
+        'city': row['City'],
         'country': row['Country'],
-        'pronouns': row['Pronouns'],
-        'expertise': row['Areas of expertise (1 element per line)'],
+        'pronouns': row['Preferred pronouns (optional)'],
+        'expertise': row['Areas of expertise'],
         'bio': row['Bio']
     }
     github = row['Github username']
@@ -31,24 +32,12 @@ def extract_people_info(row):
             info['first-name'].lower(),
             info['last-name'].lower())
         info['github'] = False
-    if info['email'] is None:
-        del info['email']
-    if info['twitter'] is None:
-        del info['twitter']
-    if info['website'] is None:
-        del info['website']
-    if info['orcid'] is None:
-        del info['orcid']
-    if info['affiliation'] is None:
-        del info['affiliation']
-    if info['country'] is None:
-        del info['country']
-    if info['pronouns'] is None:
-        del info['pronouns']
-    if info['expertise'] is None:
-        del info['expertise']
-    if info['bio'] is None:
-        del info['bio']
+    optional_info = ['email', 'twitter', 'website', 'orcid', 'affiliation', 'city', 'country', 'pronouns', 'expertise', 'bio']
+    for i in optional_info:
+        if info[i] is None:
+            del info[i]
+    if 'expertise' in info:
+        info['expertise'] = info['expertise'].split("; ")
     return github, info
 
 
@@ -72,6 +61,10 @@ if __name__ == '__main__':
     for index, row in df.iterrows():
         github, info = extract_people_info(row)
         if github not in people:
+            print("Add info for %s" % github)
+            people[github] = info
+        else:
+            print("Update info for %s" % github)
             people[github] = info
 
     # dump people dictionary into people.yaml file

--- a/bin/extract-people.py
+++ b/bin/extract-people.py
@@ -29,9 +29,10 @@ def extract_people_info(row):
     github = row['Github username']
     if github is None:
         github = '%s-%s' % (
-            info['first-name'].lower(),
-            info['last-name'].lower())
+            info['first-name'],
+            info['last-name'])
         info['github'] = False
+    github = github.lower()
     optional_info = ['email', 'twitter', 'website', 'orcid', 'affiliation', 'city', 'country', 'pronouns', 'expertise', 'bio']
     for i in optional_info:
         if info[i] is None:

--- a/bin/sort-expertises.py
+++ b/bin/sort-expertises.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+
+import argparse
+import pandas as pd
+import yaml
+from pathlib import Path
+
+def extract_expertise(people_list, people):
+    '''Extract expertise for interesting people
+    and return them as a key and a dictionary
+
+    :param people_list: list of username for which extracting expertise
+    :param people: dictionary with people information
+
+    :return: dictionary with key being expertise and values 
+    list of people with expertise
+    '''
+    no_expertise = 'No listed expertise'
+    p_expertise = {no_expertise: []}
+    for p in people_list:
+        if 'expertise' in people[p]:
+            for e in people[p]['expertise']:
+                p_expertise.setdefault(e, [])
+                p_expertise[e].append(p)
+        else:
+            p_expertise[no_expertise].append(p)
+    if len(p_expertise[no_expertise]) == 0:
+        p_expertise.pop(no_expertise)
+    return p_expertise
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Extract expert/mentor expertise from metadata file and order expert/mentor given that information')
+    parser.add_argument('-c', '--cohort', help="Cohort id (3, 4, etc)")
+    args = parser.parse_args()
+
+    people_fp = Path('_data') / Path('people.yaml')
+    # load people.yaml file into a dictionary
+    with open(people_fp, 'r') as people_f:
+        people = yaml.load(people_f, Loader=yaml.FullLoader)
+
+    metadata_fp = Path('_data') / Path('ols-%s-metadata.yaml' % args.cohort )
+    # load metadata cohort file into a dictionary
+    with open(metadata_fp, 'r') as metadata_f:
+        metadata = yaml.load(metadata_f, Loader=yaml.FullLoader)
+
+    # add expertise:people for possible mentors in a dictionary to metadata
+    metadata['possible-mentors-with-expertise'] = extract_expertise(
+        metadata['possible-mentors'],
+        people
+    )
+
+    # add expertise:people for possible mentors in a dictionary to metadata
+    metadata['experts-with-expertise'] = extract_expertise(
+        metadata['experts'],
+        people
+    )
+    
+    # dump expertise dictionary into metadata file
+    with metadata_fp.open("w") as metadata_f:
+        metadata_f.write('# List of experts, possible mentors and organizers for OLS-%s\n' % args.cohort)
+        metadata_f.write('#\n')
+        metadata_f.write('#\n')
+        metadata_f.write('# People should be also in people.yaml file and linked using their GitHub username\n')
+        metadata_f.write('# Ordering by expertise should be done by running the bin/sort-expertises.py script\n')
+        metadata_f.write('---\n')
+        metadata_f.write(yaml.dump(metadata))
+        
+    

--- a/css/custom.scss
+++ b/css/custom.scss
@@ -316,3 +316,7 @@ $link-active: $link-hover;
     margin-right: 0px;
   }
 }
+
+.peoples {
+  margin-top: 1em;
+}

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -32,3 +32,21 @@ document.addEventListener('DOMContentLoaded', function() {
 		});
 	}
 });
+
+document.addEventListener('DOMContentLoaded', function() {
+	let cardToggles = document.getElementsByClassName('expertise-toggle');
+	for (let i = 0; i < cardToggles.length; i++) {
+		cardToggles[i].addEventListener('click', e => {
+			e.currentTarget.parentElement.querySelector(".peoples").classList.toggle('is-hidden');
+		});
+	}
+});
+
+document.addEventListener('DOMContentLoaded', function() {
+	let cardToggles = document.getElementsByClassName('expertise-detail-toggle');
+	for (let i = 0; i < cardToggles.length; i++) {
+		cardToggles[i].addEventListener('click', e => {
+			e.currentTarget.parentElement.parentElement.querySelector(".expertise-detail").classList.toggle('is-hidden');
+		});
+	}
+});

--- a/ols-3.md
+++ b/ols-3.md
@@ -123,19 +123,58 @@ Mentors advise and inspire
 - Recommend: resources, readings, classes, experiences
 - Feedback: for the project leads to consider
 
-<!-- Any modification of the content should be done in the _data/ols-3-projects.yaml file -->
+### Pool of mentors
 
-**Pool of mentors for OLS-3**
+<!-- Pool of possible mentors (hidden when cohort has started)
+Any modification of the content should be done in the _data/ols-3-metadata.yaml file -->
+
+We thank the **{{ metadata.possible-mentors | size }} persons who registered to be mentors** in this round
 
 <div class="people">
-{% for entry in metadata.possible-mentors %}
-    {% assign username = entry %}
-    {% assign user = site.data.people[username] %}
-    {% include _includes/people.html user=user username=username %}
-{% endfor %}
+    {% for mentor in metadata.possible-mentors %}
+        {% assign username = mentor %}
+        {% assign user = site.data.people[username] %}
+        {% include _includes/people.html user=user username=username %}
+    {% endfor %}
 </div>
 
+{% if metadata.possible-mentors-with-expertise %}
+
+<div class="expertise">
+    <h4 class="expertise-detail-question">
+        <a class="expertise-detail-toggle">
+            Mentors sorted by their expertise areas
+            <i class="fa fa-angle-down"></i>
+        </a>
+    </h4>
+    <ul class="expertise-detail is-hidden">
+        {% for expertise in metadata.possible-mentors-with-expertise %}
+        <li class="expertise-question">
+            <a class="expertise-toggle">
+                {{ expertise[0] }}
+                <i class="fa fa-angle-down"></i>
+            </a>
+            <div class="peoples is-hidden">
+                <div class="people">
+                {% for mentor in expertise[1] %}
+                    {% assign username = mentor %}
+                    {% assign user = site.data.people[username] %}
+                    {% include _includes/people.html user=user username=username %}
+                {% endfor %}
+                </div>
+            </div>
+        </li>
+        {% endfor %}
+    </ul>
+</div>
+{% endif %}
+
+
+<!-- Pool of mentors (hidden before cohort starts)
+Any modification of the content should be done in the _data/ols-3-projects.yaml file -->
+
 <!--
+We thank the {{ metadata.possible-mentors | size }} mentors this round.
 <div class="people">
 {% for entry in p-mentors %}
     {% assign username = entry %}
@@ -164,13 +203,46 @@ Experts are invited to join cohort calls or individual mentorship calls to share
 
 <!-- Any modification of the content should be done in the _data/ols-3-metadata.yaml file -->
 
+We thank the **{{ metadata.experts | size }} persons who registered to be experts** in this round. 
+
 <div class="people">
-{% for entry in metadata.experts %}
-    {% assign username = entry %}
-    {% assign user = people[username] %}
-    {% include _includes/people.html username=username user=user %}
-{% endfor %}
+    {% for mentor in metadata.experts %}
+        {% assign username = mentor %}
+        {% assign user = site.data.people[username] %}
+        {% include _includes/people.html user=user username=username %}
+    {% endfor %}
 </div>
+
+{% if metadata.experts-with-expertise %}
+
+<div class="expertise">
+    <h4 class="expertise-detail-question">
+        <a class="expertise-detail-toggle">
+            Experts sorted by their expertise areas
+            <i class="fa fa-angle-down"></i>
+        </a>
+    </h4>
+    <ul class="expertise-detail is-hidden">
+        {% for expertise in metadata.experts-with-expertise %}
+        <li class="expertise-question">
+            <a class="expertise-toggle">
+                {{ expertise[0] }}
+                <i class="fa fa-angle-down"></i>
+            </a>
+            <div class="peoples is-hidden">
+                <div class="people">
+                {% for mentor in expertise[1] %}
+                    {% assign username = mentor %}
+                    {% assign user = site.data.people[username] %}
+                    {% include _includes/people.html user=user username=username %}
+                {% endfor %}
+                </div>
+            </div>
+        </li>
+        {% endfor %}
+    </ul>
+</div>
+{% endif %}
 
 A dedicated slack channel will facilitate open discussions among experts and other participants in OLS-3 to help them expand their network while discussing relevant topics (contact the team if you are not yet on this channel).
 


### PR DESCRIPTION
This PR:

- Add possible mentors and experts
- Fix #249: Organize mentors and experts in cohort page by expertise areas (not perfect)
  
  ![Screenshot 2021-01-07 at 22 17 40](https://user-images.githubusercontent.com/1842467/103946136-92ecac00-5136-11eb-9db3-6062f7fed03d.png)
