### PR TITLE
OLS-5: add people, project and also announcement post

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
-CONDA_ENV = open-life-science-website
+CONDA_ENV = ols-website
 SHELL=bash
 
 CONDA = $(shell which conda)
+CONDA_ENV_DIR=$(shell dirname $(dir $(CONDA)))
 ifeq ($(CONDA),)
 	CONDA=${HOME}/miniconda3/bin/conda
 endif

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Add the person to their corresponding list to be visible on the website:
 
 Add many people in a row to `_data/people.yaml`:
 
-1. Create a CSV file with at least the following columns (named this way): 
+1. Create a CSV file with at least the following columns (named this way):
    - `First name`
    - `Last name`
    - `Email`
@@ -175,7 +175,47 @@ Add many people in a row to `_data/people.yaml`:
 4. Run the script which extract information from the CSV file and add them to `_data/people.yaml`
 
    ```
-   $ python bin/prepare_website_data.py extractpeople -i <path to csv file>
+   $ python bin/prepare_website_data.py extractpeople \
+      -df <path to csv file with participants> OR -du <URL to csv file with participants>
+   ```
+
+## Add possible mentors and experts for a cohort
+
+1. Create a CSV file with at least the following columns (named this way):
+   - `First name`
+   - `Last name`
+   - `Email`
+   - `Github username`
+   - `Twitter username`
+   - `Website`
+   - `ORCID`
+   - `Affiliation`
+   - `City`
+   - `Country`
+   - `Pronouns`
+   - `Areas of expertise (1 element per line)`
+   - `Bio`
+
+   A form like [this one](https://docs.google.com/forms/d/e/1FAIpQLScmsWw0VSvdytz3A1k6HnbfgOnsE4SiJcL9_qkMTs_Na6-l2Q/viewform?usp=pp_url) can be used to generate such csv
+
+2. Activate the conda environment
+
+   ```
+   $ source activate open-life-science-website
+   ```
+
+   Or alternatively, get locally:
+   - Python 3.*
+   - pyyaml
+   - pandas
+
+4. Run the script which extract information from the CSV file and add them to `_data/people.yaml`
+
+   ```
+   $ python bin/prepare_website_data.py addmentorsexperts \
+      -c <cohort id> \
+      -t <mentors or experts> \
+      -df <path to csv file with participants> OR -du <URL to csv file with participants>
    ```
 
 ## Add a partner/sponsor
@@ -196,7 +236,7 @@ The schedule displayed in a cohort page is automatically generated from a file `
 In this file, for each week, it is listed the timeframe and the different calls planned. For each call, several information are given:
 - `type`: `Mentor-Mentee`, `Cohort`, `Mentors` or `Coworking`
 - `duration` in min
-- `title` 
+- `title`
 - `date` in the format `Month Day, Year`
 - `time` in the format '14:00' and for Berlin time
 - `calendar-event`: link to calendar event
@@ -236,7 +276,7 @@ In this file, for each week, it is listed the timeframe and the different calls 
 
 ## Order experts and possible mentors by expertise areas
 
-In metadata file for cohort, experts and possible mentors can be ordered by expertise area to be display in cohort page given these areas. 
+In metadata file for cohort, experts and possible mentors can be ordered by expertise area to be display in cohort page given these areas.
 
 To order them:
 
@@ -285,9 +325,8 @@ To order them:
    ```
    $ python bin/prepare_website_data.py addprojects \
       -c <cohort id> \
-      -p <path to csv file with projects> \
-      -i <path to csv file with participants> \
-      -l <path to log file>
+      -pf <path to csv file with projects> OR -pu <URL to csv file with projects> \
+      -df <path to csv file with participants> OR -du <URL to csv file with participants>
    ```
 
 ## Add events to Google calendar

--- a/_data/ols-4-metadata.yaml
+++ b/_data/ols-4-metadata.yaml
@@ -37,7 +37,7 @@ experts:
 - k8hertweck
 - karvovskaya
 - katoss
-- kstackwhitney
+- kswhitney
 - lauracarter
 - lwinfree
 - markuskonk
@@ -53,9 +53,9 @@ experts:
 - unode
 experts-with-expertise:
   Ableism:
-  - kstackwhitney
+  - kswhitney
   Accessibility:
-  - kstackwhitney
+  - kswhitney
   - smklusza
   Agrobiodiversity:
   - iramosp
@@ -349,7 +349,7 @@ experts-with-expertise:
   Open workflows:
   - ekaroune
   Openness without extraction:
-  - kstackwhitney
+  - kswhitney
   Osteology:
   - estherplomp
   Palaeoecology:

--- a/_data/ols-5-metadata.yaml
+++ b/_data/ols-5-metadata.yaml
@@ -4,10 +4,466 @@
 # People should be also in people.yaml file and linked using their GitHub username
 # Ordering by expertise should be done by running the bin/sort-expertises.py script
 ---
-experts: []
+experts:
+- alexholinski
+- alexwlchan
+- annemtreasure
+- cassgvp
+- deepakunni3
+- ewallace
+- georgiahca
+- gugy89
+- ha0ye
+- iramosp
+- iratxepuebla
+- jesperdramsch
+- jezcope
+- joyceykao
+- jsheunis
+- karvovskaya
+- klauer2207
+- lauracarter
+- luispedro
+- msundukova
+- pherterich
+- raphaels1
+- santosrac
+- selgebali
+- stefaniebutland
+- teresa-cisneros
+experts-with-expertise:
+  ' r':
+  - stefaniebutland
+  Academia-to-professional services transition / research adjacent roles:
+  - cassgvp
+  Agrobiodiversity:
+  - iramosp
+  Ally skills training:
+  - ha0ye
+  App/software development:
+  - joyceykao
+  Automl:
+  - raphaels1
+  Balancing open science with the rest of your career;:
+  - ewallace
+  Benchmarking:
+  - raphaels1
+  Bio-ontologies:
+  - deepakunni3
+  Biochemstry:
+  - gugy89
+  Biodiversity:
+  - annemtreasure
+  Bioinformatics:
+  - ewallace
+  - gugy89
+  - santosrac
+  Biology:
+  - annemtreasure
+  Building inclusive sustainable communities:
+  - stefaniebutland
+  Champions/ambassadors programme:
+  - cassgvp
+  Citizen science:
+  - georgiahca
+  Climate change:
+  - annemtreasure
+  Co-creation:
+  - georgiahca
+  Collaboration:
+  - pherterich
+  Communicating in the open:
+  - stefaniebutland
+  Community:
+  - cassgvp
+  Community building:
+  - joyceykao
+  Community management:
+  - ha0ye
+  Computational biology:
+  - joyceykao
+  - luispedro
+  Computational inclusion:
+  - selgebali
+  Conference organization:
+  - joyceykao
+  Creative thinking:
+  - msundukova
+  Curation:
+  - selgebali
+  Data driven life sciences:
+  - klauer2207
+  Data life cycle:
+  - annemtreasure
+  Data literacy:
+  - ewallace
+  Data management:
+  - annemtreasure
+  - iramosp
+  Data pipelines and workflows:
+  - annemtreasure
+  Data publication:
+  - iratxepuebla
+  Data sharing:
+  - cassgvp
+  Data stewardship:
+  - gugy89
+  Deep eutectic solvents:
+  - gugy89
+  Digital equity:
+  - selgebali
+  Digital scholarship:
+  - jezcope
+  Discrimination:
+  - lauracarter
+  Diversity:
+  - jesperdramsch
+  Diversity and inclusion (transformative justice approaches):
+  - teresa-cisneros
+  Ecology:
+  - annemtreasure
+  - ha0ye
+  Edi:
+  - cassgvp
+  Education:
+  - santosrac
+  Electrophysiology:
+  - msundukova
+  Entrepreneurship:
+  - klauer2207
+  Environment:
+  - annemtreasure
+  Enzymology:
+  - gugy89
+  Equity:
+  - teresa-cisneros
+  Ethical modelling:
+  - raphaels1
+  Evolutionary biology:
+  - joyceykao
+  External relations:
+  - klauer2207
+  Fair data:
+  - gugy89
+  - pherterich
+  Fair data principles:
+  - deepakunni3
+  Fair principles:
+  - selgebali
+  Feminism:
+  - lauracarter
+  Fieldwork:
+  - karvovskaya
+  Gender:
+  - lauracarter
+  Gene expression:
+  - ewallace
+  Genomics:
+  - santosrac
+  Git and github:
+  - ha0ye
+  Github:
+  - stefaniebutland
+  Health sciences:
+  - ha0ye
+  Human rights:
+  - lauracarter
+  Incentives/reward:
+  - cassgvp
+  Infectious diseases:
+  - klauer2207
+  Inter and transdisciplinary research:
+  - iramosp
+  Invasion biology:
+  - annemtreasure
+  Knowledge graphs:
+  - deepakunni3
+  Laboratory automation:
+  - gugy89
+  Libraries:
+  - jezcope
+  Library and archiving skills:
+  - pherterich
+  Licensing:
+  - jezcope
+  Life science:
+  - selgebali
+  Linguistics:
+  - karvovskaya
+  Machine learning:
+  - jesperdramsch
+  - raphaels1
+  Marine sciences:
+  - annemtreasure
+  Metadata management:
+  - deepakunni3
+  Microbiome:
+  - luispedro
+  Microscopy:
+  - msundukova
+  Mobility:
+  - msundukova
+  Molecular dynamics simulations:
+  - gugy89
+  Molecular modelling:
+  - gugy89
+  Neurodiversity:
+  - georgiahca
+  Neuroimaging:
+  - cassgvp
+  Neuroscience:
+  - msundukova
+  No listed expertise:
+  - alexholinski
+  - alexwlchan
+  Omics:
+  - santosrac
+  Open access:
+  - iratxepuebla
+  Open data:
+  - annemtreasure
+  - iramosp
+  - jezcope
+  Open research:
+  - jezcope
+  Open scholarship:
+  - jezcope
+  Open science:
+  - annemtreasure
+  - ewallace
+  - jezcope
+  Open science and community:
+  - pherterich
+  Open science in project and teaching context:
+  - ewallace
+  Open software peer review:
+  - stefaniebutland
+  Open source:
+  - georgiahca
+  Open source tools for code and data sharing:
+  - jsheunis
+  Oxidoreductases:
+  - gugy89
+  Participatory science:
+  - georgiahca
+  Practical github:
+  - ewallace
+  Preprints:
+  - iratxepuebla
+  Publishing:
+  - iratxepuebla
+  R:
+  - ha0ye
+  R packages:
+  - ewallace
+  Reflection:
+  - msundukova
+  Reproducible research:
+  - annemtreasure
+  Research data management:
+  - jezcope
+  - jsheunis
+  - karvovskaya
+  - pherterich
+  - selgebali
+  Research reproducibility:
+  - ha0ye
+  Research software engineering practice:
+  - jezcope
+  Risk and uncertainty communication:
+  - raphaels1
+  Rna:
+  - ewallace
+  Scientific biocuration:
+  - selgebali
+  Semantics:
+  - karvovskaya
+  Sensory processing:
+  - georgiahca
+  Signal processing with python;:
+  - jsheunis
+  Strategy:
+  - klauer2207
+  Survival analysis (and fundamental problems):
+  - raphaels1
+  Sustainability science:
+  - iramosp
+  Terrestrial sciences:
+  - annemtreasure
+  Time series analysis:
+  - ha0ye
+  Transcriptomics:
+  - santosrac
+  Transition:
+  - msundukova
+  Transparent and accessible ai:
+  - raphaels1
+  Transparent and inclusive leadership.:
+  - cassgvp
+  Typology:
+  - karvovskaya
+  Version control:
+  - ha0ye
+  Virtual events:
+  - joyceykao
+  - stefaniebutland
+  Web applications:
+  - joyceykao
+  Work-life balance:
+  - msundukova
+  Yeast & fungi:
+  - ewallace
 organizers:
 - bebatut
 - emmyft
 - malvikasharan
 - yochannah
-possible-mentors: []
+possible-mentors:
+- annemtreasure
+- batoolmm
+- burceelbasan
+- chucklesongithub
+- deepakunni3
+- georgiahca
+- karvovskaya
+- klauer2207
+- luispedro
+- macelik
+- msundukova
+- pherterich
+- selgebali
+possible-mentors-with-expertise:
+  Animal behavior:
+  - chucklesongithub
+  Bio-ontologies:
+  - deepakunni3
+  Biodiversity:
+  - annemtreasure
+  Bioinformatics methods:
+  - macelik
+  Biology:
+  - annemtreasure
+  Birdsong:
+  - chucklesongithub
+  Citizen science:
+  - georgiahca
+  Climate change:
+  - annemtreasure
+  Co-creation:
+  - georgiahca
+  Collaboration:
+  - pherterich
+  Computational biology:
+  - batoolmm
+  - luispedro
+  Computational inclusion:
+  - selgebali
+  Creative thinking:
+  - msundukova
+  Curation:
+  - selgebali
+  Data driven life sciences:
+  - klauer2207
+  Data life cycle:
+  - annemtreasure
+  Data management:
+  - annemtreasure
+  Data pipelines and workflows:
+  - annemtreasure
+  Digital equity:
+  - selgebali
+  Ecology:
+  - annemtreasure
+  Electrophysiology:
+  - chucklesongithub
+  - msundukova
+  Entrepreneurship:
+  - klauer2207
+  Environment:
+  - annemtreasure
+  External relations:
+  - klauer2207
+  Fair data:
+  - pherterich
+  Fair data principles:
+  - deepakunni3
+  Fair principles:
+  - selgebali
+  Fieldwork:
+  - karvovskaya
+  Galaxy:
+  - macelik
+  Hpc management:
+  - macelik
+  Infectious diseases:
+  - klauer2207
+  Invasion biology:
+  - annemtreasure
+  Knowledge graphs:
+  - deepakunni3
+  Library and archiving skills:
+  - pherterich
+  Life science:
+  - selgebali
+  Linguistics:
+  - karvovskaya
+  Marine sciences:
+  - annemtreasure
+  Metadata management:
+  - deepakunni3
+  Metagenomics:
+  - macelik
+  Microbiome:
+  - luispedro
+  Microscopy:
+  - msundukova
+  Mobility:
+  - msundukova
+  Molecular genetics:
+  - burceelbasan
+  Molecular mechanisms of cancer pathogenesis:
+  - burceelbasan
+  Neurodiversity:
+  - georgiahca
+  Neuroscience:
+  - msundukova
+  Open data:
+  - annemtreasure
+  Open science:
+  - annemtreasure
+  Open science and community:
+  - pherterich
+  Open science;:
+  - macelik
+  Open source:
+  - georgiahca
+  Participatory science:
+  - georgiahca
+  Reflection:
+  - msundukova
+  Reproducibility:
+  - batoolmm
+  Reproducible research:
+  - annemtreasure
+  Research data management:
+  - karvovskaya
+  - pherterich
+  - selgebali
+  Scientific biocuration:
+  - selgebali
+  Semantics:
+  - karvovskaya
+  Sensory processing:
+  - georgiahca
+  Strategy:
+  - klauer2207
+  Terrestrial sciences:
+  - annemtreasure
+  Transition:
+  - msundukova
+  Typology:
+  - karvovskaya
+  Work-life balance:
+  - msundukova
+  Workflow development:
+  - macelik

--- a/_data/ols-5-projects.yaml
+++ b/_data/ols-5-projects.yaml
@@ -2,4 +2,560 @@
 #
 # Check previous OLS for examples
 ---
-[]
+- description: The project *Multilingual Open Science* aims to create an open educational resource about FAIR research in Central Asian (CA) languages. The goal is to popularise and raise local researchers' awareness of open science practices and platforms and thus to tackle the existing structural barriers (e.g., linguistic, epistemic, etc.) in accessing the information and disseminating the research from Central Asia. Currently, the local scholarship is located - geographically, linguistically, epistemically - in the global periphery which hinders the knowledge production, use, and dissemination in the region. Many scholars, as the result, become trapped in fraudulent research and publication practices. Moreover, there are cases when openly accessible educational resources are offered to researchers as a marketable product. So, to address these and other issues related to inaccessibility of knowledge production infrastructure, this project aims to create an openly accessible, fair, and multilingual educational resource about open science with the particular focus on Central Asia. To this end, I am planning to use Jupyter Notebook and create a platform similar to [The Turing Way](https://the-turing-way.netlify.app/welcome).
+  keywords:
+  - equity
+  - diversity
+  - inclusion
+  - open scholarship
+  - multilingual open science
+  - epistemic/linguistic
+  - justice
+  mentors:
+  - acocac
+  - smklusza
+  name: 'Multilingual Open Science: Creating Open Educational Resources in Central Asian Languages'
+  participants:
+  - sarenaz
+- description: 'Our initiative is called "Training Latin American scientists community to create high-quality open journals with good editorial standards". We intend to build a community of native spanish speaking scientists who teach and learn about creating editorial boards and open access scientific journals that meet international high editorial quality standards. We intend to organise hands-on workshops about different steps in the editorial process of creating scientific open access journals, with experienced trainers and with open source tools. Some of the topics we would like to cover are:
+
+- Acquiring ISSN code for online journals,
+
+- Acquiring plug-ins for displaying online journal view statistics,
+
+- Implementing DOIs for scientific articles,
+
+- Implementing Ithenticate to stop plagiarism in articles submitted to the OJS system.
+
+
+These workshops would merge synchronic and asynchronic activities throughout  a period of 6 weeks, so that trainees get to learn all the necessary concepts through, familiarize with the required software and conceptualize and brainstorm solutions to the local needs for the journals they intend to develop, with peer support and mentoring.'
+  keywords:
+  - training and education
+  - research community
+  - editorial community
+  - open journals systems.
+  mentors:
+  - mxrtinez
+  #- María Belén Ticona
+  name: Training Latin American scientists' community to create high-quality open journals with good editorial standards
+  participants:
+  - camila-gómez
+  - danae-carelis-davila-espinoza
+  - andre-vargas-de
+  - nelson-franco
+  - jvillcavillegas
+- description: 'Cloud-SPAN trains researchers, and the research software engineers that support them, to run specialised analyses for environmental omics datasets on cloud-based high-performance computing infrastructure. It is a collaboration between the University of York and The Software Sustainability Institute funded by the UKRI Innovation Scholars award (Project Reference: MR/V038680/1). The primary objective of the project is to generate training materials and opportunities which are open, accessible and reusable (FAIR) for all researchers. We aim to build an engaged community of practice around the participation in, and the development and maintenance of, the materials. The community-building element would be the main focus of the OLS scheme project.'
+  keywords:
+  - Education
+  - Training
+  - Environmental biotechnology
+  - Omics
+  - Community
+  mentors:
+  - annefou
+  name: Building a Cloud-SPAN community of practice
+  participants:
+  - evelyngreeves
+- description: There is a considerable gap in cases of sub-Saharan African countries regarding assessment of embodied energy of building materials and operational energy of various building types. Lack of data remains a critical barrier to closing this gap. Creating a database of embodied energy of building materials and operational energy of building typologies will be key in establishing the carbon footprint of buildings in Ghana. The development of an online platform will also allow interested groups, individuals and cooperation's to submit key information needed for the computation of energy outputs in buildings.  The aim of this project is to explore the scope and path towards establishing an open database and an inclusive community.
+  keywords:
+  - Sustainabilty
+  - Open science
+  - Carbon footprint
+  - Buildings
+  mentors:
+  - annemtreasure
+  name: Developing a carbon footprint database for buildings in Ghana
+  participants:
+  - 0sahene
+- description: "TU Delft OPEN Publishing, Open Access academic publisher of the TU Delft, publishes open access (OA) journals and open (text)-books. The OA journals currently receive not enough support regarding their development. This project aims to bring all OA journals to the same high level of quality expected of any TU Delft product.  This project will establish the identity of TU Delft OPEN Publishing as a trustworthy academic publisher within and beyond TU Delft.
+
+The success of the plan is linked to the open collaboration of the journal editorial boards. The publishing plan will help journals
+
+- Identify their readership by targeting the correct authors,
+
+- Evaluate the quality of their publications (Impact),
+
+- Determine their publishing priorities,
+
+- Consider other publishing options (special Issues, new article types, publishing peer review comments, cascading),
+
+- Growth,
+
+- Improve communications and networking,
+
+- Diversify the editorial board
+
+- Take part in the education of young researchers
+
+
+The plan needs to integrate as much as possible open science principles such as Open Data, Open peer review or authorship transparency in their publishing processes. While the plan will benefit all, It should consider the specificity of each journal. Overall the plan has to demonstrate its value to the editorial board."
+  keywords:
+  - open publishing
+  - open access
+  - open peer review
+  - scholarly communication
+  mentors:
+  - ariellebl
+  - jcolomb
+  name: Publishing development plan for the Open access journals of TU Delft OPEN Publishing
+  participants:
+  - frédérique-belliard
+- description: This project is envisioned as one that ends up as something that can explain the “why” when encouraging people from legal backgrounds to learn R and some data science. A case for open and reproducible research in a field that does not typically use R and qualitative methods. The idea is to get to that point by creating different data sets derived from commonly used legal sources that law students or graduates would be familiar with and incorporating them into a single platform with a few examples of practical use and application as well as code to encourage such persons to see the “why”. On this platform, I would like to share resources to places where the intro to R courses are available, etc. At this stage, this is an idea I have and I hope to develop it as the week's progress.
+  keywords:
+  - Rstudio
+  - qualitative research
+  - quantitative research
+  - legal research
+  - law
+  mentors:
+  - batoolmm
+  name: Why R, for those with legal backgrounds using examples from South Africa
+  participants:
+  - b14-rsa
+- description: Next-generation sequencing (NGS) is a revolutionary technique with wide applications in biology. Its applications are widely being used from young researchers to pioneer researchers of the field. The NGS data analysis has various approaches and many resources are explaining these methods. However, it can be difficult for beginners in this field to quickly understand and apply these methods. Also, beginner researchers might not have enough knowledge to overcome the most common errors that are encountered during these analyses. Due to the challenges that we mentioned above, in this project, we aimed to create a comprehensive open educational resource explaining NGS data analysis and its different methods and offer an example for the application of methodology and solutions to the most common errors. We believe that this project will be enlightening for anyone interested in NGS data analysis by providing a necessary roadmap.
+  keywords:
+  - Next-generation sequencing
+  - data analysis
+  - bioinformatics
+  - genomics
+  - open education
+  - open resource
+  mentors:
+  - beatrizserrano
+  - fpsom
+  name: 'NGS-HuB: An open educational resource for NGS data analysis'
+  participants:
+  - nihansultan
+  - farukustunel
+  - esbusis
+  - birgül-çolak-al
+- description: "This project aims to establish and nurture an active (virtual) community of learners with the Turing. The Institute is in the process of creating an open online learning platform to host training and learning materials, covering a range of subjects related to Data Science and AI. In order to ensure that the offering is useful to our audience, that it is responsive to their needs, and that it continues to grow, it is key to involve them in the creation and direction of the resources. Having real user voices and input will help to create an open learning space that is truly useful and valuable. Not only that, but the platform can serve as a central meeting point where learners can come together over shared interests and issues, and collaborate on projects that may have a wider impact.
+
+In order to do this, learners will need a way to connect and communicate effectively."
+  keywords:
+  - community
+  - community engagement
+  - open learning
+  - Data Science and AI education
+  - training
+  mentors:
+  - kipkurui
+  name: 'Community engagement: Building an open online learning community'
+  participants:
+  - sarah-nietopski
+- description: 'This project aims to assist researchers in the field of wood formation and ecophysiology to explore datasets and computational models in a flexible and integrative way. The goal is to provide a platform - in the form of an open knowledge graph and associated interface - that will allow researchers (even those with minimal familiarity with the underlying technology) to explore linked representations of metadata for the included datasets and models. Researchers should be able to survey a variety of models that target phenomena at different scales; ranging from process-based models of the cellular determinants of wood formation, to empirical models of gross tree growth in different environmental contexts. The linked information should allow complex questions to be asked, including: how similar models differ; which datasets can be repurposed to test different model outputs; and identifying   whether and how different models can be composed together. This will promote open scientific practices in this research area (through the use of common metadata standards and terms), and may serve as a valuable framework for collaborative knowledge capture and exploration.'
+  keywords:
+  - forestry
+  - xylogenesis
+  - wood formation
+  - ecophysiology
+  - FAIR
+  - metadata
+  - models
+  - data
+  - ontologies
+  - knowledge graph
+  mentors:
+  - deepakunni3
+  name: Finding paths through the FAIR forest; linking metadata from forestry models and datasets to assist analysis and hypothesis generation
+  participants:
+  - k-c-martin
+- description: We propose SciHack, as the first Open Community Lab in Peru. Our principal aim is to make available the tools and resources necessary for anyone, including non-professionals, to conduct biological engineering research and learning. As part of our activities, we will focus on democratizing science and biotechnology knowledge in low-income populations of Peru where there's little to no presence of science and technology education. To address these issues, we will conduct workshops about DIY lab equipment, Bioinformatics open source projects and educational resources, and molecular biology tools to train teachers and teach students how to make and analyze scientific experiments. Furthermore, by the end of our activities, we would like to implement a space for bio-makers of all ages and backgrounds to conduct research projects and build prototypes. In this way, we would be fighting against misinformation of science methodology and results that are primordial not only for the current COVID19 situation but also for the progress of science.
+  keywords:
+  - DIY Bio
+  - Open Source
+  - Biohacking
+  - Computational Biology
+  - Python programming
+  - R programming
+  mentors:
+  - diegoonna
+  name: 'SciHack: Promoting the Open Source and DIY movements in Peru'
+  participants:
+  - maria-andrea-gonzales-castillo
+  - nadia-odaliz-chamana-chura
+  - piero-beraun
+  - darwin-diaz
+  - sandra-larriega
+  - jhon-anderson-pérez-silva
+  - codito22
+- description: I would like to work with the Skills Team at the Alan Turing institute in order to create a peer-mentoring training programme from the main topics of The Turing Way. Our aim is to turn the five main areas in The Turing Way, namely research reproducibility, project design, collaboration, communication, and ethics into modules which the participants of the peer-mentoring programme can work on together. They would apply it on their own research/ projects, therefore they could put the learnt knowledge in use immediately. The aim of The Turing Way has been to be an open source, collaborative, applicable, and practical tool, and with this programme we would like to facilitate the use of it. We would like to see how people in their different stages of their career (PhD, Post-Doc, Researcher, Admin) can collaborate to deepen their knowledge about the contents of The Turing Way, while understand each other's perspective on the subject. If the prototype is successful, we would like open it up for any applicants interested in applying the practices of The Turing Way to their own projects as part of the other trainings offered by the Institute.
+  keywords:
+  - peer-mentoring
+  - open source
+  - collaboration
+  - academic
+  - Turing Way
+  - ethics
+  - communication
+  mentors:
+  - emmyft
+  name: Data Science and AI Educators' Programme AND Tools, Practices & Systems Peer Mentorship Programme
+  participants:
+  - ayeshadunk
+  - nea-bridget
+  - aurigandrea
+- description: "Together with co-workers, I have developed a Python-based tool ([Source code](https://github.com/epics-group/chemspax), [publication 1](https://doi.org/10.1002/zaac.202100078), [publication 2](https://doi.org/10.26434/chemrxiv-2021-46d50-v3)) which can be used to explore the local chemical space of an existing molecular scaffold. Homogeneous catalysts are important in many of our daily processes, but also in our fight against climate change. Our goal was to create a tool that can automatically generate large datasets that can be used in research for data-driven catalyst discovery.
+
+
+The issue was that a simple SMILES representation of a molecular scaffold does not work when it contains a transition metal complex. With this tool we use the 3D coordinates of a molecular scaffold and let the user place molecular fragments to create many variations of this scaffold. Other inorganic chemistry fields that use transition-metal containing molecules might benefit from this tool as well. A first prototype is published, but several things can be done to increase the usability of our tool."
+  keywords:
+  - software
+  - homogeneous catalysis
+  - data-driven chemistry
+  - chemical space
+  - transition
+  - metal complexes
+  - open-source
+  mentors:
+  - estherplomp
+  name: Increasing the usability of ChemSpaX, a Python tool for chemical space exploration
+  participants:
+  - akalikadien
+- description: We have created the [Ersilia Model Hub](https://github.com/ersilia-os/ersilia), a FLOSS platform containing AI/ML models for infectious and neglected disease research . These models can be accessed with little to no-coding expertise, solving a major roadblock in the applicability of such technologies to day-to-day research. The Hub currently includes a hundred open source models, both from the literature and developed by the [Ersilia organization](https://ersilia.io). With this project, we aim to open the Hub to the whole computer science community, encouraging third-author model depositions so that the code they develop is not simply open source but also deployed in a user-friendly manner. By leveraging the Hub architecture, computer scientists can reach more users, interact with them and further the impact of the assets they have developed by facilitating its implementation in real case scenarios. To this end, the project will focus on establishing clear guidelines on the quality of the software and its reproducibility (as it won't necessarily be yet peer-reviewed) and creating a standard model deposition form and minimum required documentation. The ultimate goal of the project is to build a community of contributors by facilitating their access.
+  keywords:
+  - reproducibility
+  - sustainability
+  - accessibility
+  - artificial intelligence
+  - community engagement
+  mentors:
+  - fpsom
+  name: 'The Ersilia Model Hub: encouraging deployment of computer-based research tools for non-expert usage'
+  participants:
+  - gemmaturon
+- description: Living in South Africa, and in much of the world, you can see a large gap in the accessibility of healthcare resources based on a person's income and education level. I am privileged enough to have had access to good quality healthcare resources throughout my life, which resulted in me being seen by numerous different therapists, counsellors and psychologists and being diagnosed with Autism Spectrum Disorder, more specifically Asperger's syndrome. I am also privileged in that I am able to comfortably speak and read English.   Unfortunately, a large percentage of our country has a very poor level of education, often not being able to read or speak English very well. Most South African resources I have found for individuals with, and parents of children with, autism are only available in English. My project aims to create a database of resources in a variety of South African languages, both written and as a video format (due to poor literacy rates, especially among older generations due to historical discrimination), in easy to understand language and with concepts that are easy to grasp. This is also useful as more people will be able to access online resources than resources at a healthcare facility.
+  keywords:
+  - free resources
+  - autism
+  - translation
+  mentors:
+  - georgiahca
+  - jsheunis
+  name: Easy Access Autism Resources for Rural Parents
+  participants:
+  - robert-schreiber
+- description: As open science projects mature, they attract, engage and retain members who actively participate and contribute to the project. They build *Communities of Practice* around the project through knowledge exchange, maintenance or development practices and ultimately guide the future directions for both the projects and their communities. To build a more equitable, resilient and sustainable open infrastructure for a diverse community, it is important to select governance models that give voices to people (users, contributors and wider society) from different socio-technical and socio-cultural backgrounds, identities, career stages, contextual needs and   research communities.  The Turing Way is a guide for reproducible, ethical and collaborative research and data science. Open Life Science is a training and mentoring program to help researchers learn and apply open principles in their work. They are mission-aligned open science projects that involve participants from around the world to create something deeply meaningful for them. The Turing Way has grown exponentially in the last three years that offers more than 200 pages co-created by more than 300 contributors. Open Life Science has offered 4 cohorts in the last 2 years and currently supports a community of over 300 members (present and past mentees, mentors and experts).  To support the governance work in these projects in 2022, I would like to carry out a systematic study of governance models suitable for decentralised and distributed communities such as these. By creating a portfolio of governance models suitable for projects at different maturity levels, members from these projects will be able to identify the right model for their respective  projects. The aim is to establish norms, workflows and processes that ensure a  democratic structure for decision-making and leadership in a way that contributes to projects' own visions while collaborating on the shared mission for global open science.
+  keywords:
+  - Open Source
+  - Community
+  - Governance
+  - Research
+  mentors:
+  - graciellehigino
+  - ekaroune
+  name: Exploring “Governance Models” for Open Science community projects as per their maturity stage
+  participants:
+  - malvikasharan
+  - aleesteele
+- description: "The International Committee on Open Phytolith Science (ICOPS) was initiated as a new committee within the International Phytolith Society in September 2021 and the first committee meeting took place in December 2021. This committee aims to increase the knowledge of and implementation of open science practices in phytolith research. We are embracing an open source approach to our work in this committee so that the work of our committee is transparent. This will include open documentation, regularly communicating with our community, and providing guidelines and communication channels to enable our community to engage with us. Therefore, we want to establish a solid base for this work going forward by further developing our GitHub repository - adding clear contributing guidelines and documentation on how the committee   is to be run. All members of the committee will also benefit from training in  all aspects of open science practices. This will allow us to gain further insight into the training and initiatives that we want to work on with our community.
+
+We will also start to develop training packages specific to phytolith research such as in open publishing and open and FAIR data."
+  keywords:
+  - Community Building
+  - Open Science
+  - Open Data
+  - Open Access
+  - Phytolith
+  - Archaeology
+  - Palaeoecology.
+  mentors:
+  - graciellehigino
+  - malvikasharan
+  name: 'International Committee on Open Phytolith Science: community building initiative
+    and open science training for the Phytolith Community'
+  participants:
+  - cl379
+  - jruizperez
+  - gabimusaubach
+  - abraham-dabengwa
+  - ekaroune
+  - cel31
+  - zdunseth
+  - juanjo-garcía-granero
+- description: The Turing-Roche strategic partnership was established in June 2021 with the goal of establishing a collaboration in advanced analytics between the two organisations to develop new data science methods to investigate large, complex, clinical and healthcare datasets to better understand how and why patients respond differently to treatment, and how treatment can be improved.  As Community Manager for the project I am developing a collaborative and open community between both organisations and beyond. As the partnership is just beginning and is flexible in nature there are opportunities to embed open practices such as open publication,   reproducibility, open data, training, co-working as well as establishing networks such as an early career researchers.
+  keywords:
+  - treatment heterogeneity
+  - missing health data
+  - academia-industry partnership
+  - open
+    science
+  mentors:
+  - klauer2207
+  name: Building an open community around the Turing-Roche Strategic Partnership
+  participants:
+  - vhellon
+- description: On of my goals from my current position, as a community manager at the open science community Rotterdam,  is to engage and include as many as possible; I want to sustain and grow the community. One of my ambitions is curating events and engage public to open discussions around open science. One of the events that I really want to arrange is through art (as a means) to raise awareness around open science practices, and create the floor for an open discussion around open science.  It is still a general idea, so I am aware that I still need to go over all the details and I am still not sure what blockages will rise through this journey. But I am really positive and I truly believe that art is open and can act as a mediator towards connection, expression, openness, and understanding.
+  keywords: []
+  mentors:
+  - karvovskaya
+  name: Art as a means to open science
+  participants:
+  - eirinibotsari
+- description: "[_A History of Research Ethics_](https://www.tiki-toki.com/timeline/entry/1753034/A-History-of-Research-Ethics/) is a free, online resource for researchers, governance professionals, and even college students to learn about science and ethics, and be inspired to develop practical tools for the assurance of adequately conducted research.  A key purpose of _A History of Research Ethics_ is to demonstrate the variety of disciplines and backgrounds that research ethics can draw on. In other words, interdisciplinarity is critical for its success. This means both interdisciplinary contributions _and_ adapting to audiences from diverse fields and sectors.  By embracing the collaborative nature of GitHub and OLS' open science community, I expect to take _A History of Research Ethics_ to its next stage of development."
+  keywords:
+  - History of Science
+  - Philosophy of Science
+  - Research Ethics
+  mentors:
+  - lisanna
+  name: An Incomplete History of Research Ethics
+  participants:
+  - ismael-kg
+- description: 'This study aims to develop a diagnostic LAMP kit that''s sensitive and robust to Plasmodium falciparum from saliva and urine to enhance simple and easy non-invasive molecular testing. The first phase of this study involved target validation, primer, and probe design using open-access tools. Here, a principal component analysis (PCA) of the R/adegenet package (Jombart et al, 2010) and phylogenetic tree (Neighbour-joining) using R/ape package (Paradis et al, 2004) to cluster repeats of the chosen amplification target. These clusters were aligned to generate a consensus sequence for designing primers and probes for establishing the LAMP assay. I have designed an incorporated strand displacement probe using the engineering guideline of Juan et al, 2015 and the open-access Nupack software tool. The assay has and the master mix is being lyophilized for further experimental evaluation.
+
+
+The sensitivity of this kit will be evaluated on extracted DNA from three sample types: saliva, urine, and clinical blood, with crude samples, lysed using lysis buffer. Correlation generated from these results will inform the best sensitive amplification. Further, a possible decay of the lyophilised master mix will be evaluated for six months to ascertain possible shelf-life.'
+  keywords:
+  - Non invasive diagnostics
+  - molecular kit development
+  - molecular assays
+  - molecular diagnostics
+  - R programming
+  mentors:
+  - luispedro
+  name: Developing thermally stable loop mediated isothermal amplification kit for a non invasive detection of malaria
+  participants:
+  - mgawe-cavin
+- description: In October 2021, the RSE Asia Association was launched. This was done to create awareness in the Asia region about the field of Research Software Engineering. The digital infrastructure for the association has been built during the Open Life Science Cohort 4 (OLS-4) program. The webpage is in place, the contact addresses have also been created for communication with people. A small community has also started emerging. It is time that the community can expand. With the expanding community, it is now required that we create well-defined pathways for people to get onboard to the association. This project aims at building such pathways. Also, a basic Code of Conduct is already present on the RSE Asia webpage. It is to be modified to make it more appropriate for the Asian region.
+  keywords:
+  - Community Building
+  - Creating Pathway
+  - Onboarding
+  - modifying Code of Conduct
+  mentors:
+  - malvikasharan
+  name: Building Pathways for Onboarding to Research Software Engineering (RSE) Asia Association and Adoption of Code of Conduct
+  participants:
+  - jyoti-bhogal
+  - shubhamrj7
+- description: "We are to process bladder cancer RNA-Seq datasets that are publicly available. The co-authors of this manuscript will work on the analysis and apply bioinformatics methods for analysis of this large scale, heterogeneous RNA-sequencing dataset (20 + samples - 3Gb) that will be downloaded from any of the following databases; Genome Atlas (TCGA) database, Genotype-Tissue Expression (GTEx), cBio Cancer GenCancer Genomics Portal (cBioPortal) database and SRA NCBI database (choose any suitable database you are familiar with). The biological questions of particular interest include
+
+1. identification of differentially expressed transcripts (DEGs)
+
+2. pathways and gene networks
+
+3. hub genes associated with cancer progression  and recurrence
+
+4. small molecular identification 5) survival analysis.
+
+
+Open source software such as R/Bioconductor (DESeq2), Unix/Linux, Python and Jupyter notebook will be mainly used for the analyses."
+  keywords:
+  - RNA-Seq
+  - Bladder Cancer
+  - Transcriptomics
+  - Bioinformatics
+  mentors:
+  - malvikasharan
+  - yochannah
+  name: Transcriptomics profiling of bladder cancer using publicly available datasets
+  participants:
+  - babasaraki
+- description: Bioinformatics Secondary School Outreach (BSSO) is an initiative to develop bioinformatics capacity among High school students in Nigeria and this will create early interest in genomics data analysis among the students and equip them with the relevant skills and knowledge in Bioinformatics. Bioinformatics Hub Nigeria will be training these students on how to use Bioinformatics tools and pipelines and this can be achieved by establishing Bioinformatics research clubs in the visited schools to facilitate the trainings. We would be working alongside with other sister organizations to achieve this goal
+  keywords:
+  - Bioinformatics
+  - Students
+  - data analysis
+  mentors:
+  - meagdoh
+  name: Bioinformatics Secondary school Outreach in Nigeria
+  participants:
+  - emmanuel19-ada
+- description: The [OpenGHG project](https://github.com/openghg/openghg) is a NERC funded project that aims to be a community platform for greenhouse gas data science. There is currently no central platform for greenhouse gas / atmospheric chemistry researchers to access standardised data / workflows, or easily share and analyse their measurements. Currently our prototype service processes and standardises the raw measurement data taken from sensor networks worldwide (such as the [DECC](http://www.bris.ac.uk/chemistry/research/acrg/current/decc.html) and [AGAGE](https://agage.mit.edu/) networks), records associated metadata and makes this data searchable.  We are currently in the process of adding the ability to process data from other sources, such as satellite and meteorological models.
+  keywords:
+  - Greenhouse gases
+  - repeatable science
+  - data science
+  - data sharing
+  - data analysis
+  - open source
+  mentors:
+  - michael-addy
+  name: OpenGHG - a cloud platform for greenhouse gas data analysis and collaboration
+  participants:
+  - gareth-j
+- description: '**Visualization of participants by their countries**  I would like to work on a project ''Visualization of participants by their countries'' from the projects listed [here](https://github.com/open-life-science/open-life-science.github.io/issues/297).
+
+
+With this project, I would try to represent participants and mentors participating in OLS on the map by their countries, and year of participation. I am planning to achieve  this using [Mapbox](https://www.mapbox.com/about/maps/) and [OpenStreetMap](https://www.openstreetmap.org/about/).  When hovering over a particular flag we can see that particular participants/mentors all info which is listed [here](https://openlifesci.org/ols-4/projects-participants/#participants) or [this one](https://github.com/open-life-science/open-life-science.github.io/blob/main/_data/people.yaml).
+
+
+I would like to make something like [this](https://drive.google.com/file/d/1Ikd8Tylp_gpNi5Yt7ewqdJKqb4TcuMTG/view?usp=sharing) but would do a lot of brainstorming about design and representation. Also, we can add something like showing mentors vs ols-1/2/3/4 participants or showing number per country, or anything else creative.  The next step would be to implement this on the official site of OLS. I want to practice my coding and visualization skills through this project and would appreciate the opportunity to meet, interact and work with like-minded people.'
+  keywords:
+  - Data Visualization
+  - database
+  - web application
+  mentors:
+  - muhammetcelik
+  - burceelbasan
+  name: Visualisation of participants by their countries
+  participants:
+  - astroakanksha24
+- description: "In this project we want to develop and implement new ways of building, engaging and maintaining the community around the TU Delft Open Science MOOC. We are part of the teaching team of the TU Delft Open Science MOOC called: 'Open Science: sharing your research with the world'. The MOOC''s next run starts in [May 2022](https://www.edx.org/course/open-science-sharing-your-research-with-the-world).
+
+
+The course runs for 6 weeks and discusses a variety of open science topics, course materials are also available on [TU OpenCourseWare](https://ocw.tudelft.nl/courses/open-science-sharing-research-world/).
+
+
+The first Open Science MOOC started in 2018 and on average the course attracts about 1000 participants from an international environment.   As the course runs participants engage with the teachers and each other through discussion forums. Here they introduce themselves, post assignments, and share and reply to each other''s thoughts. While a few participants actively contribute and respond in  the fora, engagement is still quite limited. Moreover, there is not yet a  strategy in place to maintain the community after the course has finished.   We would like to strengthen the community building taking place during and after this course by implementing additional strategies to engage participants during the course run and keeping up with participants after the course has finished."
+  keywords:
+  - Open Science
+  - Community Building
+  - Open Education
+  - Engagement
+  mentors:
+  - pherterich
+  name: Build a community around the TU Delft Open Science MOOC
+  participants:
+  - alessandra-candian
+  - lisanne-walma
+- description: "Binderhub is a service that allows users to share reproducible interactive computing environments through public code repositories. The subject of our project, Hub23, is an organisational deployment of Binderhub, designed to allow Turing Researchers to use binder (the user interface) to collaborate on repositories internal to Turing. This is sometimes necessary if the underlying repository can not be shared for some reason, or is not yet ready to publish openly. During the OLS program, we aim to build an open community around Hub23 to help to guide future technical developments, and encourage use and contributions from the wider Turing community. We will host a series of Zero-to-Binder workshops aimed at introducing Turing researchers to regular binder, followed by structured discussion of what the ideal features of a collaborative reproducible environment for research would be. Any conclusions and subsequent technical development will be fed upstream to Binderhub, and we also aim to open source the methodologies used to create an internal binderhub deployment, allowing other organisations to do so."
+  keywords:
+  - Open Source
+  - Reproducibility
+  - Community
+  - Open Infrastructure
+  - Research
+  mentors:
+  - unode
+  name: "Hub23: An open source community and infrastructure for Turing's BinderHub"
+  participants:
+  - callummole
+  - lydiafrance
+- description: "We aim to build an online platform and community that allows open sharing, storage, and synthesis of clinical (meta)data, crucial for the development of modern, transdiagnostic, FAIR neuropsychology. First, published peer-reviewed papers will be scrapped to collect already available (meta)data. Second, our platform will allow direct uploading of clinical brain maps and their corresponding metadata.
+
+
+A basic automated preprocessing and data-quality check pipeline will be implemented. Key data will be automatically extracted, synthesized, and made available alongside the one directly uploaded. All the available demographic, behavioral, clinical, and cognitive data will be properly organized and mapped onto the neural data to allow statistical analysis (i.e., data-driven lesion-symptom mapping). Ultimately, probabilistic maps synthesizing transdiagnostic information on lesion-symptom mapping would be constantly updated as more data are gathered. To this end, data visualization will be critical (e.g. http://speechbrainviewer.com/). Overall, the platform will
+
+
+1. enable sharing of FAIR neuropsychological datasets across research centres and groups;
+
+2. foster understanding of the topographical distribution and morphological characteristics of brain lesions;
+
+3. allow large-scale, data-driven exploration of the associations between behavior and cognitive symptoms and brain regions."
+
+  keywords:
+  - neuropsychology
+  - neuroimaging
+  - data sharing
+  - cognitive neuroscience
+  - clinical neuroscience
+  - data
+    visualization
+  - meta-analysis
+  mentors:
+  - selgebali
+  name: Development of an Open Source Platform for the Storage, Sharing, Synthesis and Meta-Analysis of Clinical Data
+  participants:
+  - vborghe
+  - complexbrains
+  - pinheirochagas
+  - sladjana-lukic
+- description: 'Open science is vital for reproducible, fair, and rigorous research. For its principles to thrive, we need OS practices to be shared and adopted by as many scientists as possible, from the earliest stages of their career. A 2017 survey by the European Commission reports that, among 1277 researchers at all career stages, the majority were unaware of the OS concept, and had never attended an OS initiative (from the Open Science Skills Working Group Report, July 2017).
+
+
+For open research to become an established reality, those who are moving their first steps into research must have the opportunity to develop the necessary skillset to apply and disseminate the OS framework. "Open Science, Open Future" aims to be an educational resource to be used online by young scientists: undergraduates, MSc students, and potentially high-school pupils. The curriculum will consist of several modules explaining why each aspect of the OS practice can improve research and make it fairer (e.g. best practices in sharing protocols, storing data, publishing, collaborating). I''m the co-founder of a pan-european collective of scientists, http://biotop.co/, aiming at rethinking the way we do science. Fellow members are willing to take part to the project.'
+  keywords:
+  - open education
+  - student training
+  - community building
+  - educational resources
+  - neuroscience
+  mentors:
+  - saravilla
+  name: Open Science, Open Future
+  participants:
+  - mariangelap
+- description: 'Open Science for Improve diagnostics of Cancer through Artificial Intelligence and Digital Pathology.
+
+
+Cancer is becoming increasingly prevalent among the group of treatable diseases in African countries. In sub-Saharan Africa, only 10% of histopathology needs are met and this is a major barrier to comprehensive management of cancers
+
+
+1. There is a shortage of clinicians and pathologists available for cancer diagnosis and treatment. One of the critical factors in treatment efficiency is the correct and timely diagnosis of specimens by pathologists. However, there is currently a significant shortage of cancer care clinicians in Africa and an even more considerable shortage of pathologists. In Cameroon, there are 19 pathologists currently in practice for 22,179,707 inhabitants
+
+2. The absolute number of patients with cancer in Cameroon was estimated to be 25,000 cases a year.
+
+
+Diagnosis of cancer relies on histology in nearly 80% of cases, cytology in 10%, and clinical diagnosis in 10% (1). There is, therefore, an urgent need to develop a rapid, highly sensitive and diagnostic tool for the diagnosis of   cancers, to increase cancer treatment efficacy and reduce overtreatment of tumors clinically suspicious for malignancy.   We propose a hybrid diagnosis method with a deep Learning algorithm applied on hematoxylin and eosin histology slides. Digital microscopy and telepathology were already successfully used to mitigate the lack of pathologists in Cameroon, thus confirming the availability of a robust dataset for our project (1). Following splitting into training, validation and test sets, we will use CNNs as algorithms on the collected images to train the algorithm before deployment and tests. In addition to automated diagnostic, the developed program will have specific features such as sample information storage and tracking software as well as image optimization and analysis tools.
+
+1. Gruber-Mösenbacher, U., Katzell, L., McNeely, M., Neier, E., Jean, B., Kuran, A., & Chamala, S. (2021). Digital pathology in Cameroon. JCO Global Oncology, 7, 1380-1389.
+
+2. Ministry of Public Health (2017) Health analytical profile 2016 Cameroon. Ministry of Public Health, Cameroon, Yaounde.'
+  keywords:
+  - AI
+  - Cancer
+  - Diagnostics
+  - Digital pathology
+  mentors:
+  - sayalaruano
+  name: Open Science for Improve diagnostics of Cancer through Artificial Intelligence and Digital Pathology
+  participants:
+  - nodiraibrogimova
+  - jafsia
+  - fadanka
+  - agossoubido2021
+- description: The “AI for Science and Government” (ASG) programme at The Alan Turing Institute seeks to produce three community-led white papers that will capture the outcomes of research into deploying AI and data science in priority areas to support the UK's economy. The papers will also highlight advances in practices towards open and reproducible research in the fields of AI and data science. The process of authoring the white papers will itself be collaborative, open and transparent, soliciting contributions from the wider ASG community at every step of the way.
+  keywords:
+  - community management
+  - open and reprodicible data science
+  - Artificial Intelligence
+  - community white papers
+  mentors:
+  - yochannah
+  name: Cultivating a Community of Practice of AI researchers
+  participants:
+  - raoofphysics
+- description: "ARPHAI is an interdisciplinary research consortium, whose mission is to develop technological tools and recommendations to anticipate and manage epidemiological events. ARPHAI pilots data-driven open source tools using artificial intelligence and data science towards upgrading Argentina's electronic health record (EHR) system. ARPHAI is part of the [Global South AI4COVID Program](https://covidsouth.ai/).
+
+
+ARPHAI includes persons from 20  institutions. ARPHAI started in October 2020 and has grown very fast from scratch. More specifically, ARPHAI is piloting three EHR-based components in parallel to anticipate and detect potential epidemic outbreaks
+
+1. The extraction of computable phenotypes of diseases, symptoms, and syndromes using natural language processing to analyze EHR structured and free-text;
+
+2. Models for understanding and prediction of relevant epidemiological variables using computable phenotypes and open data information as input; and
+
+3. Dashboard visualization of the results from both points above, along with additional open data sources to inform decisions made by the public sector epidemiological authorities.
+
+
+There are two additional lines of work ARPHAI undertakes that are transversal to these three research developments, which include a) diversity, equity, and inclusion (DEI) with a focus on gender and b) responsible use of health data."
+  keywords: []
+  mentors:
+  - msundukova
+  name: Argentinean Public Health Research on Data Science and Artificial Intelligence for Epidemic Prevention (ARPHAI)
+  participants:
+  - veroxgithub
+  - slldec
+  - vickygisel
+  - federico-cestares
+  - lauracion
+- description: The project focuses on building tools to understand the evolution of life. We develop bioinformatic tools to determine evolutionary processes to detect early stage life development. The project looks at data from two specific parts of detecting life - co-evolution of life and environment and biosignature assessment within the context of habitability. We use data from current experimental projects and develop new models to aid the growth of astrobiology search for life. The platform will cater to multiple sections such as- data management from all astrobiology projects, experiments, research labs and conferences; new tools to analyse data, predictive model section to simulations from the data set and collaborative forum to encourage citizen science.The platform will help create open source bioinformatic tools to help detect biosignature, assess habitability, promote involvement within  astrobiology. In addition to using bioinformatic tools, a part of the platform will use game theory and gamification to test the citizen science component. Using both the platform as a destination for tool testing and science education, we hope to advance the research in astrobiology.
+  keywords:
+  - Bioinformatics
+  - data
+  - astrobiology
+  - biosignatures
+  - life evolution
+  - game theory
+  mentors: []
+  name: FarawayFermi - A platform for open source bioinformatic tools to detect biosignatures in astrobiology
+  participants:
+  - thatspacegirl
+  - sairajdillikar
+- description: "
+1. Scientific perspectives Depression is becoming more common mental illness caused by the complicate network of various extrinsic and intrinsic stimulators.For the healthier and happier brain status, three key diets such as Emotional,Physical, and Nutritional diets should be considered. Scientific researchers are mostly focusing on research in unraveling the key molecule associated the mechanism of depression. However, we need to pull and process more extensive dataset from individuals, public health, and professionals in psychology, nutrition science, physical science, and neuroscience to improve or treat the brain kept or recovered to the healthy status.
+
+2. Open science perspectives.   For comprehensive data, we need to build up the collaborative digital network with trust through benefiting to each participant to accelerate innovation from the open dataset. Effective collaboration tool or co-creation platform for the intersectoral collaboration would be required for the practice in this project."
+  keywords:
+  - Collaboration
+  - building trust
+  - intersectoral collaboration
+  - Emotional/Physical/Nutritional diet for brain
+  - global connectivity
+  - Digitalization
+  - Incentives to public and scientists
+  mentors: []
+  name: Open collaborative network and incentive system for brain health
+  participants:
+  - olsjuju

--- a/_data/people.yaml
+++ b/_data/people.yaml
@@ -6,6 +6,21 @@
 #
 # Mandatory: first-name, last-name, country
 ---
+0sahene:
+  affiliation: Carbon Footprint Development For Buildings In Ghana.  Phase 2
+  bio: I am a civil engineer with a drive to impact the knowledge sharing through
+    open science.
+  city: Tamale
+  country: Ghana
+  expertise:
+  - Civil engineer
+  - Construction
+  - Sustainability
+  first-name: Sitsofe
+  last-name: Morgah
+  orcid: 0000-0002-2985-9463
+  pronouns: He
+  twitter: 0sahene
 '0x174':
   affiliation: Boston University
   bio: I'm the primary Software Engineer at the DAMP Lab at Boston University, focusing
@@ -53,6 +68,23 @@ abdulelahsm:
   pronouns: he/him
   twitter: asmesfer
   website: https://abdulelahsm.github.io/about
+abraham-dabengwa:
+  affiliation: School Of Animal, Plant And Environmental Sciences, University Of The
+    Witwatersrand
+  bio: |-
+    Abraham is an ecological researcher based at the University of the Witwatersrand, Johannesburg, South Africa. He is interested in how climate, fire, and large mammal herbivores shape grassland and savanna ecosystems in space and time. This knowledge is valuable for assessing current ecological theory, guiding successful ecosystem conservation and restoration, and understanding roles of
+    humans in ecosystems.
+  city: Johannesburg
+  country: South Africa
+  expertise:
+  - Palaeoecology
+  - Savanna and grassland ecology
+  - Landscape ecology
+  first-name: Abraham
+  last-name: Dabengwa
+  orcid: 0000-0002-1568-5482
+  pronouns: he/ him
+  twitter: Nqabutho
 abretaud:
   affiliation: Inrae
   bio: Working on insect genomics/bioinformatics platforms, and regular contributor
@@ -136,6 +168,25 @@ agbeltran:
   orcid: 0000-0003-3499-8262
   twitter: alegonbel
   website: https://agbeltran.github.io/
+agossoubido2021:
+  affiliation: Mboalab
+  bio: Innovative, problems solver, community builder and team player, I hold two
+    masters degrees in computer sciences and information systems. I am interested
+    in contributing to solve community issues using ICT including cutting edge technologies
+    such as ML, AI, and IoT.
+  city: Abomey Calavi
+  country: Benin
+  expertise:
+  - Software design
+  - Data analysis
+  - Machine learning
+  - Artificial intelligence
+  - Iot
+  - Icd4d
+  first-name: Agossou
+  last-name: Bidossessi Emmanuel
+  pronouns: He/Him/His
+  website: https://http://bidossessi.atwebpages.com/
 aida-turing:
   affiliation: The Alan Turing Institute
   bio: I am a Research Application Manager at The Alan Turing Institute. It's a new
@@ -174,7 +225,7 @@ ajstewartlang:
     I am the University of Manchester Open and Reproducible Research Institutional
     Lead.
   city: Manchester
-  country: England
+  country: United Kingdom
   expertise:
   - Open research
   - Reproducibility
@@ -185,6 +236,64 @@ ajstewartlang:
   pronouns: he/him
   twitter: ajstewart_lang
   website: https://ajstewartlang.netlify.app/
+akalikadien:
+  affiliation: Tu Delft
+  bio: I am a first-year PhD student at the Inorganic Systems Engineering group of
+    TU Delft. In collaboration with an industry partner, I do research in data-driven
+    catalyst discovery.
+  city: Delft
+  country: Netherlands
+  expertise:
+  - Catalyst discovery
+  - Cheminformatics
+  - Quantum chemistry
+  - Chemical space exploration
+  - Data-driven catalysis
+  - Data science
+  - Python;
+  first-name: Adarsh
+  last-name: Kalikadien
+  orcid: ' 0000-0002-5414-3424'
+aleesteele:
+  affiliation: The Turing Institute, Turing Way
+  bio: I'm the incoming Community Manager for The Turing Way @ The Alan Turing Institute,
+    and an anthopologist by training. I was previously a Frictionless Data Reproducible
+    Research Fellow at the Open Knowledge Foundation, and am currently an Early Career
+    Fellow at the Internet Society. I also co-curate The Re:Source Project, which
+    aims to support labor movements in supply chains through open data. In my past
+    and present roles, I aim to contribute to the open ecosystem, and the research
+    and tools that enable it.
+  city: London
+  country: United Kingdom
+  expertise:
+  - Open knowledge
+  - Open source research
+  - Community-building
+  - (digital) social science
+  - Ethnography
+  - Anthropology
+  - Sociology;
+  first-name: Anne
+  last-name: Lee Steele
+  orcid: 0000-0002-9262-8641
+  pronouns: she/her
+  twitter: aleesteele
+  website: https://www.aleesteele.com
+alessandra-candian:
+  affiliation: Tu Delft
+  bio: Ex-astrochemist turned academic skills teacher. I am curious and talk a lot
+    (also with my hands!). I need coffee to function properly :)
+  city: Leiden
+  country: Netherlands
+  expertise:
+  - Information literacy
+  - Diversity equity and inclusion
+  - Astrochemistry;
+  first-name: Alessandra
+  last-name: Candian
+  orcid: 0000-0002-5431-4449
+  pronouns: She/Her
+  twitter: donnainfiorino
 alexandra-holinski:
   affiliation: EMBL-EBI
   bio: I am working as a Scientific Training Officer at EMBL-EBI and dedicate my work
@@ -270,6 +379,16 @@ anayan321:
   last-name: Opasawatchai
   pronouns: She, her
   twitter: Pk_star
+andre-vargas-de:
+  affiliation: Universidad Mayor De San Simón
+  city: Cochabamba
+  country: Bolivia
+  expertise:
+  - Editorial management
+  first-name: Alvaro Andre
+  last-name: Vargas Aguilar
+  orcid: 0000-0002-5409-8854
+  twitter: AndreVargasAgu1
 andreea-avramescu:
   affiliation: University Of Manchester/The Alan Turing Institute
   bio: My research interests lie in the fields of personalised medicine, optimisation,
@@ -533,7 +652,7 @@ arentkievits:
     cell biology and data science. My hobbies are guitar playing, music, swimming
     and reading.
   city: Delft
-  country: The Netherlands
+  country: Netherlands
   expertise:
   - Electron microscopy
   - Data science
@@ -587,6 +706,24 @@ ashutosh-tiwari:
   github: false
   last-name: Tiwari
   pronouns: He/him/his
+astroakanksha24:
+  bio: I’m a junior student pursuing a Bachelors’s in Computer science studies. I
+    am a Data Science and machine learning enthusiast. I like to travel , read, dance
+    and listen to taylor's music:)
+  country: India
+  expertise:
+  - Machine learning
+  - Data science
+  - Visualization
+  - Git/github
+  - Software development
+  - Community science
+  - Flutter
+  first-name: Akanksha
+  last-name: Chaudhari
+  orcid: 0000-0003-4045-9409
+  pronouns: She/ Her
+  twitter: Akanksh27024516
 augustincaitlin:
   affiliation: This Project Is Not Affiliated With My Workplace And I Am Doing It
     As An Independent Researcher
@@ -611,12 +748,111 @@ augustincaitlin:
   orcid: 0000-0001-5658-0946
   pronouns: she/her
   twitter: augustincaitlin
+aurigandrea:
+  affiliation: Alan Turing Institute
+  bio: I am a Training Officer at the Alan Turing Institute and a digital history
+    researcher at the New College of the Humanities. I'm interested in historical
+    mythmaking and misinformation.
+  expertise:
+  - Digital humanities
+  first-name: Andrea
+  last-name: Kocsis
+  orcid: 0000-0003-4270-3911
+  pronouns: she/her
+  twitter: aurigandrea
+ayeshadunk:
+  affiliation: The Alan Turing Institute
+  bio: Hi - I'm Ayesha and I'm interested in pedagogy and education; community building
+    and forming meaningful connections; and personal development and growth. I also
+    love cycling - (on-the-road, semi-competitive, all-the-gear-no-idea kind of cycling),
+    good food and a gripping crime drama series!
+  city: London
+  country: United Kingdom
+  expertise:
+  - Community building
+  - Open research
+  - Train the trainer
+  - Education
+  - Project development
+  - Data science and ai education
+  - Open source
+  - Scalability
+  - Sustainability
+  first-name: Ayesha
+  last-name: Dunk
+  orcid: 0000-0002-1033-208X
+  pronouns: She/her
+b14-rsa:
+  affiliation: Independent Researcher
+  bio: 'For fun: I am very into catch and release fly-fishing and fly tying as well
+    as other outdoor activities. I also do a number of crafts at varying degrees of
+    success! Academically: I am nearing submission of my joint Ph.D. between North
+    West University and Oslo University. I research sanitary and phytosanitary measures
+    (SPS) in the context of barriers to trade in the South African red-meat industry
+    with particular focus on the past and ongoing challenges that have arisen with
+    the outbreak of foot-and-mouth disease in the country. I have followed a mixed
+    methodology approach which includes qualitative research by means of semi structured
+    interviews and quantitative research by means of a content analysis entirely applied
+    through R programming. I am Zimbabwean born, but call Johannesburg (South Africa)
+    home at the moment.'
+  city: Johannesburg
+  country: South Africa
+  expertise:
+  - Law
+  - International trade
+  - Legal education
+  - Mixed methodology research
+  first-name: Biandri
+  last-name: Joubert
+  orcid: 0000-0002-3498-3581
+  pronouns: She/Her
+  twitter: biandri
 babasaraki:
-  affiliation: Universiti Putra Malaysia
-  country: Malaysia
+  affiliation: Bauchi State University, Gadau, Nigeria And Memorial University Of
+    Newfoundland, Canada.
+  bio: 'Umar Ahmad is currently the Head, Department of Anatomy at Bauchi State University,
+    Nigeria. He is also a founder and CEO of BioSeq, a bioinformatics company that
+    translates omics data into informative knowledge by providing quality high-throughput
+    sequencing (NGS) data analysis. His work in basic and translational research is
+    focused on developing targeted therapy for human bladder cancer, colon and lung
+    cancers with primary focus on genomics (WGS, WES) and transcriptomics (RNA-Seq,
+    scRNA-Seq, Microarray) data integration to investigate the regulatory pathways
+    that drive tumour recurrence and progression. Additionally, Umar works in an international
+    team of scholarly professionals at AfricArXiv - the pan-African Open Access portal
+    – towards increased discoverability of African research output. His role involves
+    facilitating manuscript submission moderation and quality assurance as well as
+    representing AfricArXiv at international meetings, events and webinars. At the
+    Science Communication Hub Nigeria, he supports a team that provides mentorship,
+    implements training and community building for the next generation of Nigerian
+    scientists. Umar is a fellow of Accelerating Science and Publication in Biology
+    (ASAPbio), a mentee and a member in The Carpentries community and a member of
+    Open Bioinformatics Foundation. He is  also the current Regional Coordinator (North
+    East) of the Nigerian Bioinformatics and Genomics Network (NBGN). Moreover, Umar
+    maintains a community of scientists who are passionate about bioinformatics in
+    a slack workspace called Bioinformatics Hub to facilitate sharing of bioinformatics
+    knowledge in Nigeria. (Link: https://docs.google.com/document/d/14ayo1wHRpDvF-L5yHaBHyEqXW29EqEApfCtf3F3xiq4/edit?usp=sharing)'
+  city: Bauchi
+  country: Nigeria
+  expertise:
+  - Anatomics
+  - Genetics
+  - Cancer
+  - Computational genomics
+  - Bioinformatics
+  - R
+  - Git/github
+  - Unix/linux
+  - Open science
+  - Preprints
+  - Data science
+  - Python (dataviz)
+  - Mentoring
+  - High-throughput sequencing.
   first-name: Umar
   last-name: Ahmad
-  twitter: babasaraki
+  orcid: ' 0000-0002-3216-5171'
+  pronouns: He/Him
+  twitter: babasaraki1
 bailey-harrington:
   country: United States
   first-name: Bailey
@@ -785,6 +1021,13 @@ billbrod:
   last-name: (William) Broderick
   pronouns: he/him
   twitter: wfbroderick
+birgül-çolak-al:
+  affiliation: Bezmialem Vakif University
+  city: Istanbul
+  country: Turkey
+  first-name: Birgül
+  last-name: Çolak-Al
+  orcid: 0000-0002-5219-309X
 biscuitnapper:
   bio: I am a UX (User Experience) designer whose practice centers on using service
     design methods to inclusively design digital experiences. My research focuses
@@ -882,7 +1125,7 @@ c-martinez:
     every project I have been involved, I have always learned something new, and I
     love that feeling of discovering new things.
   city: Amsterdam
-  country: The Netherlands
+  country: Netherlands
   expertise:
   - Software sustainability
   - FAIR software
@@ -895,18 +1138,19 @@ c-martinez:
   website: https://www.esciencecenter.nl/team/dr-carlos-martinez-ortiz/
 callummole:
   affiliation: The Alan Turing Institute
-  bio: Callum is a Research Data Scientist at the Alan Turing Institute. A cognitive
-    scientist by training, he is interested in promoting practices that support reproducible
-    and open science.
+  bio: I am a Research Data Scientist at the Alan Turing Institute. An experimental
+    psychologist by training, I moved to the research engineering group to be part
+    of research projects that are more focussed on being open and reproducible!
+  city: London
   country: United Kingdom
   expertise:
   - Open infrastructure
-  - Reproducible science
-  - Open source
+  - Open science
+  - Reproducibility
   first-name: Callum
   last-name: Mole
   orcid: 0000-0002-1463-6419
-  pronouns: he/his
+  pronouns: He/Him
   twitter: CallumDMole
 camachoreina:
   affiliation: Cnrs/Cern. Co-Coordinator Of La-Conga Physics
@@ -929,6 +1173,18 @@ camachoreina:
   pronouns: She/her
   twitter: rcamachotoro
   website: https://camachoreina.github.io
+camila-gómez:
+  bio: |-
+    I am a cheerful person,  and the last year I have to learned to have more patience to deal with various situations in my life
+    I have been able to count on the support of my friends
+  city: Cochabamba
+  country: Bolivia
+  expertise:
+  - Health
+  - Pediatrics
+  first-name: Camila
+  last-name: Gómez
+  orcid: 0000-0001-7642-6049
 cassgvp:
   affiliation: University Of Oxford
   bio: I've been promoting open science since 2018 (formalised with OLS-1!), and in
@@ -979,6 +1235,24 @@ cbolibaugh:
   pronouns: she/her
   twitter: CBolibaugh
   website: https://www.york.ac.uk/education/research/eros/
+cel31:
+  affiliation: University Pompeu Fabra
+  bio: "I am an early career researcher with a deep interest in past plant technology\
+    \ and \nresponsible research. My research aims at identifying plant fibre remains\
+    \ preserved in \narchaeological contexts and in museum collections. For this,\
+    \ I combine micro (comparative \nanatomy, phytoliths) and macro studies (plant\
+    \ morphology and indigenous/local knowledge) \nwith data gathered from experimental\
+    \ archaeology"
+  city: Barcelona
+  country: Spain
+  expertise:
+  - Archaeobotany
+  - Plant comparative anatomy
+  - Phytolith studies
+  - Ethnobotany
+  first-name: Celine
+  last-name: Kerfant
+  orcid: 0000-0002-4297-5469
 cemonks:
   affiliation: University Of Western Australia
   bio: Carly is a Senior Technician at the University of Western Australia, responsible
@@ -1057,7 +1331,8 @@ chucklesongithub:
   twitter: ChuckleScience
   website: https://ceci.herbert.com.ar
 cl379:
-  affiliation: Department Of Humanities, Universitat Pompeu Fabra And Icrea
+  affiliation: Universitat Pompeu Fabra And Icrea
+  bio: Archaeobotanist and ethnoarchaeologist interested in dryland agriculture
   city: Barcelona
   country: Spain
   expertise:
@@ -1065,9 +1340,36 @@ cl379:
   first-name: Carla
   last-name: Lancelotti
   orcid: 0000-0003-1099-7329
-  pronouns: She/her
+  pronouns: she-her
   twitter: cl379
   website: https://www.icrea.cat/Web/ScientificStaff/carla-lancelotti-353040
+codito22:
+  bio: I love learning
+  city: Lima
+  country: Peru
+  first-name: Rodrigo
+  last-name: Gallegos
+complexbrains:
+  affiliation: University Of Reading, Uk
+  bio: I hold a Pure Mathematic degree and currently I am a PhD Student at University
+    of Reading, working on investigation of the changes in the complex brain networks
+    with learning. I am passionately dedicated to open, diverse, transparent and inclusive
+    scientific research and I am heavily involved in its fair dissemination across
+    the community. For which I am one of the proud members and leads of the Brainhack
+    Global organization, which is one of the biggest open and interdisciplineary neuroscience
+    organization that brings researchers, students and public from various background,
+    skill and career level to run trainings, workshops and hacking sessions around
+    new ideas to make the science accesssible for everyone!
+  city: Reading
+  country: United Kingdom
+  expertise:
+  - Computational sciences
+  - Neuroscience
+  first-name: Isil Poyraz
+  last-name: Bilgin
+  orcid: 0000-0003-3600-7004
+  pronouns: She/her
+  twitter: complexbrains
 coopersmout:
   affiliation: Institute For Globally Distributed Open Research And Education
   bio: I studied psychology in my undergraduate degree (University of Queensland,
@@ -1117,6 +1419,16 @@ da5nsy:
   pronouns: he/him
   twitter: da5nsy
   website: https://dannygarside.co.uk
+danae-carelis-davila-espinoza:
+  bio: "Medical student\nAssociate editor of the Journal of the scientific society\
+    \ of medical students of the Universidad Mayor de San Simón \"Revista Científica\
+    \ Ciencia Médica\" \nJunior Researcher \nAuxiliary of the journal of the faculty\
+    \ of medicine of the Universidad Mayor de San Simón"
+  country: Bolivia
+  first-name: Danae Carelis
+  last-name: Davila Espinoza
+  orcid: 0000-0002-0877-5041
+  twitter: CarelisDavila
 dannycolin:
   affiliation: Université de Montréal
   country: Canada
@@ -1124,6 +1436,22 @@ dannycolin:
   last-name: Colin
   pronouns: he/him
   twitter: dannycolincom
+darwin-diaz:
+  affiliation: Utec
+  bio: I am a senior Bioengineering student at UTEC in Peru. I have been part of research
+    projects involving synthetic biology and biomaterials. With knowledge of bioinformatics
+    and analysis programs. I enjoy sharing science and technology to students through
+    my participation in open programs like volunteers and organizations that promotes
+    research and curiosity.
+  city: Lima
+  country: Peru
+  expertise:
+  - Synthetic biology
+  - Biomaterials.
+  first-name: Darwin
+  last-name: Diaz
+  orcid: 0000-0002-7560-3776
+  pronouns: She/Her
 dasaderi:
   bio: Daniela is a Neuroscientist with a passion for open, equitable, and transparent
     scholarship. She is a former Mozilla Fellow, and she now leads a project called
@@ -1344,6 +1672,17 @@ ecsalomon:
   pronouns: they/them
   twitter: ecsalomon
   website: https://erikasalomon.com
+eirinibotsari:
+  bio: Highly motivated, inspired, and passionate to the open science and open scholarship
+    movement. It is one of my greatest values and interests engaging people on discussing
+    topics, curating, and organising discussions and events. I am deeply curious and
+    invested in continuous learning and self-growth.
+  city: Dem Haag
+  country: Netherlands
+  first-name: Eirini
+  last-name: Botsari
+  pronouns: she/her
+  twitter: eirini_botsari
 ekaroune:
   affiliation: The Alan Turing Institute
   bio: I'm an Open Archaeobotanist specialising in phytolith research. I'm currently
@@ -1354,16 +1693,14 @@ ekaroune:
   city: Portsmouth
   country: United Kingdom
   expertise:
-  - Environmental Archaeology
-  - Palaeoecology
-  - FAIR
-  - Collaborative working
-  - Open workflows
-  - Reproducibility
+  - Fair data
+  - Phytoliths
+  - Environmental archaeology
+  - Palaeoecology.
   first-name: Emma
   last-name: Karoune
   orcid: 0000-0002-6576-6053
-  pronouns: She/her
+  pronouns: She, her
   twitter: ekaroune
   website: https://ekaroune.github.io/Open-Science-in-Phytolith-Research/
 ekeluv:
@@ -1381,7 +1718,7 @@ elisa-rodenburg:
     Manager (maternity cover). In her job, Elisa supports researchers and other support
     staff with RDM and Open Science.
   city: Amsterdam
-  country: The Netherlands
+  country: Netherlands
   expertise:
   - Generic data stewards
   - Research data management
@@ -1447,19 +1784,13 @@ emma-lawrence:
   website: https://biobankinguk.org/
 emmanuel19-ada:
   affiliation: Helix Biogen Institute
-  bio: "Emmanuel Adamolekun currently is Research assistant  at Helix Biogen Institute,\
-    \ he graduated with a Bachelor's degree in Medical Laboratory Science from the\
-    \ Prestigious Ladoke Akintola University of Technology, Ogbomosho, Oyo State,\
-    \ Nigeria. \nHe is passionate about the role of Laboratory Medicine, Molecular\
-    \ Medicine and Research in Global Health, Infectious Diseases prevention, Global\
-    \ Vaccination and Health systems strengthening."
+  bio: I love Science
   city: Ogbomosho
   country: Nigeria
   expertise:
   - Bioinformatics
+  - Genomics
   - Science communication
-  - Immunology
-  - Infectious diseases
   first-name: Emmanuel
   last-name: Adamolekun
   orcid: 0000-0003-2992-5448
@@ -1470,7 +1801,7 @@ emmyft:
   bio: Emmy is the Community Engagement Manager for the TU Delft Open Science Programme.
     She is passionate and curious about open, research culture and knowledge equity.
     Her expertise is in community design, and open research and scholarly communication.
-  country: The Netherlands
+  country: Netherlands
   expertise:
   - Community strategies
   - Open research
@@ -1479,6 +1810,14 @@ emmyft:
   orcid: 0000-0002-9248-1280
   pronouns: she/her
   twitter: emmy_ft
+esbusis:
+  affiliation: Bezmialem Vakif University
+  bio: I am a research assistant, also a MSc student on bioinformatics.
+  city: Istanbul
+  country: Turkey
+  first-name: Esra Büşra
+  last-name: Işık
+  orcid: 0000-0003-3414-8575
 estherplomp:
   affiliation: Delft University Of Technology - Faculty Of Applied Sciences
   bio: Esther works as a Data Steward at Delft University of Technology (Faculty of
@@ -1487,7 +1826,7 @@ estherplomp:
     Esther did a PhD in bioanthropology, studying the isotopic composition of human
     teeth to determine where they grew up.
   city: The Hague
-  country: The Netherlands
+  country: Netherlands
   expertise:
   - Open protocols
   - Open data
@@ -1508,6 +1847,19 @@ evacherbst:
   last-name: Herbst
   pronouns: she/her
   twitter: EvaCHerbst
+evelyngreeves:
+  affiliation: University Of York; Software Sustainability Institute
+  country: United Kingdom
+  expertise:
+  - Omics
+  - Environmental biotechnology
+  - Training
+  - Community building
+  first-name: Evelyn
+  last-name: Greeves
+  orcid: 0000-0003-4800-3422
+  pronouns: she/her
+  website: https://cloud-span.york.ac.uk/
 ewa-leś:
   affiliation: Coalition Clean Baltic (Ccb)
   bio: |-
@@ -1591,6 +1943,54 @@ fabienne-lucas:
   pronouns: she/hers
   twitter: DrFabLucas
   website: https://www.misetrfc.com
+fadanka:
+  affiliation: Mboalab Biotech, Beneficial Bio, Open Bioeconomy Lab
+  bio: I'm a Biotechnologist and molecular biology researcher based in Cameroon. Afiliated
+    to Mboalab, beneficial.bio,  and Open Bioeconomy Lab. My research interest include
+    Molecular diagnostic, microbiology, plant biotechnology and synthetic biology.
+    I'm also a Maker passionate about artificial intelligence and a fervent advocate
+    of Open Science and research in Africa with special focus on distributed manufacturing.
+  city: Yaounde
+  country: Cameroon
+  expertise:
+  - Molecular biology
+  - Synthethic biology
+  - Molecular diagnostics
+  first-name: Stephane
+  last-name: Fadanka
+  orcid: ' 0000-0003-1807-2523'
+  twitter: StephaneFadanka
+farukustunel:
+  affiliation: Bezmiâlem Vakıf University
+  city: Istanbul
+  country: Turkey
+  expertise:
+  - Bioinformatics
+  - Viral informatics
+  - Viral immunology
+  - Immunoinformatics
+  first-name: Faruk
+  last-name: Üstünel
+federico-cestares:
+  affiliation: Ciecti - Arphai
+  bio: I'm a university technician in International Relations from the National University
+    of Lanús (UNLa)- currently - am studying for a bachelor's degree in Integration
+    Processes and International Economic Relations at the same university. I have
+    experience as a consultant in research projects financed by international organizations
+    such as the Inter-American Development Bank and the World Bank (IADB-IBRD). He
+    currently works as a Semi-Senior research assistant at CIECTI-UIME and an operational
+    assistant for the coordination of technological tools for the ARPHAI project.
+  city: Buenos Aires
+  country: Argentina
+  expertise:
+  - International relations
+  - Development economics
+  first-name: Federico
+  last-name: Cestares
+  orcid: 0000-0002-7443-3314
+  pronouns: He- él
+  twitter: fecestares
+  website: https://Don't have
 fnyasimi:
   affiliation: International Centre of Insect Physiology and Ecology (ICIPE)
   bio: Festus is a bioinformatician interested in community outreach, open science
@@ -1622,12 +2022,62 @@ fpsom:
   pronouns: He/him
   twitter: fopsom
   website: https://fpsom.github.io/
+frédérique-belliard:
+  affiliation: Tu Delft Open Publishing
+  bio: Frédérique is the publishing officer of TU Delft OPEN Publishing, the open
+    access academic publisher of TU Delft. Her role consists of helping researchers
+    to disseminate their research openly though various streams such as Open Access
+    Books, Open Access textbooks and Open access journals. She is an advocate of open
+    science, open peer-review and fair rewards &recognition.
+  city: Delft
+  country: Netherlands
+  expertise:
+  - Open publishing
+  - Open access
+  - Open peer review
+  - Scholarly communication
+  first-name: Frédérique
+  last-name: Belliard
+  orcid: 0000-0001-8750-7207
+  pronouns: she/her
+  twitter: fredbelliard
+  website: https://www.linkedin.com/in/fredbelliard/
+gabimusaubach:
+  affiliation: National University Of Jujuy. National Scientific And Technical Research
+    Council - Argentina
+  bio: I currently work at National University of Jujuy and the National Scientific
+    and Technical Research Council - Argentina.  Most of my work has focused on the
+    archaeobotanical study of ancient starch and phytoliths from dental calculus,
+    ceramic residues and sediments in pre-Hispanic sites in Argentina.
+  country: Argentina
+  expertise:
+  - '"phytolith analysis"'
+  - '" pre-hispanic archaeology"'
+  - '"archaeobotany"'
+  - '"ancient starch analysis"'
+  first-name: Maria Gabriela
+  last-name: Musaubach
+  orcid: 0000-0002-6770-7145
+  twitter: Gabi Musa
+  website: https://www.conicet.gov.ar/new_scp/detalle.php?id=28034&keywords=MUSAUBACH%2BMARIA%2BGABRIELA&datos_academicos=yes
 ganleyemma:
   affiliation: protocols.io
   country: United Kingdom
   first-name: Emma
   last-name: Ganley
   twitter: GanleyEmma
+gareth-j:
+  affiliation: University Of Bristol
+  bio: I'm a Research Software Engineer based in Bristol working on a cloud platform
+    for data sharing and analysis.
+  city: Bristol
+  country: United Kingdom
+  expertise:
+  - Research software engineer
+  first-name: Gareth
+  last-name: Jones
+  pronouns: He/ Him
+  website: https://www.openghg.org
 gedaloop:
   affiliation: Independent Researcher
   bio: Lifelong translator, former Digital Collaboration Consultant, with experience
@@ -1671,6 +2121,23 @@ gedankenstuecke:
   pronouns: he/him
   twitter: gedankenstuecke
   website: https://tzovar.as
+gemmaturon:
+  affiliation: Ersilia Open Source Initiative
+  bio: My background is in molecular biology, and I'm passionate about making science
+    accessible and reusable. As cofounder of the Ersilia Open Source Initiative, I
+    work to support research for infectious and neglected diseases using data science
+    and machine learning.
+  city: Cambridge
+  country: United Kingdom
+  expertise:
+  - Machine learning
+  - Infectious diseases
+  - Drug discovery;
+  first-name: Gemma
+  last-name: Turon
+  pronouns: she/her
+  twitter: https://twitter.com/TuronGemma
+  website: https://ersilia.io
 georgiahca:
   affiliation: The Alan Turing Institute
   bio: I am a researcher at The Alan Turing Instiitute working on co-creating a citizen
@@ -1679,7 +2146,7 @@ georgiahca:
     a believer in creating a collaborative over competitive work ethos, equity, and
     open research.
   city: London
-  country: England
+  country: United Kingdom
   expertise:
   - Citizen science
   - Participatory science
@@ -1709,7 +2176,7 @@ gill-francis:
     explores novel explanations to understanding why children play and how early years
     playful engagement impacts later development.
   city: York
-  country: England
+  country: United Kingdom
   expertise:
   - Child development
   - Cognitive psychology
@@ -1833,7 +2300,7 @@ hdinkel:
 hexylena:
   affiliation: Eramus Medical Centre
   city: Rotterdam
-  country: The Netherlands
+  country: Netherlands
   first-name: Helena
   last-name: Rasche
   twitter: hexylena
@@ -2012,11 +2479,19 @@ isahmadbbr:
   website: https://hausanlp.github.io/author/ibrahim-said-ahmad/
 ismael-kg:
   affiliation: The Alan Turing Institute
+  bio: Currently studying towards a MSc in philosophy of the social sciences at the
+    LSE. Curious about the values that drive human action, and the nature of collaboration.
+  city: London
   country: United Kingdom
+  expertise:
+  - History of science
+  - Philosophy of the social sciences
+  - Philosophy of science
   first-name: Ismael
   last-name: Kherroubi Garcia
-  pronouns: he/his
-  twitter: ismaelkhergar
+  orcid: 0000-0002-6850-8375
+  pronouns: He/him
+  twitter: hermeneuticist
 ivotron:
   affiliation: Uc Santa Cruz
   bio: Research Scientist at UC Santa Cruz, Incubator Fellow at the UC Santa Cruz
@@ -2037,6 +2512,22 @@ ivotron:
   pronouns: he/him
   twitter: ivotron
   website: https://ivotron.me
+jafsia:
+  affiliation: Mboalab
+  bio: JAFSIA is a member of the MboaLab AI team  working on reliable, interpretable,
+    and steerable AI projects mainly focused on diseases diagnosis.
+  city: Yaounde
+  country: Cameroun
+  expertise:
+  - Machine learning
+  - Deep learning
+  - Healtcare
+  first-name: Elisee
+  last-name: Jafsia
+  orcid: my-orcid?orcid=0000-0001-9262-4053
+  pronouns: He/his/him
+  twitter: euclude
+  website: https://www.mboalab.africa
 jasonjwilliamsny:
   bio: Jason is a life scientist who spends most of his time working to help researchers
     adopt computational practices in research and education
@@ -2200,6 +2691,25 @@ jezcope:
   pronouns: he/him
   twitter: jezcope
   website: https://erambler.co.uk
+jhon-anderson-pérez-silva:
+  affiliation: Scihack Community Bio Lab
+  bio: Senior student of Genetics & Biotechnology at UNMSM, Peru. Member of MikuyTec
+    synbio research group, member of Computational Biophysics Lab at UNIFAL-MG, Brasil
+    and president of SciHack, a DIY Bio community lab aiming to democratize biotechnology.
+  city: Lima
+  country: Peru
+  expertise:
+  - Computational biology
+  - Bioinformatics
+  - Python
+  - R
+  - Structural biology
+  first-name: Jhon Anderson
+  last-name: Pérez Silva
+  orcid: 0000-0003-4163-7844
+  pronouns: He/him
+  twitter: https://twitter.com/JhonPrz6
+  website: https://www.instagram.com/scihack/
 jmmaok:
   bio: A project lead in Cohort 3, Jennifer Miller has a M.S. in Technical Communication
     and a PhD in Public Policy. She has 10+ years post-secondary teaching experience
@@ -2332,6 +2842,18 @@ joyceykao:
   pronouns: she/her
   twitter: joyceykao
   website: https://jykao.com/
+jruizperez:
+  affiliation: Texas A&M University
+  city: College Station
+  country: United States
+  expertise:
+  - Archaeobotany
+  - Palaeoecology
+  - Phytolith analysis
+  first-name: Javier
+  last-name: Ruiz-Pérez
+  orcid: 0000-0001-8593-7393
+  twitter: J_Ruiz_Perez
 jsheunis:
   affiliation: Research Center Juelich, Germany
   bio: Stephan is passionate about brains, accessible education, and making scientific
@@ -2370,19 +2892,61 @@ juan-josé-garcía-granero:
   last-name: García-Granero
   orcid: 0000-0002-7546-2176
   pronouns: He/him/his
+juanjo-garcía-granero:
+  affiliation: Spanish National Research Council
+  city: Barcelona
+  country: Spain
+  first-name: Juanjo
+  last-name: García-Granero
+  orcid: 0000-0002-7546-2176
+  pronouns: he/his
+jvillcavillegas:
+  affiliation: Universidad Mayor De San Simon
+  bio: Proactive, Courageous, Positive
+  city: Bolivia
+  country: Bolivia
+  expertise:
+  - Management of open journal systems (ojs)
+  - Scientific production edition
+  - Statistical data management
+  first-name: Jose Luis
+  last-name: Villca Villegas
+  orcid: my-orcid?orcid=0000-0002-0357-5489
+  pronouns: Bolivia
+  twitter: https://twitter.com/villca_villegas
+  website: https://jose-luis-villca-villegas.netlify.app/
 jyoti-bhogal:
-  bio: I am trained in the discipline of Statistics. I have an experience in the field
-    of Biostatistics and Designing Clinical Trials. I have been working on Software
-    Testing for the same.
-  city: Pune
+  bio: I am trained formally in Statistics. I have worked as a Software Quality Engineer
+    - Statistician.
+  city: Ahmednagar, Maharashtra
   country: India
   expertise:
-  - Biostatistics
-  - Statistical designs of clinical trials via simulation
+  - Statistics
+  - Computation
+  - Software quality testing
   first-name: Jyoti
   last-name: Bhogal
-  pronouns: She/Her
-  twitter: https://twitter.com/JyotiBhogal7
+  orcid: ' 0000-0002-6289-0737'
+  pronouns: she/her
+  twitter: JyotiBhogal7
+  website: https://rse-asia.github.io/RSE_Asia/
+k-c-martin:
+  affiliation: Stellenbosch University
+  bio: PhD in Biomedical Science (with a background in mammalian tissue engineering),
+    with a deep appreciation for living systems at all scales, and an optimism about
+    the lessons that humanity can take from Nature.
+  city: Stellenbosch
+  country: South Africa
+  expertise:
+  - Forestry
+  - Xylogenesis
+  - Wood formation
+  - Tissue development
+  - Cell biology
+  first-name: Kim
+  last-name: Martin
+  orcid: http://orcid.org/0000-0002-3052-461X
+  website: https://blogs.sun.ac.za/eucxylo/the-team/#kim-martin
 k8hertweck:
   affiliation: Chan Zuckerberg Initiative
   bio: 'Kate Hertweck is a scientist and educator who endeavors to uphold core values
@@ -2717,25 +3281,26 @@ lauracarter:
   twitter: LauraC_rter
   website: https://lauracarter.github.io/
 lauracion:
-  affiliation: University Of Buenos Aires - Conicet
-  bio: I am a tenured adjunct researcher leading a health data science group. I also
-    work to improve data analysis teaching and practice. One of the roles I enjoy
-    most is mentoring and teaching others. I am a trainer and instructor for The Carpentries.
-    In 2020, I co-founded MetaDocencia, an open, collaborative, and Spanish-speaking
-    education community.
-  city: Buenos Aires
+  affiliation: Conicet - Universidad De Buenos Aires
+  bio: I am a tenured researcher leading a collaborative health data science research
+    group. I also work to improve data analysis teaching and practice. I co-founded
+    MetaDocencia, an open, collaborative, and Spanish-speaking education community.
+    One of the roles I enjoy most is mentoring and teaching others.
+  city: Ciudad Autónoma De Buenos Aires
   country: Argentina
   expertise:
-  - Health data science and artificial intelligence/Biostatistics
-  - Addiction research
+  - Ethics in artificial intelligence
+  - Health data science
+  - Responsible use of data
+  - Latin america
   - Open education
   - Community building
   first-name: Laura
   last-name: Ación
   orcid: 0000-0001-5213-6012
-  pronouns: she/her
+  pronouns: she/ella
   twitter: _lacion_
-  website: https://lacion.rbind.io
+  website: https://http://lacion.rbind.io/
 laurichi13:
   affiliation: IMDEA Food Institute
   country: Spain
@@ -2782,6 +3347,25 @@ lisanna:
   pronouns: She/they
   twitter: LisannaPaladin
   website: https://lisanna.github.io/
+lisanne-walma:
+  affiliation: Tu Delft
+  bio: I have a background in both Pharmacy and History, and I combined these fields
+    during my PhD, where I text-mined digitized newspapers to analyze historical debates
+    on morphine. I have always had a passion for education, which is why I am so happy
+    to be working as an open science and academic skills teacher at TU Delft library
+    since 2021. I am excited to join this community and learn more about open science!
+  city: Delft
+  country: The Netherlands
+  expertise:
+  - Information literacy
+  - Teaching
+  - History of medicine
+  - Basic text-mining
+  first-name: Lisanne
+  last-name: Walma
+  pronouns: she/her
+  twitter: lisannewalma
+  website: https://www.linkedin.com/in/lisannewalma/
 lomaxboydphd:
   affiliation: The Rockefeller University
   bio: Geneticist, educator, and filmmaker with experience spanning neuroscience,
@@ -2905,6 +3489,24 @@ lydia-france:
   github: false
   last-name: France
   orcid: 0000-0003-4392-568X
+lydiafrance:
+  affiliation: Alan Turing Institute
+  bio: I'm Lydia, my background is in Zoology and the aerodynamics/control of bird
+    flight. I recently joined the Alan Turing Institute as a research data scientist
+    and have great interest in education and awareness of reproducibility in science
+    and research. I'm a self taught programmer and have been involved with Software
+    Carpentries and The Turing Way
+  city: London
+  country: United Kingdom
+  expertise:
+  - Life sciences
+  - Research software engineering
+  - Binder
+  - Biology
+  - Zoology
+  first-name: Lydia
+  last-name: France
+  orcid: ' 0000-0003-4392-568X'
 macelik:
   affiliation: Bezmialem Vakif University
   bio: He is a PhD student and his general interest lies in developing and applying
@@ -2988,7 +3590,7 @@ malvikasharan:
   last-name: Sharan
   orcid: 0000-0001-6619-7369
   pronouns: she/her
-  twitter: MalvikaSharan
+  twitter: malvikasharan
 manulera:
   affiliation: Institut Curie
   bio: During my PhD, I used genetics, imaging and modelling to study the mitotic
@@ -3028,6 +3630,35 @@ margaret-wanjiku:
   github: false
   last-name: Wanjiku
   twitter: meg_wanjiku
+maria-andrea-gonzales-castillo:
+  bio: Maria Andrea Gonzales is a 4th year Bioengineering undergraduate in UTEC (Lima,
+    Peru). She is currently working in a variety of biotechnology research projects
+    as well as science communication projects. Maria Andrea is passionate about the
+    application of synthetic biology and protein engineering for the development of
+    open-source therapeutics as well as a sustainable food industry.
+  city: Lima
+  country: Peru
+  expertise:
+  - Synthetic biology
+  - Biotechnology;
+  first-name: Maria Andrea
+  last-name: Gonzales Castillo
+  orcid: 0000-0003-0842-1961
+  pronouns: She/Her
+mariangelap:
+  affiliation: Istituto Italiano Di Tecnologia
+  bio: Neurophysiologist passionate about communicating the beauty of science and
+    making research accessible and reproducible.
+  city: Genova
+  country: Italy
+  expertise:
+  - Neuroscience
+  first-name: Mariangela
+  last-name: Panniello
+  orcid: 0000-0002-1837-6116
+  pronouns: she/her
+  twitter: marpamondo
+  website: https://www.iit.it/it/people-details/-/people/mariangela-panniello
 markuskonk:
   affiliation: University Of Twente, Itc
   bio: I received my PhD from the Institute for Geoinformatics at the University of
@@ -3258,6 +3889,27 @@ mesfind:
   pronouns: he/him
   twitter: mesfindiro
   website: https://mesfind.github.io
+mgawe-cavin:
+  bio: Research student developing point of care diagnostic tool for malaria, He's
+    enthusiast of open science tools with skills in R programing and other open access
+    software for bioinformatic analysis
+  city: Nairobi, Kenya
+  country: Kenya
+  expertise:
+  - Molecular biology
+  - Lamp assay
+  - Strand displacement probes
+  - Multiple sequence alignment
+  - Principle component analysis using r
+  - Primers design
+  - Multiple sequence alignment using r package msa
+  - Invitro culture of pf3d7
+  - Open access publication
+  first-name: Cavin
+  last-name: Mgawe
+  orcid: ' 0000-0002-6546-3108'
+  pronouns: He
+  twitter: CavinMgawe
 michael-addy:
   affiliation: Kwame Nkrumah University Of Science And Technology
   bio: I am lecturer in Kwame Nkrumah University of Science and Technology (KNUST)
@@ -3483,6 +4135,21 @@ myreille-larouche:
   first-name: Myreille
   github: false
   last-name: Larouche
+nadia-odaliz-chamana-chura:
+  affiliation: Scihack
+  bio: A biohacker in progress
+  city: Lima
+  country: Peru
+  expertise:
+  - Synthetic biology
+  - Environmental biotechnology
+  - Food industry
+  - Scientific communication
+  first-name: Nadia Odaliz
+  last-name: Chamana Chura
+  orcid: 0000-0002-9429-2459
+  pronouns: She/her/hers
+  website: https://www.instagram.com/scihack/
 nadinespy:
   affiliation: University Of Sussex
   city: Brighton
@@ -3511,12 +4178,42 @@ natty2012:
   last-name: Natabona Mukhongo
   pronouns: she/her
   twitter: hnatabona
+nea-bridget:
+  affiliation: The Alan Turing Institute
+  bio: Background working in NGOs across campaigns, training and skills policy, currently
+    situated in the Turing Institute. I'm passionate about transparency, equity and
+    aim to carry this across my professional and personal life. I love sea swimming
+    and very loud music!
+  city: London
+  country: United Kingdom
+  expertise:
+  - Learning and development
+  - Project management
+  - Training and skills
+  first-name: Bridget
+  last-name: Nea
+  pronouns: she/her/hers
 nehamoopen:
   country: The Netherlands
   first-name: Neha
   last-name: Moopen
   pronouns: she/her
   twitter: NehaMoopen
+nelson-franco:
+  affiliation: 'Universidad Mayor De San Simón Facultad De Medicina: Cochabamba, Bolivia'
+  bio: Valentia, Honradez y Respeto
+  city: Cochabamba
+  country: Bolivia
+  expertise:
+  - |-
+    Area de investigación: ciencias de la salud y gestión editorial
+    temas con los que puedo ayudar: temas referente a la promoción de la salud y edición de revistas en bolivia
+  first-name: Nelson Franco
+  last-name: Condori Salluco
+  orcid: 0000-0002-8457-8226
+  pronouns: Nelson
+  twitter: Nelson Franco Condori Salluco
+  website: https://No disponible
 nerantzis:
   bio: Physicist, Teacher, Mozillian
   country: Greece
@@ -3543,6 +4240,30 @@ nihan-sultan-milat:
   github: false
   last-name: Milat
   twitter: MilatNihan
+nihansultan:
+  affiliation: Bezmialem Vakıf University
+  city: İstanbul
+  country: Turkey
+  expertise:
+  - Molecular biology
+  first-name: Nihan Sultan
+  last-name: Milat
+  twitter: MilatNihan
+  website: https://nihansultan.github.io/MBio/
+nodiraibrogimova:
+  bio: A Machine Learning enthusiast willing to learn, share and giving back to the
+    community with soft & tech skills.
+  city: Tashkent
+  country: Uzbekistan
+  expertise:
+  - Python
+  - Machine learning
+  - Angular;
+  first-name: Nodira
+  last-name: Ibrogimova
+  orcid: 0000-0003-1749-6957
+  pronouns: She/Hers
+  website: https://nodirabegim.com
 nomadscientist:
   affiliation: Embl-Ebi
   bio: I teach bioinformatics using Galaxy, I teach martial arts, and I hate onions.
@@ -3630,6 +4351,18 @@ olayile:
   first-name: Olayile
   last-name: Ejekwu
   pronouns: She/Her
+olsjuju:
+  affiliation: Binnobase Llc
+  bio: A scientist, research translator, and entrepreneur for life science innovation
+  city: Seoul
+  country: South Korea
+  expertise:
+  - '"neuroinflammation'
+  - Stem cells
+  - Diabetes
+  - Life science management"
+  first-name: Juyeon
+  last-name: Kim
 orchid00:
   bio: Paula is an Open Science advocate her passions are data management, data analytics,
     research, and diversity. She is a computer scientist who has worked on data intensive
@@ -3724,6 +4457,38 @@ pherterich:
   orcid: 0000-0002-4542-9906
   pronouns: she/her
   twitter: pherterich
+piero-beraun:
+  affiliation: Scihack
+  bio: 22 years old and Bachelor in Bioengineering. I like strawberries, plants, arthropods,
+    space and genetic modifications. Future Biohacker but not like the ones on Netflix.
+  city: Lima
+  country: Peru
+  expertise:
+  - Synthetic biology
+  - Systems biology
+  - Enviromental biotechnology
+  - Astrobiology
+  first-name: Piero
+  last-name: Beraun
+  orcid: 0000-0003-4179-6677
+  pronouns: He/Him
+  twitter: BeraunPiero
+pinheirochagas:
+  affiliation: Stanford University
+  bio: I'm a Brazilian cognitive neuroscientist studying the neural architecture and
+    dynamics of human intelligence, with a focus on elementary mathematics. I live
+    in San Francisco and I love music, art, photography, cooking, nature and endurance
+    sports.
+  city: San Francisco
+  country: United States
+  expertise:
+  - Cognitive neuroscience
+  first-name: Pedro
+  last-name: Pinheiro-Chagas
+  orcid: ' 0000-0001-8512-0113'
+  pronouns: He / him / his
+  twitter: ppinheirochagas
+  website: https://pinheirochagas.com/
 pivg:
   affiliation: Embl-Ebi (European Bioinformatics Institute)
   bio: I am a scientific training officer at the European Bioinformatics Institute
@@ -3883,6 +4648,25 @@ rainsworth:
   pronouns: she/her
   twitter: rachaelevelyn
   website: https://rainsworth.github.io/
+raoofphysics:
+  affiliation: The Alan Turing Institute
+  bio: I am the community manager for the “AI for Science and Government” research
+    programme at The Alan Turing Institute, with a background as a science writer
+    communicating high-energy particle physics.
+  city: Bristol
+  country: United Kingdom
+  expertise:
+  - Science communication
+  - Public engagement
+  - Version control
+  - A bit of r
+  - Project binder
+  first-name: Achintya
+  last-name: Rao
+  orcid: 0000-0002-1628-2618
+  pronouns: he/him
+  twitter: RaoOfPhysics
+  website: https://achintyarao.in
 raphaels1:
   affiliation: Wellcome
   bio: I'm a Technology Manager at Wellcome, a Research Associate at Imperial College
@@ -3933,6 +4717,16 @@ robandeep-kaur:
   github: false
   last-name: Kaur
   pronouns: She/her
+robert-schreiber:
+  bio: I’m a physiotherapist working in the private sector in South Africa.
+  city: Hermanus
+  country: South Africa
+  expertise:
+  - Affordable and easy access to healthcare services
+  first-name: Robert
+  last-name: Schreiber
+  pronouns: He/him
+  twitter: schrob25
 robin-lewando:
   affiliation: Independent
   bio: I am a semi retired independent researcher looking into the palaeoecology and
@@ -4006,6 +4800,15 @@ rukynas:
   first-name: Ruqayya Nasir
   last-name: Iro
   pronouns: She
+sairajdillikar:
+  city: Mysore
+  country: India
+  expertise:
+  - Seti
+  first-name: Sairaj R
+  last-name: Dillikar
+  orcid: 0000-0002-8245-3243
+  twitter: SairajDillikar
 samguay:
   affiliation: Université de Montréal
   bio: While completing his PhD in cognitive neuroscience at the Université de Montréal,
@@ -4046,6 +4849,21 @@ samvanstroud:
   first-name: Sam
   last-name: Van Stroud
   orcid: 0000-0002-7969-0301
+sandra-larriega:
+  affiliation: Scihack
+  bio: Biohacker
+  city: Ñima
+  country: Peru
+  expertise:
+  - Biotechnology
+  - Biomaterials
+  - Synbio
+  first-name: Sandra Mirella
+  last-name: Larriega Cruz
+  orcid: 0000-0003-3872-3928
+  pronouns: She, her
+  twitter: SandraLarriega
+  website: https://instagram.com/scihack?utm_medium=copy_link
 santi-rello-varona:
   affiliation: Hospital La Paz Institute For Health Research
   bio: After a PhD and several years in Cancer Research I am devoted now to promote
@@ -4081,6 +4899,19 @@ santosrac:
   pronouns: He
   twitter: CorreaSantosRA
   website: https://santosrac.netlify.app/
+sarah-nietopski:
+  affiliation: The Alan Turing Institute
+  bio: I have a background in educational resource design and development, and a keen
+    interest in exploring how to make online learning experiences as engaging as possible.
+  city: London
+  country: United Kingdom
+  expertise:
+  - Course design
+  - Online learning
+  - Blending learning
+  first-name: Sarah
+  last-name: Nietopski
+  pronouns: she/her
 saranjeetkaur:
   bio: I am a Statistician by training. I have completed the Google Summer of Code
     2020 with the Turing team of the Julia language organisation. Recently I have
@@ -4111,6 +4942,25 @@ saravilla:
   orcid: 0000-0001-9502-0888
   pronouns: She/her
   twitter: VillaScience
+sarenaz:
+  affiliation: Nazarbayev University
+  bio: Currently, I am a Research Assistant for the “Co-Creating Culturally Appropriate
+    Research Ethics” (CARE) project at Nazarbayev University. I am also a Frictionless
+    Data for Reproducible Research Fellow and interdisciplinary human rights researcher.
+    For the last nine years of my research, I have studied such topics as gender,
+    sexuality, nationalism/racism, disability, mental health issues, and epistemic
+    (in)justice - mainly through the lenses of post/decolonial, critical pedagogical,
+    feminist, and indigenous theories.
+  city: Astana (Nursultan)
+  country: Kazakhstan
+  expertise:
+  - Research ethics
+  - Epistemic injustice
+  - Decolonial research
+  - Political economy of knowledge production
+  first-name: Zarena
+  last-name: Syrgak
+  pronouns: she/they
 satagopam7:
   bio: Venkata is a Bioinformatician, a Senior Researcher at Bioinformatics core facility,
     and Deputy Head of the BioMedical Informatics Department, LCSB, University of
@@ -4271,6 +5121,20 @@ shmuhammad2004:
   pronouns: He/Him
   twitter: shmuhammadd
   website: https://www.shmuhammad.com/
+shubhamrj7:
+  affiliation: Iiser Bhopal
+  bio: I am a fourth-year integrated Ph.D. student in IISER Bhopal. My interest in
+    inverse problems is related to partial differential equations, which have broad
+    applications in biomedical imaging.
+  city: Bhopal
+  country: India
+  expertise:
+  - Inverse problem related to non linear equations and ray transform.
+  first-name: Shubham
+  last-name: Jathar
+  orcid: ' 0000-0002-9109-7543'
+  pronouns: he/him
+  website: https://rse-asia.github.io/RSE_Asia/
 sithyphus:
   affiliation: University of Arizona
   country: United States
@@ -4297,6 +5161,45 @@ sk-sahu:
   last-name: Sahu
   pronouns: he/him
   twitter: sangram_ksahu
+sladjana-lukic:
+  affiliation: Https://Www.Adelphi.Edu/Faculty/Profiles/Profile.Php?Pid=0966
+  bio: 'I received my PhD in Neurolinguistics from Northwestern University under the
+    supervision of Dr. Cynthia K. Thompson and completed postdoctoral training in
+    cognitive neuroscience under the supervision of Dr. Maria Luisa Gorno-Tempini
+    at the University of California San Francisco (UCSF) - Memory and Aging Center.
+    My neurobiology of language and behavior (NoLaB) lab focuses on the two lines
+    of research: the neurocognitive correlates of the lexical system and its relation
+    with emotions and other cognitive systems.'
+  city: New York City
+  country: United States
+  expertise:
+  - Lexical system
+  - Psycholinguistics
+  - Aphasia
+  - Emotions
+  - Lesion-symptom mapping
+  first-name: Sladjana
+  last-name: Lukic
+  orcid: 0000-0001-7009-3474
+  pronouns: she/her
+  twitter: NoLaB_Lukic
+  website: https://​sites.​google.​com/​view/​sladjanalukic/​home
+slldec:
+  affiliation: Arphai / Instituto De Cálculo (Uba-Conicet)
+  bio: I have a Ph.D. in Biology (neuroscience) where I acquired diverse tools for
+    data analysis. In the last years, I became interested in the impact of new technologies
+    and their ethical implications in Public Health
+  city: Buenos Aires
+  country: Argentina
+  expertise:
+  - Biostatistics
+  - Health data science
+  - Ethics
+  - Natural language processingarphai
+  first-name: Sabrina
+  last-name: Lopez
+  orcid: 0000-0003-1572-1815
+  pronouns: she/her/ella
 smklusza:
   affiliation: Clayton State University
   bio: Lifelong developmental geneticist with interest in synthetic biology and creating
@@ -4359,7 +5262,7 @@ spitschan:
   twitter: mspitschan
   website: https://www.psy.ox.ac.uk/team/manuel-spitschan
 stefan-gaillard:
-  country: The Netherlands
+  country: Netherlands
   first-name: Stefan
   github: false
   last-name: Gaillard
@@ -4416,7 +5319,7 @@ teresa-cisneros:
   bio: I practice where I am from which is the MX/TX border the centres a politics
     of collective action and care.
   city: London
-  country: England
+  country: United Kingdom
   expertise:
   - Equity
   - Diversity and inclusion (transformative justice approaches)
@@ -4442,20 +5345,16 @@ teresa-m:
   pronouns: She/Her
   twitter: tesamueller
 thatspacegirl:
-  bio: Rika (Sagarika) is a 3rd year undergraduate student in India pursuing an engineering
-    degree in Electronics and Communication from RNSIT Bangalore. She is a Research
-    Fellow at the Center for Fundamental Research and Creative Education Bangalore
-    and the founder of WoAA India.
-  city: Banaglore
+  bio: Rika, a 4th year undergraduate student in Bengaluru India majoring in Electronics
+    and Communication. She is currently pursuing her project work at RRSC ISRO and
+    is passionate about women in stem and space. She started WOAA India in 2020.
+  city: Bengaluru
   country: India
   expertise:
-  - Physics
   - Astrobiology
-  - Xenobiology
-  - Bioinformatics
   - Planetary science
-  - Exoplanets
-  - Extremophiles
+  - Ml
+  - Data science;
   first-name: Sagarika
   last-name: Valluri
   orcid: ' 0000-0003-2764-4028'
@@ -4627,11 +5526,34 @@ valerie-parent:
   first-name: Valerie
   github: false
   last-name: Parent
+vborghe:
+  affiliation: University Of Montreal
+  bio: Valentina Borghesani, Ph.D., is an Italian cognitive neuroscientist currently
+    working as senior postdoctoral researcher within the CNeuroMod project at the
+    Psychology Department of the Université de Montreal. Her research focuses on the
+    neuro-cognitive correlates of semantic knowledge which she investigates with both
+    neuroimaging techniques (fMRI, MEG) and neuropsychological data. She deeply cares
+    (and is very active in) bridging neuroscience & ethics, community, diversity, environment,
+    and the arts. After a PhD in France and postdocs in California and Quebec, Valentina
+    is starting as an Assistant Professor at the University of Geneva in September
+    2022.
+  city: Montréal
+  country: Canada
+  expertise:
+  - Cognitive neuroscience
+  - Clinical neuroscience
+  - Neuroimaging;
+  first-name: Valentina
+  last-name: Borghesani
+  orcid: 0000-0002-7909-8631
+  pronouns: she/her/hers
+  twitter: https://twitter.com/vborghesani
+  website: https://valentina.borghesani.org/
 vcheplygina:
   bio: Veronika''s research area is machine learning in medical imaging. She is an
     now assistant professor but will be leaving her position soon. She is blogging
     about this and other academia-related topics on her website veronikach.com
-  country: The Netherlands
+  country: Netherlands
   expertise:
   - Machine learning
   - Medical imaging (classification / segmentation)
@@ -4643,6 +5565,57 @@ vcheplygina:
   pronouns: she/her
   twitter: DrVeronikaCH
   website: https://www.veronikach.com
+veroxgithub:
+  affiliation: Arphai/Ciecti
+  bio: |-
+    I am a Doctor in Social Sciences, University of Buenos Aires (UBA), Master in Political Science and Sociology, Latin American Faculty of Social Sciences (FLACSO), and Anthropologist (UBA). I have extensive experience in interdisciplinary research and intervention projects on free technologies, co-production of knowledge, and data. I'm currently working as a researcher at the Interdisciplinary Center for Studies in Science, Technology, and Innovation (CIECTI) in the area of Digital Economy and the ARPHAI project. Also, I am an activist for Free Software and Knowledge, and I enjoy working in heterogeneous and interdisciplinary teams where we all learn from each other.
+    To have into account: I reach top productivity in Spanish. I find it more difficult to work in English as it is not my native tongue.
+  city: Avellaneda
+  country: Argentina
+  expertise:
+  - Co-production of knowledge
+  - Interdisciplinarity
+  - Open data
+  - Free software
+  first-name: Verónica
+  last-name: Xhardez
+  orcid: 0000-0002-0184-0277
+  pronouns: She/Her
+  twitter: xhardez
+  website: https://http://www.ciecti.org.ar/arphai/
+vhellon:
+  affiliation: The Alan Turing Institution
+  bio: Vicky Hellon is currently a community manager based at the Turing Institute,
+    working on the Turing-Roche partnership. She has a BSc in Biomedical Science from
+    the University of Sheffield and previously worked for Health Data Research UK
+    and in Open Access Publishing roles at Springer Nature and F1000Research.
+  city: London
+  country: United Kingdom
+  expertise:
+  - Personalised medicine
+  - Open access publishing
+  first-name: Vicky
+  last-name: Hellon
+  orcid: ' 0000-0002-2745-0445'
+  pronouns: she/her
+  twitter: vickyhellon
+  website: https://www.turing.ac.uk/research/research-projects/alan-turing-institute-roche-strategic-partnership
+vickygisel:
+  affiliation: Fundación Sadosky - Arphai
+  bio: I'm a very curious person who enjoy teaching and learning. My personal interests
+    are very varied, from science, education and health to plant-based cooking, gardening
+    and composting. Since my PhD project I have worked on different data projects
+    and on the way I discovered I'm particularly interested in data visualization.
+    I feel particularly motivated by projects with socio-environmental impact.
+  city: Oro Verde
+  country: Argentina
+  expertise:
+  - Data science - data visualization
+  first-name: Victoria
+  last-name: Dumas
+  orcid: 0000-0003-4286-0060
+  pronouns: She, Her
+  twitter: VickyDumas
 vickynembaware:
   bio: "Vicky has a PhD in Bioinformatics and an MPhil in Monitoring and Evaluation.\n\
     Her research experience (qualitative and quantitative) spans Genomics and Public\
@@ -4721,6 +5694,17 @@ yvanlebras:
   pronouns: He
   twitter: Yvan2935
   website: https://yvanlebras.fr
+zdunseth:
+  affiliation: Icops
+  city: Providence
+  country: United States
+  expertise:
+  - Phytolith
+  - Geoarchaeology
+  first-name: Zachary
+  last-name: Dunseth
+  orcid: 0000-0003-2081-0089
+  pronouns: he/his
 zebetus:
   bio: A mentor for many previous waves of open leaders, who is currently studying
     for their PhD at UCL.

--- a/_data/people.yaml
+++ b/_data/people.yaml
@@ -4,21 +4,6 @@
 # if not, add github: false tag and
 # use firstname-lastname as collection name
 #
-# List of tags for people
-#
-# first-name:
-# last-name:
-# twitter:
-# website:
-# gitter:
-# orcid:
-# affiliation:
-# country:
-# pronouns:
-# expertise:
-#    -
-# bio:
-#
 # Mandatory: first-name, last-name, country
 ---
 '0x174':
@@ -225,6 +210,9 @@ alexandra-holinski:
   last-name: Holinski
   orcid: 0000-0003-2321-5568
   pronouns: She/her
+alexholinski:
+  first-name: Alexandra
+  last-name: Holinski
 alexwlchan:
   affiliation: Wellcome Collection
   country: United Kingdom
@@ -467,6 +455,39 @@ annefou:
   pronouns: she/her
   twitter: AnneFouilloux
   website: https://github.com/annefou
+annemtreasure:
+  affiliation: Talarify
+  bio: I'm a recovering academic, with a strong interest in all elements of the data
+    life cycle, from data collection and data analytics, to data curation and good
+    data management practices, and I love figuring out data pipelines and workflows.
+    I believe strongly in open science and open data, and promoting good practices
+    for reproducible research. I have strong interests in capacity development, community
+    building, and mentorship, and have worked in a variety of industries and academic
+    institutes worldwide, and have research and work experience in many different
+    scientific fields including ecology, biology, marine and terrestrial sciences,
+    invasion biology, polar science, and climate change.
+  city: Cape Town
+  country: South Africa
+  expertise:
+  - Data life cycle
+  - Data management
+  - Open data
+  - Open science
+  - Reproducible research
+  - Ecology
+  - Biology
+  - Marine sciences
+  - Invasion biology
+  - Terrestrial sciences
+  - Climate change
+  - Data pipelines and workflows
+  - Biodiversity
+  - Environment
+  first-name: Anne
+  last-name: Treasure
+  orcid: 0000-0002-8345-4811
+  twitter: annemtreasure
+  website: https://Needs updating (https://sites.google.com/site/annemtreasure/about?authuser=0)
 anproulx:
   affiliation: Université de Montréal
   country: Canada
@@ -615,21 +636,20 @@ banshee1221:
   twitter: edebeste
 batoolmm:
   affiliation: Kaimrc
-  bio: Batool is a bioinformatician and computational biologist affiliated with KAIMRC
-    in Saudi Arabia. As an advocate for Open Science and its role in improving scientific
-    and economic outputs in the Middle east, Batool established an Open Science Community
-    in Saudi Arabia (OSCSA). OSCSA aims to create significant value towards Saudi
-    Arabia's Vision 2030, which focus on enhancing knowledge and improving equal access
-    to education in the Kingdom
-  city: Riyadh
+  bio: Batool is a computational biologist affiliated with both KAIMRC in Saudi Arabia
+    and the University of Liverpool in the UK. As an advocate for Open Science and
+    its role in improving scientific and economic outputs in the Middle east, Batool
+    established an Open Science Community in Saudi Arabia (OSCSA). OSCSA aims to create
+    significant value towards Saudi Arabia’s Vision 2030, which focus on enhancing
+    knowledge and improving equal access to education in the Kingdom
+  city: Liverpool
   country: Saudi Arabia
   expertise:
-  - Open science
-  - Ngs
-  - Metagenomics
+  - Reproducibility
+  - Computational biology
   first-name: Batool
   last-name: Almarzouq
-  orcid: my-orcid?orcid=0000-0002-3905-2751
+  orcid: 0000-0002-3905-2751
   pronouns: She/Her
   twitter: batool664
   website: https://batool-almarzouq.netlify.app/
@@ -820,6 +840,14 @@ burce-elbasan:
   first-name: Burce
   github: false
   last-name: Elbasan
+burceelbasan:
+  affiliation: University Ulm
+  country: Germany
+  expertise:
+  - Molecular genetics
+  - Molecular mechanisms of cancer pathogenesis
+  first-name: Burce
+  last-name: Elbasan
 burkemlou:
   affiliation: Australian Biocommons
   bio: Melissa is the Training and Communications Officer with Australian BioCommons.
@@ -902,53 +930,41 @@ camachoreina:
   twitter: rcamachotoro
   website: https://camachoreina.github.io
 cassgvp:
-  affiliation: University of Oxford
-  bio: Cassandra worked for 10 years in magnetic resonance imaging, mainly with clinical
-    psychiatric populations. After discovering open science, it reignited her passion
-    and enthusiasm for the way research *could* be done, and she focused a lot of
-    her efforts into educating and training her team in programming, reproducible
-    and transparent methods. She was recently appointed Open Science Community Engagement
-    Coordinator for her department, one of only a few professional open science roles
-    in the UK. She is very proud to support her colleagues in the transition towards
-    working open, and doing so with the principles of open leadership at the forefront
-    of her work.
+  affiliation: University Of Oxford
+  bio: I've been promoting open science since 2018 (formalised with OLS-1!), and in
+    2020 I moved to a research support role to implement behaviour change towards
+    the adoption of open science and reproducibility practices at our Centre (https://www.win.ox.ac.uk).
+    I care a lot about inclusivity and being a positive role model in my interactions
+    and leadership.
+  city: Oxford
   country: United Kingdom
   expertise:
-  - Online conferences
-  - Behaviour change
-  - Community engagement
-  - Open science practices
   - Neuroimaging
+  - Community
+  - Edi
+  - Champions/ambassadors programme
+  - Data sharing
+  - Incentives/reward
+  - Academia-to-professional services transition / research adjacent roles
+  - Transparent and inclusive leadership.
   first-name: Cassandra
-  last-name: Gould van Praag
+  last-name: Gould Van Praag
+  orcid: 0000-0002-8584-4637
   pronouns: she/her
   twitter: cassgvp
+  website: https://www.psych.ox.ac.uk/team/cassandra-gould-van-praag
 cbolibaugh:
   affiliation: Department Of Education, University Of York
-  bio: 'I am a Lecturer in Language Education at the University of York in the UK,
-    where I study second language processing and acquisition. My research explores
-    what individual cognitive differences can tell us about the mechanisms underlying
-    second language learning, and how these mechanisms interact with the language
-    environment.
+  bio: |-
+    I am a Lecturer in Language Education at the University of York in the UK, where I study second language processing and acquisition. My research explores what individual cognitive differences can tell us about the mechanisms underlying second language learning, and how these mechanisms interact with the language environment.
 
+    I also work to make research in education and the language sciences open and accessible to all through my work with EROS, IRIS and OASIS.
 
-    I also work to make research in education and the language sciences open and accessible
-    to all through my work with EROS, IRIS and OASIS.
+    IRIS (https://iris-database.org) is a collection of instruments, materials, stimuli, and data coding and analysis tools used for research into second languages, including second and foreign language learning, multilingualism, language education, language use and processing.
 
+    The OASIS initiative (https://oasis-database.org) is establishing a systematic and sustainable culture of providing open, accessible summaries of research in the language sciences.
 
-    IRIS (https://iris-database.org) is a collection of instruments, materials, stimuli,
-    and data coding and analysis tools used for research into second languages, including
-    second and foreign language learning, multilingualism, language education, language
-    use and processing.
-
-
-    The OASIS initiative (https://oasis-database.org) is establishing a systematic
-    and sustainable culture of providing open, accessible summaries of research in
-    the language sciences.
-
-
-    EROS (https://osf.io/qwurf/) is an Open Research working group within the Department
-    of Education at York who advocate for more inclusive, open and reproducible research.'
+    EROS (https://osf.io/qwurf/) is an Open Research working group within the Department of Education at York who advocate for more inclusive, open and reproducible research.
   city: York
   country: United Kingdom
   expertise:
@@ -1146,6 +1162,20 @@ davidviryachen:
   last-name: Chentanaman
   pronouns: he/him
   twitter: davidchenn
+deepakunni3:
+  affiliation: European Molecular Biology Laboratory
+  city: Heidelberg
+  country: Germany
+  expertise:
+  - Knowledge graphs
+  - Bio-ontologies
+  - Metadata management
+  - Fair data principles
+  first-name: Deepak
+  last-name: Unni
+  orcid: 0000-0002-3583-7340
+  pronouns: He/Him
+  twitter: deepakunni3
 delphine-l:
   affiliation: Penn State University
   bio: I am an Assistant Professor at Penn State University and I  have been   part
@@ -1480,44 +1510,19 @@ evacherbst:
   twitter: EvaCHerbst
 ewa-leś:
   affiliation: Coalition Clean Baltic (Ccb)
-  bio: 'Moving present dreams towards a better real future with committed ignited
-    teams, within the socio-environmental field. Skilled in environmental awareness,
-    empathic and efficient coordination, Non-Governmental Organizations (NGOs), community
-    & stakeholder engagement.
-
-    Founder of River University, under the wings of Coalition Clean Baltic (2018);
-    co-founder of Polish Save the Rivers Coalition/Koalicja Ratujmy Rzeki /KRR (2016);
-    co-initiator and coordinator of the first Water Round Table in Poland on the protection
-    of waters and rivers in cooperation with the Ministry of the Environment (2009-2011);
-    co-creator of Partnership for The Baltic initiative (2007-2012).
-
-    I''m particularly interested and working in areas of #transboundary waters, #water
-    stakeholders inclusion, #waterconflicts, #waterdiplomacy #waterdemocracy building,
-    #problemsolving. Additional advantages of my long life curiosity and learning
-    are certificates focused on global diplomacy, efficient management (PRINCE2® Foundation),
-    Governance for Transboundary Freshwater Security.
-
-    In 2021 nominated to Ashoka SHE SAYS program supporting women changemakers and
-    social entrepreneurs.
-
+  bio: |-
+    Moving present dreams towards a better real future with committed ignited teams, within the socio-environmental field. Skilled in environmental awareness, empathic and efficient coordination, Non-Governmental Organizations (NGOs), community & stakeholder engagement.
+    Founder of River University, under the wings of Coalition Clean Baltic (2018); co-founder of Polish Save the Rivers Coalition/Koalicja Ratujmy Rzeki /KRR (2016); co-initiator and coordinator of the first Water Round Table in Poland on the protection of waters and rivers in cooperation with the Ministry of the Environment (2009-2011); co-creator of Partnership for The Baltic initiative (2007-2012).
+    I'm particularly interested and working in areas of #transboundary waters, #water stakeholders inclusion, #waterconflicts, #waterdiplomacy #waterdemocracy building, #problemsolving. Additional advantages of my long life curiosity and learning are certificates focused on global diplomacy, efficient management (PRINCE2® Foundation), Governance for Transboundary Freshwater Security.
+    In 2021 nominated to Ashoka SHE SAYS program supporting women changemakers and social entrepreneurs.
 
     Actively present in:
-
-    Coalition Clean Baltic (CCB) - working on rivers, especially transboundary ones,
-    source to sea approach [https://ccb.se]
-
+    Coalition Clean Baltic (CCB) - working on rivers, especially transboundary ones, source to sea approach [https://ccb.se]
     Water working group of European Environment Bureau [https://eeb.org/membership/our-working-groups]
-
-    Save The Rivers Coalition (KRR) - Polish national coalition dedicated to rivers/water
-    protection [www.ratujmyrzeki.pl]
-
-    Friends of Ina and Gowienica Rivers Society (TPRIiG) [www.tpriig.pl] - regional
-    level of riverine activity
-
-    International Commission for the Protection of the Odra River against Pollution
-    (ICPO) [www.mkoo.pl]
-
-    You may also find some bits of me here: www.researchgate.net/profile/Ewa_Les'
+    Save The Rivers Coalition (KRR) - Polish national coalition dedicated to rivers/water protection [www.ratujmyrzeki.pl]
+    Friends of Ina and Gowienica Rivers Society (TPRIiG) [www.tpriig.pl] - regional level of riverine activity
+    International Commission for the Protection of the Odra River against Pollution (ICPO) [www.mkoo.pl]
+    You may also find some bits of me here: www.researchgate.net/profile/Ewa_Les
   country: Poland
   expertise:
   - Transboundary waters
@@ -1532,17 +1537,16 @@ ewa-leś:
   orcid: 0000-0002-7749-020X
   website: https://ccb.se/?event=15161&event_date=2021-08-11
 ewallace:
-  affiliation: School Of Biological Sciences, The University Of Edinburgh
-  bio: 'My research group studies how organisms respond to their environment, focusing
+  affiliation: University Of Edinburgh
+  bio: My research group studies how organisms respond to their environment, focusing
     on molecular mechanisms used by fungi. We collect and analyze genome-scale datasets
     to understand how fungi dynamically reorganize their RNA and protein to adapt
     to environmental change. We also produce open-science software tools, including
     tidyqpcr for quantitative PCR analysis in the tidyverse, and riboviz for ribosome
-    profiling analysis.
-
-
-    Alongside my research, I''m an open science advocate and teach data literacy to
-    scientists, working with The Carpentries and Edinburgh Carpentries.'
+    profiling analysis. Both of these packages are going through software review and
+    I'm learning a lot from the process. Alongside my research, I'm an open science
+    advocate and teach data literacy to scientists, working with The Carpentries and
+    Edinburgh Carpentries.
   city: Edinburgh
   country: United Kingdom
   expertise:
@@ -1552,13 +1556,16 @@ ewallace:
   - Bioinformatics
   - Open science
   - Data literacy
-  - Balancing open science with the rest of your career
+  - Open science in project and teaching context
+  - Practical github
+  - R packages
+  - Balancing open science with the rest of your career;
   first-name: Edward
   last-name: Wallace
   orcid: 0000-0001-8025-6361
   pronouns: he, him
   twitter: ewjwallace
-  website: https://ewallace.github.io/
+  website: https://ewallace.github.io
 ewuramaminka:
   affiliation: University of Manchester
   country: United Kingdom
@@ -1665,10 +1672,25 @@ gedankenstuecke:
   twitter: gedankenstuecke
   website: https://tzovar.as
 georgiahca:
-  country: United Kingdom
+  affiliation: The Alan Turing Institute
+  bio: I am a researcher at The Alan Turing Instiitute working on co-creating a citizen
+    science platform, AutSPACEs, with a community of autistic collaborators. I also
+    worked for 3 years for the British Civil Service in their fast track scheme. I'm
+    a believer in creating a collaborative over competitive work ethos, equity, and
+    open research.
+  city: London
+  country: England
+  expertise:
+  - Citizen science
+  - Participatory science
+  - Open source
+  - Neurodiversity
+  - Sensory processing
+  - Co-creation
   first-name: Georgia
   last-name: Aitkenhead
-  pronouns: she/her
+  pronouns: She/her
+  website: https://github.com/alan-turing-institute/AutisticaCitizenScience
 ghammad:
   affiliation: University Of Liège
   bio: High-energy physicist recruited by a neuroscience lab!
@@ -1719,6 +1741,23 @@ graciellehigino:
   pronouns: She/her
   twitter: graciellehigino
   website: https://graciellehigino.github.io/
+gugy89:
+  bio: Polyglot European Scientist. Thrives working in interdisciplinary environments
+    combining the study of enzyme reactions and mechanisms with bioinformatics, molecular
+    modelling, automated data analysis and data stewardship.
+  expertise:
+  - Enzymology
+  - Biochemstry
+  - Bioinformatics
+  - Molecular modelling
+  - Molecular dynamics simulations
+  - Deep eutectic solvents
+  - Oxidoreductases
+  - Data stewardship
+  - Laboratory automation
+  - Fair data
+  first-name: Gudrun
+  last-name: Gygli
 guille1107:
   bio: I am currently a Chemistry graduate student in the Universidad de Buenos Aires,
     Argentina. I find myself really interested in nanomaterials and the huge world
@@ -1892,34 +1931,26 @@ iramosp:
   - Sustainability science
   - Inter and transdisciplinary research
   first-name: Irene
-  last-name: Ramos Pérez
+  last-name: Ramos
   orcid: 0000-0003-3315-2281
   pronouns: she / her
 iratxepuebla:
   affiliation: Asapbio
-  bio: 'I am Associate Director for ASAPbio, a nonprofit with a mission to accelerate
-    innovation and transparency in life sciences communication. In this role I work
-    to foster awareness of preprints and drive community engagement, and support initiatives
-    to bring further transparency into peer review.
+  bio: |-
+    I am Associate Director for ASAPbio, a nonprofit with a mission to accelerate innovation and transparency in life sciences communication. In this role I work to foster awareness of preprints and drive community engagement, and support initiatives to bring further transparency into peer review.
 
-
-    Prior to ASAPbio, I worked in publishing for 16 years, I held editorial roles
-    with Open Access publishers, initially at BioMed Central and then PLOS, where
-    I was Deputy Editor-in-Chief at the journal PLOS ONE. I am also Facilitation and
-    Integrity Officer for the Committee on Publication Ethics (COPE).'
+    Prior to ASAPbio, I worked in publishing for 16 years, I held editorial roles with Open Access publishers, initially at BioMed Central and then PLOS, where I was Deputy Editor-in-Chief at the journal PLOS ONE. I am also Facilitation and Integrity Officer for the Committee on Publication Ethics (COPE).
   city: Cambridge
   country: United Kingdom
   expertise:
   - Preprints
-  - Science communication
   - Publishing
-  - Peer review
-  - Community engagement
-  - Research integrity
+  - Open access
+  - Data publication
   first-name: Iratxe
   last-name: Puebla
   orcid: 0000-0003-1258-0746
-  pronouns: she/her/hers
+  pronouns: she/her
   twitter: IratxePuebla
   website: https://asapbio.org/dt_team/iratxe-puebla
 irena-maus:
@@ -2070,6 +2101,24 @@ jelioth-muthoni:
   first-name: Jelioth
   github: false
   last-name: Muthoni
+jesperdramsch:
+  affiliation: Ecmwf
+  bio: Jesper Dramsch works at the intersection of machine learning and physical,
+    real-world data. Currently, they're working as a scientist for machine learning
+    in numerical weather prediction at the coordinated organisation ECMWF. Jesper
+    holds a PhD and recently gave their first keynote. They're passionate about teaching
+    Python and elevating people's careers with machine learning across the world.
+  city: Bonn
+  country: Germany
+  expertise:
+  - Machine learning
+  - Diversity
+  first-name: Jesper
+  last-name: Dramsch
+  orcid: 0000-0001-8273-905X
+  pronouns: they
+  twitter: jesperdramsch
+  website: https://dramsch.net
 jessica-sims:
   affiliation: University College London
   bio: I work at the UKCRC Tissue Directory and Coordination Centre (TDCC). It is
@@ -2133,22 +2182,24 @@ jezcope:
     alongside research data in the scholarly record, and helping researchers develop
     the skills to make the most of this. He is a Fellow of the Software Sustainability
     Institute, 2020 intake.
-  city: North Yorkshire
+  city: Harrogate
   country: United Kingdom
   expertise:
+  - Research data management
+  - Digital scholarship
   - Libraries
-  - Data management
-  - Digital preservation
-  - Open source
-  - Open access publishing
-  - Git
-  - Web
+  - Open research
+  - Licensing
+  - Open data
+  - Open scholarship
+  - Open science
+  - Research software engineering practice
   first-name: Jez
   last-name: Cope
   orcid: 0000-0003-3629-1383
   pronouns: he/him
   twitter: jezcope
-  website: https://erambler.co.uk/
+  website: https://erambler.co.uk
 jmmaok:
   bio: A project lead in Cohort 3, Jennifer Miller has a M.S. in Technical Communication
     and a PhD in Public Policy. She has 10+ years post-secondary teaching experience
@@ -2257,15 +2308,16 @@ joshsimmons:
   last-name: Simmons
   twitter: joshsimmons
 joyceykao:
-  affiliation: Open Innovation In Life Sciences Association
-  bio: I am a recovering academic researcher (in evolutionary biology), who is currently
-    occupied with the use and development of web-based applications, using tech to
-    make processes efficient and reproducible, and growing the Open Innovation in
-    Life Sciences association to promote open science among early career researchers
-    in Switzerland. In my spare time, I watch a lot of Netflix (i.e., crime dramas,
-    sci-fi, RPDR)  and go on long walks with my family in the Swiss countryside.
-  city: Zurich
-  country: Switzerland
+  affiliation: Uniklinikum Rwth Aachen
+  bio: Currently, I am a Senior Project Manager at the Univerisity Hospital RWTH Aachen
+    coordinating the development of digital health apps and an enthusiast for using
+    tech to make processes efficient and reproducible. In a previous position, I co-founded
+    the Open Innovation in Life Sciences association that promotes open science among
+    early career researchers in Switzerland. Things that make me happy at the moment
+    include playing piano and introducing chapter books from my childhood to my school-aged
+    kid.
+  city: Aachen
+  country: Germany
   expertise:
   - Web applications
   - App/software development
@@ -2279,7 +2331,31 @@ joyceykao:
   orcid: 0000-0003-2082-6937
   pronouns: she/her
   twitter: joyceykao
-  website: https://joyceykao.github.io/
+  website: https://jykao.com/
+jsheunis:
+  affiliation: Research Center Juelich, Germany
+  bio: Stephan is passionate about brains, accessible education, and making scientific
+    practice more transparent and inclusive. Throughout his doctoral research, he
+    has been active in the Dutch network of Open Science Communities and he founded
+    OpenMR Benelux, a community working on wider adoption of open science practices
+    in MRI research through talks, discussions, workshops and hackathons. Stephan
+    has since continued this passion as a Research Data and Software Engineer at the
+    Forschungszentrum Jülich in Germany, where he works on software solutions for
+    neuroinformatics and decentralised research data management. He also holds post-doctoral
+    positions in the SYNC developmental neuroscience lab at Erasmus University Rotterdam
+    and Leiden University in the Netherlands.
+  city: Juelich
+  country: Germany
+  expertise:
+  - Research data management
+  - Open source tools for code and data sharing
+  - Signal processing with python;
+  first-name: Stephan
+  last-name: Heunis
+  orcid: 0000-0003-3503-9872
+  pronouns: he/him
+  twitter: fmrwhy
+  website: https://jsheunis.github.io/
 juan-josé-garcía-granero:
   affiliation: Spanish National Research Council
   bio: I am an archaeobotanist interested in how late prehistoric societies interacted
@@ -2332,19 +2408,9 @@ karegapauline:
   pronouns: she/her
   twitter: KaregaP
 kariljordan:
-  bio: 'Kari is the Senior Director of Equity and Assessment for The Carpentries,
-    Executive Director of the Engineer Like a Girl after-school program, and a Zumba
-    Fitness Instructor!
-
-    Kari''s background is mechanical engineering, and she earned a PhD in Engineering
-    Education from The Ohio State University. Her doctoral research explored self-efficacy
-    of underrepresented engineering students. After completing a post-doc in the Engineering
-    Fundamentals Department at Embry-Riddle Aeronautical University, she was hired
-    to lead The Carpentries assessment efforts. In her current role, her focus is
-    developing programs through the lens of equity, and setting strategic efforts
-    around assessment that inform The Carpentries curriculum and other initiatives.
-
-    '
+  bio: |
+    Kari is the Senior Director of Equity and Assessment for The Carpentries, Executive Director of the Engineer Like a Girl after-school program, and a Zumba Fitness Instructor!
+    Kari's background is mechanical engineering, and she earned a PhD in Engineering Education from The Ohio State University. Her doctoral research explored self-efficacy of underrepresented engineering students. After completing a post-doc in the Engineering Fundamentals Department at Embry-Riddle Aeronautical University, she was hired to lead The Carpentries assessment efforts. In her current role, her focus is developing programs through the lens of equity, and setting strategic efforts around assessment that inform The Carpentries curriculum and other initiatives.
   country: United States
   expertise:
   - Equity and Inclusion
@@ -2367,23 +2433,23 @@ karinlag:
   twitter: karinlag
 karvovskaya:
   affiliation: Vu Amsterdam
-  bio: I am interested in linguistics, especially in semantic fieldwork and language
-    documentation. After completing my PhD at Leiden University I started working
-    at university libraries in the area of Research Data Management. My experience
-    with research and language archives is a great help and inspiration
+  bio: I am a theoretical linguist turned community manager for research data management
+    and open science. I am excited about research and infrastructure and look forward
+    to learning from OLS project leads about their projects and supporting them through
+    their challenges!
   city: Amsterdam
-  country: The Netherlands
+  country: Netherlands
   expertise:
   - Linguistics
-  - Language documentation
-  - Typology
-  - Semantics
   - Research data management
+  - Fieldwork
+  - Semantics
+  - Typology
   first-name: Lena
   last-name: Karvovskaya
   orcid: 0000-0001-7777-5603
   pronouns: she, her
-  twitter: LangData
+  twitter: Lingdata
 katesimpson:
   affiliation: Imperial College London/ The Alan Turing Institute
   bio: I am an early career researcher focused on building energy use with a passion
@@ -2516,26 +2582,28 @@ kirstiejane:
   twitter: kirstie_j
   website: https://whitakerlab.github.io/
 klauer2207:
-  bio: Kathi is charge of implementing and driving ELIXIR''s industry Programme. ELIXIR
-    is an intergovernmental organisation with over 220 bioinformatics research centres
-    in 22 countries and the EMBL-EBI with open science at the core. ELIXIR is active
-    in the areas of data, compute, interoperability, tools and training in the data
-    driven life science sector. Kathi is further involved developing and delivering
-    initiatives to support Cambridge researchers in their pursuit of business and
-    entrepreneurial ventures through the Entrepreneurial Postdocs of Cambridge University.
-    Prior to her current role Kathi worked as a researcher in vaccines & virology.
+  affiliation: Elixir
+  bio: PhD in medical sciences with expertise in infectious diseases and vaccines
+    with expansive knowledge of the data driven life science industry. Proven ability
+    to present and write clearly and persuasively, complex scientific and technical
+    content, tailored to different audiences. Experience in inspiring, enthusing and
+    influencing stakeholders and leading teams while navigating different cultural
+    contexts. Extensive experience in developing strategies for national and international
+    projects covering public-private partnerships, communication, and outreach as
+    well as scientific programmes.
+  city: Cambridge
   country: United Kingdom
   expertise:
-  - Stakeholder engagement
-  - Entrepreneurship
-  - Open data resources
-  - Strategy and business development
-  - Public-private partnerships
+  - Infectious diseases
   - Data driven life sciences
-  - Virology
+  - Entrepreneurship
+  - Strategy
+  - External relations
   first-name: Katharina
   last-name: Lauer
+  orcid: 0000-0002-4347-7525
   pronouns: she/her
+  twitter: lauerkatharina
   website: https://www.linkedin.com/in/katharina-lauer-33aa2674/
 kmexter:
   affiliation: Flanders Marine Institute (Vliz)
@@ -2578,23 +2646,6 @@ kristinariemer:
   last-name: Riemer
   pronouns: she/her
   twitter: KristinaRiemer
-kstackwhitney:
-  affiliation: Rochester Institute Of Technology
-  bio: Dr. Stack Whitney is an environmental studies and STS professor in upstate
-    NY, USA. She conducts research in part on ableism and inaccessibility as barriers
-    to open science and open research - as well as ethical issues in open data.
-  city: Rochester, Ny
-  country: United States
-  expertise:
-  - Accessibility
-  - Ableism
-  - Openness without extraction
-  first-name: Kaitlin
-  last-name: Stack Whitney
-  orcid: 0000-0002-0815-5037
-  pronouns: she/her/hers
-  twitter: kstackwhitney
-  website: https://www.rit.edu/sweetlab
 kswhitney:
   affiliation: Rochester Institute Of Technology
   bio: Dr. Stack Whitney is an environmental studies professor at RIT in upstate NY,
@@ -2619,9 +2670,10 @@ kswhitney:
   website: https://rit.edu/sweetlab
 lalmehlisy:
   affiliation: King Abdullah International Medical Research Center (KAIMRC)
-  bio: I am a Research Lab Technician in KAIMRC working on Metagenomics-based drug discovery 
-    Project. I am learning about how to apply Open Science practices in my reserach while 
-    at the same time simplify them and make them more accessible to my community.
+  bio: I am a Research Lab Technician in KAIMRC working on Metagenomics-based drug
+    discovery Project. I am learning about how to apply Open Science practices in
+    my reserach while at the same time simplify them and make them more accessible
+    to my community.
   city: Riyadh
   country: Saudi Arabia
   expertise:
@@ -2650,25 +2702,20 @@ landimi2:
   twitter: CofiaLandy
 lauracarter:
   affiliation: University Of Essex
-  bio: 'Laura is a PhD candidate at the University of Essex, researching the use of
-    data assemblages in the public sector in England. Before this, she worked for
-    almost a decade as a researcher at Amnesty International, focusing on gender,
-    women''s rights, and LGBTI rights. She believes in research as a means to an end:
-    to building a better world for everyone.'
+  bio: I'm a PhD student researching gender stereotypes in public sector technology.
+  city: London
   country: United Kingdom
   expertise:
+  - Gender
+  - Discrimination
   - Human rights
-  - Data usage in the public sector
-  - Gender and stereotyping
-  - Feminist and queer approaches to tech and data
-  - Ethical and reflexive research methodologies
-  - Equality, Anti-discrimination and justice
+  - Feminism
   first-name: Laura
   last-name: Carter
   orcid: 0000-0002-4285-1140
   pronouns: she/her
   twitter: LauraC_rter
-  website: https://lauracarter.github.io
+  website: https://lauracarter.github.io/
 lauracion:
   affiliation: University Of Buenos Aires - Conicet
   bio: I am a tenured adjunct researcher leading a health data science group. I also
@@ -2794,20 +2841,21 @@ lpantano:
   twitter: lopantano
   website: https://lpantano.github.com
 luispedro:
-  bio: Luis is Junior PI at Fudan University in Shanghai. His work in computational
-    biology focus on the global microbiome. He has written several open source scientific
-    software packages and organized and taught at multiple Software Carpentry workshops.
+  affiliation: Fudan University
+  bio: I am the principal investigator of the Big Data Biology Lab at Fudan University
+    (Shanghai) since September 2018. Our group works in computational biology, with
+    a focus on the very large-scale. See https://luispedro.org/
+  city: Shanghai
   country: China
   expertise:
-  - Computational biology
-  - Group leadership
   - Microbiome
+  - Computational biology
   first-name: Luis Pedro
   last-name: Coelho
-  orcid: 0000-0002-9280-7885
-  pronouns: he/him
+  orcid: 0000-0002-8046-9831
+  pronouns: he/them
   twitter: luispedrocoelho
-  website: http://luispedro.org
+  website: https://luispedro.org
 lukehare:
   affiliation: The Alan Turing Institute
   city: London
@@ -2859,20 +2907,19 @@ lydia-france:
   orcid: 0000-0003-4392-568X
 macelik:
   affiliation: Bezmialem Vakif University
-  bio: I studied Bioinformatics at University Malaya in Malaysia, and doing my MSc
-    at Konya Food and Agriculture University. I am currently working for a research
-    institute (Beykoz Institute of Life Sciences and Biotechnology), which is part
-    of a local University (Bezmialem Vakıf Üniversitesi) in Istanbul.
+  bio: He is a PhD student and his general interest lies in developing and applying
+    computational methods and algorithms to analyze large collections of biological
+    data. At the moment, he is participating in a research project to develop a platform
+    for a real-time comprehensive study of viral proteomics.
   city: Istanbul
   country: Turkey
   expertise:
-  - Bioinformatics
-  - Virology
-  - Immunology
+  - Bioinformatics methods
+  - Workflow development
+  - Hpc management
   - Metagenomics
-  - Evolutionary Trace Analysis
-  - miRNA analysis
   - Galaxy
+  - Open science;
   first-name: Muhammet
   last-name: Celik
   pronouns: He/Him
@@ -2920,20 +2967,11 @@ malloryfreeberg:
   pronouns: she/her
   twitter: malloryfreeberg
 malvikasharan:
-  bio: 'Malvika Sharan is the community manager of [_The Turing Way-](https://the-turing-way.netlify.com)
-    at [The Alan Turing Institute](https://turing.ac.uk).
-
-    Malvika works with its community of diverse members to develop resources and ways
-    that can make data science accessible for a wider audience.
-
-    Malvika has a PhD in Bioinformatics and she worked at  [European Molecular Biology
-    Laboratory](http://embl.org), Germany, that helped her solidify her values as
-    an Open Researcher and community builder.
-
-    She is a co-founder of the Open Life Science program, a fellow of [Software Sustainability
-    Institute](https://software.ac.uk/about/fellows/malvika-sharan), a board member
-    of [Open Bioinformatics Foundation](https://www.open-bio.org/board/), and a contributing
-    member of [The Carpentries](https://carpentries.org/) community.'''
+  bio: |-
+    Malvika Sharan is the community manager of [_The Turing Way-](https://the-turing-way.netlify.com) at [The Alan Turing Institute](https://turing.ac.uk).
+    Malvika works with its community of diverse members to develop resources and ways that can make data science accessible for a wider audience.
+    Malvika has a PhD in Bioinformatics and she worked at  [European Molecular Biology Laboratory](http://embl.org), Germany, that helped her solidify her values as an Open Researcher and community builder.
+    She is a co-founder of the Open Life Science program, a fellow of [Software Sustainability Institute](https://software.ac.uk/about/fellows/malvika-sharan), a board member of [Open Bioinformatics Foundation](https://www.open-bio.org/board/), and a contributing member of [The Carpentries](https://carpentries.org/) community.'
   city: London
   country: United Kingdom
   expertise:
@@ -3308,13 +3346,8 @@ mishrose123:
   twitter: mishrose2
   website: https://www.ebi.ac.uk/about/people/michelle-mendonca
 mkuzak:
-  bio: 'Mateusz is Research Software Community Manager at the Netherlands eScience
-    Center. He has background in life sciences and have been working with bioinformatics
-    data analysis and research software engineering. Past few years he has been involved
-    in the Carpentries as an instructor, trainer and mentor (both in the mentoring
-    subcommittee and mentoring teams).
-
-    '
+  bio: |
+    Mateusz is Research Software Community Manager at the Netherlands eScience Center. He has background in life sciences and have been working with bioinformatics data analysis and research software engineering. Past few years he has been involved in the Carpentries as an instructor, trainer and mentor (both in the mentoring subcommittee and mentoring teams).
   country: The Netherlands
   expertise:
   - Training
@@ -3384,6 +3417,27 @@ mruizvelley:
   orcid: 0000-0002-9248-1280
   pronouns: she/her
   twitter: mruizvelley
+msundukova:
+  bio: 'Mayya is a physicist by training, neuroscientist by experience and artist
+    by calling. Her favourite research topics evolve around touch/pain and fluorescent
+    tools to render invisible processes glowing. SISSA, EMBL, MCSA alumna, now an
+    Eccentric Mentor. Her motto is: "It is..what is if?"'
+  city: Bilbao
+  country: Spain
+  expertise:
+  - Neuroscience
+  - Electrophysiology
+  - Microscopy
+  - Creative thinking
+  - Reflection
+  - Work-life balance
+  - Mobility
+  - Transition
+  first-name: Mayya
+  last-name: Sundukova
+  orcid: 0000-0003-1328-0008
+  pronouns: she/her
+  twitter: mayya_sundukova
 muhammetcelik:
   country: Turkey
   first-name: Muhammet
@@ -3650,19 +3704,21 @@ pescini:
   pronouns: he/him
   twitter: darioPescini
 pherterich:
+  affiliation: Dcc, University Of Edinburgh
   bio: Patricia is currently a Research Data Specialist working at the Digital Curation
-    Centre at the University of Edinburgh working on the FAIRsFAIR project aiming
-    at fostering Fair Data Practices in Europe. Before joining the DCC, she was the
-    Research Repository Advisor at the University of Birmingham and have previously
-    worked as a data librarian at CERN''s Scientific Information Service working closely
+    Centre at the University of Edinburgh. Before joining the DCC, she was the Research
+    Repository Advisor at the University of Birmingham and have previously worked
+    as a data librarian at CERN’’s Scientific Information Service working closely
     with software developers to deliver data and code sharing solutions. She loves
     collaborating openly and making projects welcoming to new comers.
+  city: Edinburgh
   country: United Kingdom
   expertise:
-  - Data management
+  - Research data management
+  - Fair data
   - Collaboration
   - Library and archiving skills
-  - Open Science and community
+  - Open science and community
   first-name: Patricia
   last-name: Herterich
   orcid: 0000-0002-4542-9906
@@ -3713,16 +3769,11 @@ prakriti-karki:
   pronouns: She/her
 prashbio:
   affiliation: Bioclues.Org
-  bio: 'A Systems Biologist with wide interests in the areas on functional genomics,
-    protein informatics and interactions.
-
-    *Principal Investigator for four or more projects coalescing keywords #HypotheticalProteins
-    #VitaminK #LncRNAs #ProstateCancer
-
-    *Founder of Bioclues.org, India''s largest bioinformatics society working for
-    mentor-mentee relationships since 2005.
-
-    *Advocate #OpenAcess and #OpenSource'
+  bio: |-
+    A Systems Biologist with wide interests in the areas on functional genomics, protein informatics and interactions.
+    *Principal Investigator for four or more projects coalescing keywords #HypotheticalProteins #VitaminK #LncRNAs #ProstateCancer
+    *Founder of Bioclues.org, India's largest bioinformatics society working for mentor-mentee relationships since 2005.
+    *Advocate #OpenAcess and #OpenSource
   city: Jaipur
   country: India
   expertise:
@@ -3832,6 +3883,29 @@ rainsworth:
   pronouns: she/her
   twitter: rachaelevelyn
   website: https://rainsworth.github.io/
+raphaels1:
+  affiliation: Wellcome
+  bio: I'm a Technology Manager at Wellcome, a Research Associate at Imperial College
+    London, and a Senior Postdoctoral Fellow at University of Kaiserslautern. I have
+    a PhD in Statistics (specifically ML for survival analysis) from UCL and gained
+    experience in mathematical modelling from working in Prof. Neil Ferguson's COVID
+    response team.
+  city: London
+  country: United Kingdom
+  expertise:
+  - Machine learning
+  - Ethical modelling
+  - Risk and uncertainty communication
+  - Transparent and accessible ai
+  - Automl
+  - Benchmarking
+  - Survival analysis (and fundamental problems)
+  first-name: Raphael
+  last-name: Sonabend
+  orcid: 0000-0001-9225-4654
+  pronouns: They/He
+  twitter: RaphaelS101
+  website: https://http://www.raphaelsonabend.co.uk (don't open in Safari!)
 rgaiacs:
   bio: Raniere is a PhD student at Department of Infectious Diseases and Public Health,
     City University of Hong Kong. He worked with the Software Sustainability Institute
@@ -3987,18 +4061,26 @@ santi-rello-varona:
   pronouns: he/him
   twitter: KropTor
 santosrac:
-  bio: Bioinformatician working on genomics and transcriptomics of ascomycete and
-    basidiomycete fungi. Interested in education, teaching programming skills to bioscientists,
-    and in open science.
+  affiliation: Changing From Unicamp To Another Institution (Post-Doc)
+  bio: I am biologist. I worked with fungal genomics during my master and doctorate
+    projects. Over my career, I organized several workshops for teaching programming
+    skills to bioscientists, including the Brazilian Python Workshop for Biological
+    Data. This year (2022), I will be an Ambassador in the eLife Community Ambassadors
+    program.
+  city: Piracicaba
   country: Brazil
   expertise:
   - Bioinformatics
-  - Introduction to programming skills (Python or Perl)
-  - Fungal Biology
-  first-name: Renato Augusto Corrêa
-  last-name: dos Santos
-  pronouns: he/him
+  - Genomics
+  - Transcriptomics
+  - Omics
+  - Education
+  first-name: Renato Augusto
+  last-name: Correa Dos Santos
+  orcid: 0000-0003-0826-5479
+  pronouns: He
   twitter: CorreaSantosRA
+  website: https://santosrac.netlify.app/
 saranjeetkaur:
   bio: I am a Statistician by training. I have completed the Google Summer of Code
     2020 with the Turing team of the Julia language organisation. Recently I have
@@ -4052,15 +4134,10 @@ satagopam7:
 sayalaruano:
   affiliation: Regional Student Group Ecuador, Part Of The International Society For
     Computational Biology Student Council
-  bio: 'I am a focused and motivated young researcher that has worked in Bioinformatics
-    for four years at different laboratories. Phylogenetics and Structural Bioinformatics
-    have been the main topics of this research experience. However, my current interests
-    are devoted to Network Science, Complex Systems, and Machine Learning to understand
-    different biological phenomena.
+  bio: |-
+    I am a focused and motivated young researcher that has worked in Bioinformatics for four years at different laboratories. Phylogenetics and Structural Bioinformatics have been the main topics of this research experience. However, my current interests are devoted to Network Science, Complex Systems, and Machine Learning to understand different biological phenomena.
 
-
-    I am involved in various initiatives to empower Bioinformatics in Ecuador and
-    Latin America.'
+    I am involved in various initiatives to empower Bioinformatics in Ecuador and Latin America.
   city: Quito
   country: Ecuador
   expertise:
@@ -4102,15 +4179,16 @@ sebastianeggert:
   pronouns: he/his
   twitter: se_eggert
 selgebali:
-  affiliation: Opencider
-  bio: I'm a Research Data Manager, with a background in scientific curation, and
+  affiliation: Scilifelab-Data Centre
+  bio: I’m a Research Data Manager, with a background in scientific curation, and
     cancer research. Graduate of elife innovation leaders program with OpenCIDER (Open
-    Computational Inclusion and Digital Equity Resource).
+    Computational Inclusion and Digital Equity Resource) and cofounder of FAIRPoints
+    https://www.fairpoints.org/.
   city: Gothenburg
   country: Sweden
   expertise:
   - Research data management
-  - Open science
+  - Scientific biocuration
   - Fair principles
   - Computational inclusion
   - Digital equity
@@ -4121,7 +4199,7 @@ selgebali:
   orcid: 0000-0003-1378-5495
   pronouns: she/her
   twitter: yalahowy
-  website: https://www.opencider.org/
+  website: https://www.fairpoints.org/
 serahrono:
   affiliation: The Carpentries
   bio: Serah Rono is a computer scientist and writer with a knack and deep seated
@@ -4289,24 +4367,22 @@ stefan-gaillard:
   twitter: sdmgaillard
 stefaniebutland:
   affiliation: Ropensci
-  bio: I have my dream job as the Community Manager for rOpenSci. I'm a biologist,
-    bioinformatician, and compulsive people-connector and knowledge-sharer. I was
-    one of the inaugural AAAS Community Engagement Fellows and am actively involved
-    with the new Center for Scientific Collaboration and Community Engagement. My
-    former research life involved bacteria, plants, insects, and mammals, first at
-    the bench and then on a laptop. At rOpenSci I'm helping building up the social
-    and technical infrastructure for open and reproducible research with shared data
-    and reusable software.
+  bio: I'm a tech community manager and reformed research scientist who can never
+    resist connecting people, sharing knowledge, and helping people recognize the
+    value they bring to a project. I am actively involved with the Center for Scientific
+    Collaboration and Community Engagement as one of the inaugural Community Engagement
+    Fellows, a mentor, and member. My research life involved bacteria, plants, insects,
+    and mammals, first at the bench and then on a laptop. I was rOpenSci's Community
+    Manager from 2016 to 2022.
   city: Kamloops
   country: Canada
   expertise:
-  - Community building
+  - Building inclusive sustainable communities
   - Communicating in the open
-  - Maintaining a blog
-  - Open software peer review
-  - R
-  - GitHub
   - Virtual events
+  - Github
+  - ' r'
+  - Open software peer review
   first-name: Stefanie
   last-name: Butland
   orcid: 0000-0002-5427-8951
@@ -4336,6 +4412,17 @@ tai-rocha:
   last-name: Rocha
   orcid: 0000-0001-6874-2447
   twitter: Tai_Rocha_
+teresa-cisneros:
+  bio: I practice where I am from which is the MX/TX border the centres a politics
+    of collective action and care.
+  city: London
+  country: England
+  expertise:
+  - Equity
+  - Diversity and inclusion (transformative justice approaches)
+  first-name: Teresa
+  last-name: Cisneros
+  twitter: chicanaEnLondon
 teresa-m:
   affiliation: University Of Freiburg, Bioinformatics Group
   bio: I am Teresa, a PhD student in the Backofen lab at the University of Freiburg.
@@ -4557,17 +4644,15 @@ vcheplygina:
   twitter: DrVeronikaCH
   website: https://www.veronikach.com
 vickynembaware:
-  bio: 'Vicky has a PhD in Bioinformatics and an MPhil in Monitoring and Evaluation.
-
-    Her research experience (qualitative and quantitative) spans Genomics and Public
-    Health. She is currently a Project Coordinator for the Sickle Africa Data Coordinating
-    Center at the University of Cape Town. She also coordinates several other groups
-    and projects including the African Genomic Medicine Training Initiative (AGMT),
-    Sickle Cell Disease Ontology Working Group (SCDO) and mGenAfrica.
-
-    She is the current secretary of the African Society of Human Genetics (AfSHG).
-    She is passionate about building research capacity, mentoring young investigators
-    and translational research. '
+  bio: "Vicky has a PhD in Bioinformatics and an MPhil in Monitoring and Evaluation.\n\
+    Her research experience (qualitative and quantitative) spans Genomics and Public\
+    \ Health. She is currently a Project Coordinator for the Sickle Africa Data Coordinating\
+    \ Center at the University of Cape Town. She also coordinates several other groups\
+    \ and projects including the African Genomic Medicine Training Initiative (AGMT),\
+    \ Sickle Cell Disease Ontology Working Group (SCDO) and mGenAfrica.\nShe is the\
+    \ current secretary of the African Society of Human Genetics (AfSHG). She is passionate\
+    \ about building research capacity, mentoring young investigators and translational\
+    \ research. "
   country: South Africa
   expertise:
   - Bioinformatics
@@ -4601,18 +4686,15 @@ wykhuh:
   last-name: Kwan
   orcid: 0000-0001-6113-0210
 yochannah:
-  bio: Yo is Open Source Technology Lead at the Wellcome Trust's Data for Science and 
-    Health team, a [Software Sustainability Institute Fellow](https://software.ac.uk/about/fellows/yo-yehudi),
-    co-founder of [Open Life Science](https://openlifesci.org/) and 
-    [Code is Science](http://www.codeisscience.com/manifesto), 
-    [EngD student at the University of 
-    Manchester](https://www.research.manchester.ac.uk/portal/yochannah.yehudi-postgrad.html) 
-    studying pathogen-related data sharing and sustainability of open source 
-    software. Previously, they were editor for the [PLOS Open Source 
-    Toolkit](https://channels.plos.org/open-source-toolkit), editor emeritus at the 
-    [Journal of Open Source Software](https://joss.theoj.org/), board member of the
-    [Open Bioinformatics Foundation](https://www.open-bio.org/board/), and a 
-    software developer at the University of Cambridge, working on an open source
+  bio: Yo is Open Source Technology Lead at the Wellcome Trust's Data for Science
+    and Health team, a [Software Sustainability Institute Fellow](https://software.ac.uk/about/fellows/yo-yehudi),
+    co-founder of [Open Life Science](https://openlifesci.org/) and [Code is Science](http://www.codeisscience.com/manifesto),
+    [EngD student at the University of Manchester](https://www.research.manchester.ac.uk/portal/yochannah.yehudi-postgrad.html)
+    studying pathogen-related data sharing and sustainability of open source software.
+    Previously, they were editor for the [PLOS Open Source Toolkit](https://channels.plos.org/open-source-toolkit),
+    editor emeritus at the [Journal of Open Source Software](https://joss.theoj.org/),
+    board member of the [Open Bioinformatics Foundation](https://www.open-bio.org/board/),
+    and a software developer at the University of Cambridge, working on an open source
     biological data warehouse called [InterMine](http://intermine.org/).
   country: United Kingdom
   expertise:

--- a/_posts/2022-03-03-ols-5-annoucement.md
+++ b/_posts/2022-03-03-ols-5-annoucement.md
@@ -1,0 +1,123 @@
+---
+layout: post
+title: Meet our fifth cohort of project leads and their mentors
+authors:
+- bebatut
+- malvikasharan
+- yochannah
+- emmyft
+image: https://images.unsplash.com/photo-1523948045103-b6f020310a21?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1170&q=80
+photos:
+  name: Keenan Constance
+  license: CC-BY
+  url: https://unsplash.com/photos/vqfcd3A04BM
+---
+
+*We are excited to kick-off the fifth round of Open Life Science with another incredible cohort of mentors, mentees, and experts. We are honored to bring together members of diverse identities and backgrounds who represent expertise from different domains of research, who are working to address a wide range of relevant questions in their field and are motivated to bring a culture change in their areas. Many of them are long-standing Open Scientists who aim to use this opportunity to apply open science and community-based principles in their projects through this program.*
+
+{% assign people = site.data.people %}
+{% assign projects = site.data.ols-5-projects %}
+{% assign experts = site.data.ols-5-metadata.experts %}
+{% assign cohort = 'ols-5' %}
+
+<!-- extract previous participants and mentors and count them later among mentors -->
+{% assign prev-projects = site.data.ols-4-projects %}
+{% assign prev-participants = '' %}
+{% assign prev-mentors = '' %}
+{% for project in prev-projects %}
+    {% for p in project.participants %}
+        {% capture prev-participants %}{{ prev-participants }}, {{ p }}{% endcapture %}
+    {% endfor %}
+    {% for m in project.mentors %}
+        {% capture prev-mentors %}{{ prev-mentors }}, {{ m }}{% endcapture %}
+    {% endfor %}
+{% endfor %}
+
+{% assign all-participants = '' %}
+{% assign all-p-countries = '' %}
+{% assign all-mentors = '' %}
+{% assign all-m-countries = '' %}
+{% assign all-keywords = '' %}
+{% assign prev-part-count = 0 %}
+{% assign prev-mentor-count = 0 %}
+
+{% for project in projects %}
+
+<!-- parse participants of the project -->
+    {% for p in project.participants %}
+<!-- for name and link to them -->
+        {% capture all-participants %}{{ all-participants }}, [{{ people[p].first-name }} {{ people[p].last-name }}](/{{ cohort }}/projects-participants#{{ p }}){% endcapture %}
+<!-- for list of countries -->
+        {% if people[p].country %}
+            {% capture all-p-countries %}{{ all-p-countries }}, {{ people[p].country }}{% endcapture %}
+        {% endif %}
+    {% endfor %}
+
+<!-- parse mentors of the project -->
+    {% for m in project.mentors %}
+<!-- for name and link to them -->
+        {% capture all-mentors %}{{ all-mentors }}, [{{ people[m].first-name }} {{ people[m].last-name }}](/{{ cohort }}#{{ m }}){% endcapture %}
+<!-- for list of countries -->
+        {% if people[m].country %}
+            {% capture all-m-countries %}{{ all-m-countries }}, {{ people[m].country }}{% endcapture %}
+        {% endif %}
+<!-- add +1 if participant in previous cohort -->
+        {% if prev-participants contains m %}
+            {% assign prev-part-count = prev-part-count | plus: 1 %}
+        {% endif %}
+<!-- add +1 if mentor in previous cohort -->
+        {% if prev-mentors contains m %}
+            {% assign prev-mentor-count = prev-mentor-count | plus: 1 %}
+        {% endif %}
+    {% endfor %}
+
+<!-- parse keywords -->
+    {% for k in project.keywords %}
+        {% capture all-keywords %}{{ all-keywords }}, {{ k }}{% endcapture %}
+    {% endfor %}
+{% endfor %}
+
+<!-- transform into lists -->
+{% assign p-participants = all-participants | remove_first: ', ' | split: ", " | uniq | sort %}
+{% assign p-countries = all-p-countries | remove_first: ', ' | split: ", " | uniq | sort %}
+{% assign p-mentors = all-mentors | remove_first: ', ' | split: ", " | uniq | sort %}
+{% assign m-countries = all-m-countries | remove_first: ', ' | split: ", " | uniq | sort %}
+{% assign keywords = all-keywords | remove_first: ', ' | split: ", " | uniq | sort %}
+
+We are thrilled to announce that [{{ p-participants | size }} members](/{{ cohort }}/projects-participants/#participants), who are the project leads of [{{ projects | size }} diverse projects](/{{ cohort }}/projects-participants/#projects), have joined the fourth cohort of the Open Life Science mentoring program - OLS-5!
+
+### Meet our mentees!
+
+The mentees joining this program are {{ p-participants | join: ', ' }}. These individuals are based in {{ p-countries | size }} countries ({{ p-countries | join: ', ' }}) where they will be leading their respective projects.
+
+Topics for their projects include {{ keywords | join: ', ' }}.
+
+### Meet our mentors!
+
+Our project leads (aka mentees) have been paired with 1 or 2 mentors based on their specific requirements of expertise and interests along with time zones and language preferences. Our mentors are Open Science champions with previous experiences in training, mentoring, computing, and community skills. They are currently working in different professions in data science, education, citizen science, publishing, community building, software development, clinical studies, industries, scientific training, policymaking, IT services, and so on.
+
+Additionally, we have an incredible experts' community who will be delivering specialised talks during the cohort calls and will be available for our project leads for expert consultations upon request.
+
+We welcome our {{ p-mentors | size }} mentors, {{ p-mentors | join: ', ' }}, based in {{ m-countries | size }} countries ({{ m-countries | join: ', ' }}). {{ prev-part-count }} of them were participants and {{ prev-mentor-count }} mentors in the [previous cohort (OLS-4)](/ols-4). They will be supported by [{{ experts | size }} experts](/{{ cohort }}#experts).
+
+We are extremely grateful to them for their support and contributions to OLS and their impactful work in other open communities. They are committed to supporting their mentees in this program to help create a more open and fair-research, knowledge-sharing and inclusive culture within life science and beyond.
+
+### The Program
+
+We begin our program this week with a mentoring training call and mentor-mentee introductions. Check out the complete schedule and plans for OLS-5 here: [{{ site.url }}/{{ cohort }}](/{{ cohort }}).
+
+You can keep track of our program, the progress of our second cohort and future announcements by following our twitter profile [@{{ site.twitter }}](https://twitter.com/{{ site.twitter }}) or subscribe to [our announcements list]({{ site.announcement_list }}).
+
+We invite new contributions to the program as a [new issue on the GitHub repo]({{ site.github.repository_url }}/issues) or by [email to the team](mailto:{{ site.email }}).
+
+Once again, let's welcome our mentors, mentees and experts to this program!
+
+## Project details ([click here for full description](/{{ cohort }}/projects-participants/))
+
+| Project | Project leaders | Mentors |
+|----------|-----------------------|------------|
+{%- for project in projects %}
+| [{{ project.name }}](/{{ cohort }}/projects-participants/#{{ project.name | downcase | remove: "(" | remove: ")" | remove: "@" | remove: ":" | remove: "," | replace: " ", "-" }}) | {% capture p-participants %} {% for p in project.participants -%}, [{{ people[p].first-name }} {{ people[p].last-name }}](/{{ cohort }}/projects-participants#{{ p }}){% endfor %} {% endcapture %} {{ p-participants | remove_first: ', ' }} | {% capture p-mentors %} {% for p in project.mentors -%}, [{{ people[p].first-name }} {{ people[p].last-name }}](/{{ cohort }}#{{ p }}){% endfor %} {% endcapture %} {{ p-mentors | remove_first: ', ' }} |
+{%- endfor %}
+
+We wish our cohort members all the best as they begin this journey with us.

--- a/bin/add_mentors_experts.sh
+++ b/bin/add_mentors_experts.sh
@@ -1,11 +1,14 @@
 #!/usr/bin/env bash
 
 [ ! -e "mentor_update" ] || rm "mentor_update"
-python bin/extractpeople.py \
-    --url "https://docs.google.com/spreadsheets/d/1n-cZTJI27kfrXmvIWYIFQXab_27EArm2C-QBnkSY7iM/export?format=csv&gid=1983788876" \
-    >> "mentor_update"
+python bin/prepare_website_data.py addmentorsexperts \
+    -c 5 \
+    -t "mentor" \
+    -du "https://docs.google.com/spreadsheets/d/1cf_eT5_GSw3kH6W4BKpzYTeXCqwVzlaig16XyPpte0Q/export?format=csv&gid=1347834503"
 
 [ ! -e "expert_update" ] || rm "expert_update"
-python bin/extractpeople.py \
-    --url "https://docs.google.com/spreadsheets/d/1n-cZTJI27kfrXmvIWYIFQXab_27EArm2C-QBnkSY7iM/export?format=csv&gid=75468187" \
-    >> "expert_update"
+python bin/prepare_website_data.py addmentorsexperts \
+    -c 5 \
+    -t "expert" \
+    -du "https://docs.google.com/spreadsheets/d/1cf_eT5_GSw3kH6W4BKpzYTeXCqwVzlaig16XyPpte0Q/export?format=csv&gid=830320790"
+

--- a/bin/add_mentors_experts.sh
+++ b/bin/add_mentors_experts.sh
@@ -1,12 +1,10 @@
 #!/usr/bin/env bash
 
-[ ! -e "mentor_update" ] || rm "mentor_update"
 python bin/prepare_website_data.py addmentorsexperts \
     -c 5 \
     -t "mentor" \
     -du "https://docs.google.com/spreadsheets/d/1cf_eT5_GSw3kH6W4BKpzYTeXCqwVzlaig16XyPpte0Q/export?format=csv&gid=1347834503"
 
-[ ! -e "expert_update" ] || rm "expert_update"
 python bin/prepare_website_data.py addmentorsexperts \
     -c 5 \
     -t "expert" \

--- a/bin/prepare_website_data.py
+++ b/bin/prepare_website_data.py
@@ -94,7 +94,7 @@ def get_people_ids(names, people):
     if not pd.isnull(names):
         names = names.replace(' and ', ', ').title().split(', ')
         for n in names:
-            ids.append(get_people_id(n, people))
+            ids.append(get_people_id(n.rstrip(), people))
 
     return ids
 
@@ -159,6 +159,11 @@ def extract_people_info(row, people):
     github = github.replace('https://github.com/', '')
     github = github.rstrip()
     github = github.lower().replace(' ', '-').replace('@', '')
+    # format country
+    if info['country'] is not None:
+        info['country'] = info['country'].replace('UK', 'United Kingdom')
+        info['country'] = info['country'].replace('US', 'United States')
+        info['country'] = info['country'].replace('USA', 'United States')
     # format ORCID
     if info['orcid'] is not None:
         info['orcid'] = info['orcid'].replace('https://orcid.org/', '')

--- a/environment.yml
+++ b/environment.yml
@@ -1,5 +1,5 @@
 
-name: open-life-science-website
+name: ols-website
 channels:
   - conda-forge
   - defaults
@@ -9,7 +9,7 @@ dependencies:
   - nodejs
   - openssl
   - readline
-  - ruby
+  - ruby=2.6.6
   - yaml
   - yamllint
   - zlib
@@ -17,3 +17,4 @@ dependencies:
   - pkg-config
   - pandas
   - pyyaml
+  - gxx_linux-64


### PR DESCRIPTION
also update the script to add a command to add possible mentors / experts to a cohort (add to `people.yaml`, add to metadata file of the cohort, extract expertise)

Fix: #345 

