### PR TITLE
Fix Table Overflow

### DIFF
--- a/css/custom.scss
+++ b/css/custom.scss
@@ -59,8 +59,8 @@ $link-active: $link-hover;
   background-position: center center;
   background-repeat: no-repeat;
   background-size: cover;
-  height: auto;
-  width: 450px;
+  height: 450px;
+  width: 100%;
 
   &.no-image {
     height: auto;

--- a/css/custom.scss
+++ b/css/custom.scss
@@ -59,7 +59,7 @@ $link-active: $link-hover;
   background-position: center center;
   background-repeat: no-repeat;
   background-size: cover;
-  height: 450px;
+  height: auto;
   width: 100%;
 
   &.no-image {

--- a/css/custom.scss
+++ b/css/custom.scss
@@ -339,3 +339,19 @@ $link-active: $link-hover;
   margin-top: 25px;
   margin-bottom: 20px;
 }
+
+// table responsiveness (mobile)
+@media screen and (max-width: 768px) and (min-width: 480px) {
+  table {
+    font-size: 0.8em;
+    font-weight: 400;
+    line-height: 1.5;
+  }
+}
+@media screen and (max-width: 479px) and (min-width: 320px) {
+  table {
+    font-size: 0.5em;
+    font-weight: 350;
+    line-height: 2;
+  }
+}

--- a/css/custom.scss
+++ b/css/custom.scss
@@ -341,17 +341,12 @@ $link-active: $link-hover;
 }
 
 // table responsiveness (mobile)
-@media screen and (max-width: 768px) and (min-width: 480px) {
+@media screen and (max-width: 768px) and (min-width: 320px) {
   table {
-    font-size: 0.8em;
-    font-weight: 400;
+    font-size: 1em;
     line-height: 1.5;
-  }
-}
-@media screen and (max-width: 479px) and (min-width: 320px) {
-  table {
-    font-size: 0.5em;
-    font-weight: 350;
-    line-height: 2;
+    display: block;
+    overflow-x: auto;
+    padding-bottom: 20px;
   }
 }

--- a/css/custom.scss
+++ b/css/custom.scss
@@ -60,7 +60,7 @@ $link-active: $link-hover;
   background-repeat: no-repeat;
   background-size: cover;
   height: auto;
-  width: 100%;
+  width: 450px;
 
   &.no-image {
     height: auto;


### PR DESCRIPTION
This PR fixes issue #420.

The width of the table had caused other elements to have too much space on the right.
My solution was to write media queries using breakpoints between 768px to 320px. A reduction in `font-size` (and slight increase in `line-height`, to ensure readability), seemed to do the trick.

Additionally, this approach fixed alignment issues across other pages containing tables.

![ols-pr-resp](https://user-images.githubusercontent.com/105166953/195493143-357dedd9-b168-4a6e-9dd4-96e6b4d0fb17.png)

<br />

![ols-pr-resp2](https://user-images.githubusercontent.com/105166953/195493488-a0eb90d0-b778-4032-b3d6-6bc70827ef17.png)