### PR TITLE
Add organisers section as well as founders section to about page

### DIFF
--- a/_data/organizers.yaml
+++ b/_data/organizers.yaml
@@ -1,0 +1,11 @@
+# List of people (alphabetical order)
+#
+# Collection names should be equal to github username,
+
+---
+organizers:
+- bebatut
+- emmyft
+- malvikasharan
+- pazbc
+- yochannah

--- a/_data/people.yaml
+++ b/_data/people.yaml
@@ -4497,7 +4497,7 @@ paulvill:
   pronouns: he/him
   twitter: paulvilloutreix
   website: https://paulcinq.wordpress.com
-pazb:
+pazbc:
   bio: I am the Community Researcher and Programme Coordinator for OLS. Previous to joining the OLS team, I worked on a project that questioned who gets to participate in scientific processes and in what capacity, who gets to be called “contributor”, and who gets to decide what the problems are in the first place. That project was called [Vuela](https://vuela.cc/) and we copied first and then modified an open source drone (Go Open Hardware!) with the help of many usual suspects (like researchers, open science enthusiasts) but also many very unusual suspects like adult immigrants who never went to university. My formal academic background is in humanities and social sciences, so no surprise that issues of governance, power and inequity in knowledge creation and sharing are what motivate me the most.
   country: Argentina
   expertise:

--- a/_data/people.yaml
+++ b/_data/people.yaml
@@ -4502,6 +4502,7 @@ pazb:
   country: Argentina
   expertise:
   - Social Science
+  - Qualitative Research
   first-name: Paz
   last-name: Bernaldo
   pronouns: she/her

--- a/_data/people.yaml
+++ b/_data/people.yaml
@@ -4498,7 +4498,7 @@ paulvill:
   twitter: paulvilloutreix
   website: https://paulcinq.wordpress.com
 pazb:
-  bio: Add Bio
+  bio: I am the Community Researcher and Programme Coordinator for OLS. Previous to joining the OLS team, I worked on a project that questioned who gets to participate in scientific processes and in what capacity, who gets to be called “contributor”, and who gets to decide what the problems are in the first place. That project was called [Vuela](https://vuela.cc/) and we copied first and then modified an open source drone (Go Open Hardware!) with the help of many usual suspects (like researchers, open science enthusiasts) but also many very unusual suspects like adult immigrants who never went to university. My formal academic background is in humanities and social sciences, so no surprise that issues of governance, power and inequity in knowledge creation and sharing are what motivate me the most.
   country: Argentina
   expertise:
   - Social Science
@@ -4506,8 +4506,8 @@ pazb:
   first-name: Paz
   last-name: Bernaldo
   pronouns: she/her
-  twitter: pazb
-  website: Add website
+  twitter: pazByC
+  website: https://openlifesci.org/posts/2022/08/10/welcome-paz/
 pescini:
   affiliation: University Of Milano-Bicocca
   city: Milan

--- a/_data/people.yaml
+++ b/_data/people.yaml
@@ -4497,6 +4497,16 @@ paulvill:
   pronouns: he/him
   twitter: paulvilloutreix
   website: https://paulcinq.wordpress.com
+pazb:
+  bio: Add Bio
+  country: Argentina
+  expertise:
+  - Social Science
+  first-name: Paz
+  last-name: Bernaldo
+  pronouns: she/her
+  twitter: pazb
+  website: Add website
 pescini:
   affiliation: University Of Milano-Bicocca
   city: Milan

--- a/_includes/default-header.html
+++ b/_includes/default-header.html
@@ -76,7 +76,7 @@
               <a class="navbar-item" href="/about#mentees"> Mentees </a>
               <a class="navbar-item" href="/about#mentors"> Mentors </a>
               <a class="navbar-item" href="/about#experts"> Experts </a>
-              <a class="navbar-item" href="/about#founders"> Founders </a>
+              <a class="navbar-item" href="/about#organisers"> Organisers </a>
               <a class="navbar-item" href="/funders"> Funding, Funders and Partners </a>
               <a class="navbar-item" href="/community"> Community </a>
               <a class="navbar-item" href="/code-of-conduct"> Code of Conduct </a>

--- a/about.md
+++ b/about.md
@@ -14,6 +14,7 @@ This program can only run with the active involvements of our volunteer communit
 - [Mentors](#mentors)
 - [Experts](#experts)
 - [Facilitators](#facilitators)
+- [Organisers](#organisers)
 - [Founders](#founders)
 
 # Mentees
@@ -60,7 +61,7 @@ They will meet their mentees every two weeks during the program and will attend 
 
 ## What are the benefits to be a mentor?
 
-Our mentors will 
+Our mentors will
 
 - gain mentoring skills (active listening, effective questioning, giving feedback) via mentoring training
 - learn to celebrate successes and approach challenges in mentoring
@@ -171,11 +172,23 @@ Facilitators are invited to:
 
 This is an invitation-based role. Facilitators are offered an honourarium in recognition of their valuable contributions to the programme.
 
-# Founders
 
-{% assign organizers = site.data.ols-1-metadata.organizers %}
+# Organisers
+
+{% assign organizers = site.data.organizers.organizers %}
 <div class="people">
 {% for entry in organizers %}
+    {% assign username = entry %}
+    {% assign user = site.data.people[username] %}
+    {% include _includes/people.html user=user username=username %}
+{% endfor %}
+</div>
+
+# Founders
+
+{% assign founders = site.data.ols-1-metadata.organizers %}
+<div class="people">
+{% for entry in founders %}
     {% assign username = entry %}
     {% assign user = site.data.people[username] %}
     {% include _includes/people.html user=user username=username %}


### PR DESCRIPTION
Adds an organisers section to the main page - I didn't realise Emmy wasn't on there! 😱  and adds Paz too. 

Marking as WIP - @pazbc, I think we need your bio for this, same as what we've been asking OLS-6 participants for. 

<img width="1377" alt="preview shows Emmy, Malvika, Berenice, Yo, and Paz, but Paz's profile is blank" src="https://user-images.githubusercontent.com/9271438/185669531-b59bf650-32f4-44a7-a719-db173e8b14d4.png">
