### PR TITLE
Issue198: add project participant status to projects

### DIFF
--- a/_data/ols-1-projects.yaml
+++ b/_data/ols-1-projects.yaml
@@ -5,7 +5,7 @@
 - name: Open Science Community Barcelona (OSCBa)
   participants:
     - bonetcarne
-  mentors: 
+  mentors:
     - zebetus
   description: >
     This project aims to create a community of local scientists to share and promote open science in Barcelona,
@@ -26,12 +26,13 @@
     We will also use this plantform to motivate colleages from other parts of the country to create
     their own local community and then connect for some events.
 
-- name: Investigate feasible solutions to help create a system that creates, collects and processes
+- name:
+    Investigate feasible solutions to help create a system that creates, collects and processes
     data efficiently for impactful research especially for driving health research and driving health
     related policies
   participants:
     - ewuramaminka
-  mentors: 
+  mentors:
     - vickynembaware
   description: >
     Most sub Saharan African countries barely have quality health data for national policy
@@ -49,7 +50,7 @@
 - name: Infusing a culture of open science within the community of researchers at the Zuckerman Institute
   participants:
     - chiarabertipaglia
-  mentors: 
+  mentors:
     - mkuzak
   description: >
     The community of <a href="https://zuckermaninstitute.columbia.edu/">Columbia University’s Zuckerman Institute</a> is composed of neuroscientists at
@@ -66,7 +67,7 @@
     mapping, action plans, and outreach. In the long run, work done in this project aims at
     developing community engagement for policy development, and will ultimately pave the way to
     establish the Zuckerman Institute as a golden standard for open science.
-  graduated: true
+  status: graduated
 
 - name: Bioinformatics Hub of Kenya (BHK)
   participants:
@@ -91,12 +92,12 @@
     through peer training and mentorship to provide a pool of qualified bioinformaticians who will
     focus on innovation and bringing novelty to assigned projects promising quality, integrity,
     reliability and trust in their services.
-  graduated: true
+  status: graduated
 
 - name: Expanding plenoptic Python Package
   participants:
     - billbrod
-  mentors: 
+  mentors:
     - rodrigocam
   description: >
     <a href="https://pypi.org/project/plenpy/">plenoptic</a> is a Python package for computational
@@ -113,13 +114,13 @@
     comparison and validation experiments. We will include four such methods, all of which have been
     described in the literature, but none of which have standard, accessible implementations that work
     on more than a handful of specific models.
-  graduated: true
+  status: graduated
 
 - name: "@Diversidade em Foco"
   participants:
     - bruno-soares
     - naralb
-  mentors: 
+  mentors:
     - unode
   description: >
     [Biodiversidade em Foco](http://www.abc.org.br/atuacao/nacional/projeto-de-ciencia-para-o-brasil/biodiversidade-em-foco/)
@@ -135,7 +136,7 @@
     audience and promote science communication. Reports will consider the number of tweets,
     participants, their experience during the account administration time, the number of followers
     and reach information in the twitter account and the blog.
-  graduated: true
+  status: graduated
 
 - name: Media Lab Nepal for Computational Biology
   participants:
@@ -160,12 +161,12 @@
     we can benefit life sciences sector of whole country through open science
     initiative. I also want to make this initiative feasible and sustainable by creating
     incoming generating platform with computational biology.
-  graduated: true
+  status: graduated
 
 - name: InterMine Similarity Explorer
   participants:
     - lazycipher
-  mentors: 
+  mentors:
     - yochannah
   description: >
     <a href="http://intermine.org/">InterMine</a> is a powerful open source data warehouse system.
@@ -189,7 +190,7 @@
 - name: Open Connect Platform in Africa
   participants:
     - lilian9
-  mentors: 
+  mentors:
     - kipkurui
   description: >
     In Open community, there is disconnect between Open practitioners and advocates hence need for
@@ -199,12 +200,12 @@
     researchers in shaping Open policies each country at a time in Africa. Since Africa poses different and
     unique development dynamics, development of all phases of this project will put into consideration
     various divides such as rich vs poor, rural vs urban, research literate vs research illiterate among others.
-  graduated: true
+  status: graduated
 
 - name: EMBL Bio-IT Community Project
   participants:
     - unode
-  mentors: 
+  mentors:
     - malvikasharan
   description: >
     <a href="https://bio-it.embl.de">Bio-IT project</a> at the <a href="https://embl.org">European Molecular Biology Laboratory (EMBL)</a>
@@ -219,12 +220,12 @@
     who is my predecessor in Bio-IT. I want to take this opportunity to ensure a smooth
     knowledge transfer within the management team of the Bio-IT project and navigate my own
     path and future prospects as a community manager.
-  graduated: true
+  status: graduated
 
 - name: "Oxford Neuroscience Open Science Co-ordinator: Changing Culture"
   participants:
     - cassgvp
-  mentors: 
+  mentors:
     - npscience
   description: >
     The <a href="https://www.win.ox.ac.uk/">Wellcome Centre for Integrative Neuroscience (WIN)</a> and other centres in Oxford
@@ -240,13 +241,13 @@
     through an understanding of the principles of behavior change, including recognizing
     scientific and individual risks and benefits for research participants, researchers (at all
     levels), and the institution.
-  graduated: true
+  status: graduated
 
 - name: "AMRITA: an online database for herbal medicine"
   participants:
     - anayan321
     - davidviryachen
-  mentors: 
+  mentors:
     - hdinkel
   description: >
     In South East Asia, herbal medicine has been used over the century as preventive
@@ -260,7 +261,7 @@
     collaboration of researchers across the fields of biological, pharmaceutical, and clinical
     sciences in establishing a solid foundation of medicinal plants and enabling the use of these
     plants in modern medicine.
-  graduated: true
+  status: graduated
 
 - name: How to build an healthy and open lab
   participants:
@@ -284,12 +285,12 @@
     work open, project management tools etc.); how to train the next generation of open
     scientists; and how to open your work to the public. Finally, I would like to approach
     organisations and institutions to help more young PIs get access to these resources.
-  graduated: true
+  status: graduated
 
 - name: Benchmarking environment for bioinformatics tools
   participants:
     - homo-sapiens34
-  mentors: 
+  mentors:
     - luispedro
   description: >
     The aim of this project is to provide a flexible protocol and unified instruments for iterative
@@ -298,12 +299,12 @@
     updated each time somebody provide new data on the performance of any considered tool.
     There should be an ability to add new tools as well as new datasets to an existing
     comparison.
-  graduated: true
+  status: graduated
 
 - name: EDAM ontology
   participants:
     - matuskalas
-  mentors: 
+  mentors:
     - bgruening
   description: >
     <a href="http://edamontology.org/page">EDAM ontology</a> is a long-established project, defining a common, controlled vocabulary in
@@ -324,7 +325,7 @@
 
     The goal of this concrete mentorship project is to further extend EDAM, so that other
     communities can benefit from it, and from the applications and use cases it fosters.
-  graduated: true
+  status: graduated
 
 - name: Improving Documentation for Open Data and Software in the Agricultural Research Community
   participants:
@@ -332,7 +333,7 @@
     - dlebauer
     - magicmilly
     - sithyphus
-  mentors: 
+  mentors:
     - katrinleinweber
   description: >
     We are members of the Data Infrastructure for Agriculture Group at <a href="https://www.arizona.edu/">The University of Arizona</a>.
@@ -352,12 +353,12 @@
     have each person in the group complete a sub-project that can be finished in 15 weeks. Each
     sub-project would result in an accompanying blog post describing the best practices
     implemented.
-  graduated: true
+  status: graduated
 
 - name: Improving open platform accessibility
   participants:
     - christinerogers
-  mentors: 
+  mentors:
     - ha0ye
   description: >
     I'm a member of the technical team for LORIS (github.com/aces/loris), an open-source
@@ -377,12 +378,12 @@
     feasible in this timeline to also pilot open tools with a new project or as an extension to an
     existing project -- to start putting this idea into action.
     What problem(s)
-  graduated: true
+  status: graduated
 
 - name: Enabling open science practices in biology education
   participants:
     - morphofun
-  mentors: 
+  mentors:
     - fpsom
   description: >
     The proposed project would establish a foundation for developing a tutorial on training
@@ -400,13 +401,13 @@
     communication between lab members and make sure that expectations of the faculty mentor
     and student / staff mentees are fully transparent so that the mentoring process can be
     improved for science mentees.
-  graduated: true
+  status: graduated
 
 - name: Open Science UMontreal (OSUM)
   participants:
     - samguay
     - dannycolin
-  mentors: 
+  mentors:
     - ajstewartlang
   description: >
     In 2019, we founded Open Science UMontreal (OSUM) because we believe in an Open by Design approach
@@ -428,12 +429,12 @@
     If you're reading this and you're interested in open research feel free to come chat with us on
     <a href="https://chat.openscience.ca">chat.openscience.ca</a>, an open-source alternative to Slack!
     We want to get to know you (and your initiative)!
-  graduated: true
+  status: graduated
 
 - name: Creating network of Data Champions at the library of Free University of Amsterdam
   participants:
     - karvovskaya
-  mentors: 
+  mentors:
     - pherterich
   description: >
     From February 1st I am starting a new position as community manager RDM at the library
@@ -445,4 +446,4 @@
     proper handling of research data.<br>
     Similar programs have been launched at the University of Cambridge, TU Delft, and Wageningen University.
     The main goal of the Data Champion programme is to drive cultural change towards open science and open data.
-  graduated: true
+  status: graduated

--- a/_data/ols-2-projects.yaml
+++ b/_data/ols-2-projects.yaml
@@ -22,7 +22,7 @@
     Not only limited to materials, as well as virtual training
     by promoting the practuce of creating and sharing of Computational
     Environment and Analysis in a reproducible manner with systems in scaling.
-  graduated: true
+  status: graduated
 
 - name: Mapping Science using Open Scholarship
   participants:
@@ -65,7 +65,7 @@
     data, developing resources/training opportunities for students and early
     career researchers, and recommending/publishing guidelines for colleagues
     to follow.
-  graduated: true 
+  status: graduated
 
 - name: Synthetic Biology Chassis Toolkit for Public Domain Use
   participants:
@@ -85,7 +85,7 @@
     toolkit that exclusively uses technologies in the public domain is the first
     step towards providing scientists and non-scientists the tools to conduct
     science and create valuable biomaterials for their communities without restriction.
-  graduated: true
+  status: graduated
 
 - name: Creating a single pipeline for metagenome classification
   participants:
@@ -103,7 +103,7 @@
     pipeline that will produce a single pdf file with cutoff-significance-sensitivity
     values for each tool. Later we can set that pipeline on web-based system that
     would make the researchers easier for the scientists.
-  graduated: true
+  status: graduated
 
 - name: Chronic Learning
   participants:
@@ -119,7 +119,7 @@
     purposes, such as lecture slides or handouts. The materials are made up of
     a mixture of graphical abstracts, tutorials, and reference pdfs; I hope to
     incorporate more formats, such as videos, as well.
-  graduated: true
+  status: graduated
 
 - name: Open Innovation in Life Sciences
   participants:
@@ -142,7 +142,7 @@
     skills (e.g. teamwork, communication, etc.) and learning non-scientific
     expertise (e.g. project management, budgeting, advertising, etc.) to
     enhance traditional Ph.D. and Postdoctoral training.
-  graduated: true
+  status: graduated
 
 - name: Using collective action to change cultural norms and drive progress in the life sciences
   participants:
@@ -168,7 +168,7 @@
     reached, everyone who has signed that campaign will be listed on the website
     and directed to carry out the new behaviour in unison, with the protection
     of their peers.
-  graduated: true
+  status: graduated
 
 - name: Developing the Research Software and Systems Engineering Community to support Life Sciences in Africa
   participants:
@@ -209,7 +209,7 @@
     this personal project, I would like to advance my community building and
     project management skill while enhancing the connection with the
     communities outside Europe.
-  graduated: true
+  status: graduated
 
 #- name: Advancing MolPDF using open principles
 #  participants:
@@ -230,7 +230,6 @@
 #    working with open and reproducible software and workflows. Therefore, with
 #    my participation in this program, I would like to learn from my mentors
 #    about how to implement open science principles in my research.
-
 
 - name: Global land-use and land-cover data under historical, current, and future climatic conditions for ecologists
   participants:
@@ -255,7 +254,7 @@
     for thirty-seven time slices from year 900 to 2100, with the following
     temporal resolution - every 100 years from 900 to 1950, every 10 years from
     1950 to 2010, and every five years from 2010 to 2300.
-  graduated: true
+  status: graduated
 
 - name: BioLab Open Source Projects
   participants:
@@ -322,7 +321,7 @@
     global public issues. Connections with companies can also be established
     (for example, to help in the production of prototypes) but with the
     requirement of use open licenses and follow the precepts of this program.
-  graduated: true
+  status: graduated
 
 - name: Supervised Classification with UMAP and Network Propagation
   participants:
@@ -368,7 +367,7 @@
     divided into subsections of publications from the 7 continents to be able
     to easily identify how the disease is affecting different geographical
     locations.
-  graduated: true
+  status: graduated
 
 - name: Sharing 3D Modeling Workflows for Biomechanists and Palaeontologists
   participants:
@@ -391,7 +390,7 @@
     specifically want to build a website with open source workflows, tips and
     tricks for setting up models for finite element analysis, as well as other
     3D workflows (such as fossil reconstruction in freeware programs).
-  graduated: true
+  status: graduated
 
 - name: Open Science Office Hours to support trainees in Montreal to help make their research more open and reproducible
   participants:
@@ -417,7 +416,7 @@
     can compensate TA’s; this would help enable less-privileged trainees to get
     involved as TA's. Finally, we would need to recruit the TA's. Thus, this
     project will involve community contributions at all stages, in various capacities.
-  graduated: true
+  status: graduated
 
 - name: Registered Reports in Primate Neurophysiology
   participants:
@@ -441,7 +440,7 @@
     seems a particularly valuable idea. This project would explore ways in
     which to find compromise in the conflict between existing registered
     report formats and current methodologies in primate neurophysiology.
-  graduated: true
+  status: graduated
 
 - name: OSUM - Open Science UMontreal
   participants:
@@ -471,7 +470,7 @@
     is a broad and wide-ranging concept with domain-specific definitions,
     we want to provide opportunities to meet and encourage the exchange of
     ideas within and across fields because we can all learn from each other.
-  graduated: true
+  status: graduated
 
 - name: APBioNetTalks
   participants:
@@ -491,7 +490,7 @@
     resources and foster the growth of bioinformatics. Additionally, the
     program is also expected to reach wider audiences and introduce more people
     to the bioinformatics.
-  graduated: true
+  status: graduated
 
 - name: Database for coordinating training needs in Kenya to faciliatate preparation and collaboration
   participants:
@@ -515,7 +514,7 @@
     also allow collaboration of students from various institutions. From
     requests obtained, organization of talks and trainings can be more
     efficient and organized. These can transition into physical meetups eventually
-  graduated: true
+  status: graduated
 
 - name: Open platform for Indian Bioinformatics community
   participants:
@@ -535,7 +534,7 @@
     contributors & ambassadors. The aim of this project is to explore the scope
     and path towards establishing an open platform and provide opportunities to
     participate, contribute and organize open initiatives.
-  graduated: true
+  status: graduated
 
 - name: OpenWorkstation - A modular and open-source concept for customized automation equipment
   participants:
@@ -563,7 +562,7 @@
     reliable experimentation for in vitro research. Ultimately, the
     OpenWorkstation concept will allow empower academic groups to the develop
     their own equipment to automated their research workflows.
-  graduated: true
+  status: graduated
 
 - name: The Turing Way - Guide for Ethical Research
   participants:
@@ -588,7 +587,7 @@
     2. Equipping scientists working in a range of fields to advocate for ethical
     research at all stages of the research process.
     3. Compiling diverse research ethics resources in one area.
-  graduated: true
+  status: graduated
 
 - name: sktime - a unified toolbox for machine learning with time series
   participants:
@@ -607,7 +606,7 @@
     learning tasks, bringing together contributors from academia and the wider
     data science community into a joint framework and embedding best practices
     into the time series analysis field.
-  graduated: true
+  status: graduated
 
 - name: Turing Data Stories
   participants:
@@ -637,7 +636,7 @@
     or included.
     4. In order to maintain the quality of the results, the story
     should be peer-reviewed by other contributors before being published.
-  graduated: true
+  status: graduated
 
 - name: Embedding Accessibility in The Turing Way Open Source Community Guidance
   participants:
@@ -669,7 +668,7 @@
     All these tasks in The Turing Way will require me to integrate Open
     Science principles and community practices, which I am confident to learn
     with my participation in the Open Life Science training and mentoring program.
-  graduated: true
+  status: graduated
 
 - name: Towards open and citizen-led data informing the decarbonisation of existing housing
   participants:
@@ -695,7 +694,7 @@
     through a citizen science approach. This is an idea in development for follow-on
     research which requires data collection protocols, ethical guidelines and data
     repositories.
-  graduated: true
+  status: graduated
 
 - name: Autistica - Turing Citizen Science Project
   participants:
@@ -722,7 +721,7 @@
     co-designing the front-end interface with the input of the autistic
     community. Most important are a diverse and growing number of autistic
     participants and (sometimes overlapping) open source developers.
-  graduated: true
+  status: graduated
 
 - name: Arua City Open Learning Circles
   participants:
@@ -769,4 +768,3 @@
     learning and growth in various bioinformatics tools for our ex-trainees
     in this instance. Through my participation in OLS, I will adapt the Open
     learning Circles Concept to our community in UWC.
-

--- a/_data/ols-3-projects.yaml
+++ b/_data/ols-3-projects.yaml
@@ -2,7 +2,8 @@
 #
 # Check previous OLS for examples
 ---
-- description: Citizen science revolves around the idea of integrating the public
+- description:
+    Citizen science revolves around the idea of integrating the public
     in scientific research. However, there are different interpretations of this idea.
     An important part of citizen science projects allows laymen only to participate
     in a limited scope of microtasks and keeps thus reinforcing the power gap between
@@ -18,54 +19,57 @@
     first steps, I am working on a best practices guide, summarizing the experiences
     of existing similar projects.
   keywords:
-  - citizen science
-  - peer-production
-  - participatory design
+    - citizen science
+    - peer-production
+    - participatory design
   mentors:
-  - fpsom
+    - fpsom
   name: Best practices for online collaboration/peer-production in citizen science
   participants:
-  - katoss
-  graduated: true
-- description: VCMS (vcms.simonduerr.eu) is convenient tool to setup a website for
+    - katoss
+  status: graduated
+- description:
+    VCMS (vcms.simonduerr.eu) is convenient tool to setup a website for
     a virtual conference including an abstract submission portal, timezone adapted
     scheduling of talks and an interactive virtual poster session with video chat
     and spotlights for posters with some features still in development. The tool is
     currently in beta and will be released as FOSS under MPL once the software is
     battle tested (in mid february).
   keywords:
-  - conferences
-  - virtual
-  - poster session
+    - conferences
+    - virtual
+    - poster session
   mentors:
-  - ealescak
+    - ealescak
   name: A virtual conference management system with seamless open science integration
   participants:
-  - duerrsimon
-  graduated: true
-- description: 'The “Memory Collecting: Croatian Homeland War” project aims to create
+    - duerrsimon
+  status: graduated
+- description:
+    "The “Memory Collecting: Croatian Homeland War” project aims to create
     a platform where survivors can submit video recordings of their own memories and
     reflections of the 1992 Homeland War. The repository will also store them in a
     publicly accessible database. By having the software be open to citizen scientists,
     the database will be one of the most inclusive and easily accessible memory banks.
     This initiative seeks to preserve the memory of the role of Croatian-Americans
-    in the creation of free, modern Croatia during the Homeland War in the 1990s.'
+    in the creation of free, modern Croatia during the Homeland War in the 1990s."
   keywords:
-  - database
-  - video
-  - generational memory
-  - record
-  - document
-  - historical
-  - Croatia
-  - Diaspora
+    - database
+    - video
+    - generational memory
+    - record
+    - document
+    - historical
+    - Croatia
+    - Diaspora
   mentors:
-  - katesimpson
-  name: 'Memory Collecting: Croatian Homeland War'
+    - katesimpson
+  name: "Memory Collecting: Croatian Homeland War"
   participants:
-  - annalee-sekulic
-  graduated: true
-- description: "I want to help build a culture of open science and good practice (as\
+    - annalee-sekulic
+  status: graduated
+- description:
+    "I want to help build a culture of open science and good practice (as\
     \ well as fun) within the plant synthetic biology community, with an initial emphasis\
     \ on the US. \n\nI hope to do this by (1) establishing an open toolset for genetic\
     \ manipulation of algae and photosynthesis enzymes (2) developing an open repository\
@@ -73,29 +77,31 @@
     \ aid experimentation, both in academia and for citizen scientists (4) building\
     \ a community of interested individuals to expand and contribute to the project."
   keywords:
-  - synthetic biology
-  - community building
-  - citizen science
+    - synthetic biology
+    - community building
+    - citizen science
   mentors:
-  - smklusza
+    - smklusza
   name: Open Phototroph
   participants:
-  - sjb287
-- description: An open-source software tool and associated protocol repository that
+    - sjb287
+- description:
+    An open-source software tool and associated protocol repository that
     translates wet-lab protocols into instruction sets for commonly available robotic
     liquid handlers. Protocols will be hosted on a publically accessible website,
     and community members can edit, annotate, and report on different protocols. Think
     Github for biological protocols with an issue tracker.
   keywords:
-  - Robotics
-  - Synthetic Biology
-  - Open Source
-  - Community Enhancement
+    - Robotics
+    - Synthetic Biology
+    - Open Source
+    - Community Enhancement
   mentors: []
   name: Opensource Transpiler of Synthetic Biology Lab Protocols for Wetlab Robotics
   participants:
-  - '0x174'
-- description: This project is a field and laboratory based research project researching,
+    - "0x174"
+- description:
+    This project is a field and laboratory based research project researching,
     surveying, and discovering the palaeoecology and palaeogeography of West Cork.
     The project will make use of:- paper research methods; sampling and scientific
     analysis of sediments; digital mapping; field and site visits and landscape analysis;
@@ -114,25 +120,27 @@
     and environment and thus to give an understanding how the future development may
     progress.
   keywords:
-  - palaeoecology
-  - palaeoenvironment
-  - palynology
-  - interdependence
-  - interconnectedness
-  - landscape
-  - public
-  - geomorphology
-  - geology
-  - geography
-  - microscopy
-  - microfossils
+    - palaeoecology
+    - palaeoenvironment
+    - palynology
+    - interdependence
+    - interconnectedness
+    - landscape
+    - public
+    - geomorphology
+    - geology
+    - geography
+    - microscopy
+    - microfossils
   mentors:
-  - bruno-soares
-  name: Field and laboratory based research project researching, surveying, and discovering
+    - bruno-soares
+  name:
+    Field and laboratory based research project researching, surveying, and discovering
     the palaeoecology and palaeogeography of West Cork
   participants:
-  - robin-lewando
-- description: 'Actigraphy provides a measure of the 24h rest-activity cycles based
+    - robin-lewando
+- description:
+    "Actigraphy provides a measure of the 24h rest-activity cycles based
     on movement counts, typically of the wrist. It is obtained using wearable devices
     and is a widely used, non-invasive way to determine sleep and circadian properties.
     Importantly, metrics derived from actigraphy are being increasingly used in clinical
@@ -151,26 +159,27 @@
     actigraphy devices produced by different commercial manufacturers and for use
     by researchers and research users. This project builds upon core research and
     technical expertise amongst the team members, and provides a framework to structure
-    the work of the newly funded Chronobiology Data Standards Interest Group (CDSIG).'
+    the work of the newly funded Chronobiology Data Standards Interest Group (CDSIG)."
   keywords:
-  - open data
-  - open science
-  - data schemas
-  - metadata
-  - actigraphy
-  - actimetry
-  - rest-activity cycles
-  - circadian rhythms
-  - chronobiology
-  - sleep research
+    - open data
+    - open science
+    - data schemas
+    - metadata
+    - actigraphy
+    - actimetry
+    - rest-activity cycles
+    - circadian rhythms
+    - chronobiology
+    - sleep research
   mentors:
-  - malloryfreeberg
+    - malloryfreeberg
   name: Open data schema for actigraphy data in chronobiology and sleep research
   participants:
-  - spitschan
-  - ghammad
-  graduated: true
-- description: BioFerm is a web application platform which can be used for kinetic
+    - spitschan
+    - ghammad
+  status: graduated
+- description:
+    BioFerm is a web application platform which can be used for kinetic
     study, simulation and optimization of bioprocesses. The user is able to calculate
     the best initial conditions as well as overall operating conditions which will
     result in the highest product yield (or any user specified output). Kinetic modelling
@@ -183,19 +192,21 @@
     currently being written in Python using an open-source app framework(streamlit)
     to run the app but will later be written using Django, also a popular web framework.
   keywords:
-  - Kinetic modelling
-  - optimization
-  - Bioprocesses
-  - Microbial growth
-  - parameter estimation
+    - Kinetic modelling
+    - optimization
+    - Bioprocesses
+    - Microbial growth
+    - parameter estimation
   mentors:
-  - unode
-  name: 'BioFerm: A web application used for kinetic modeling, parameter estimation
-    and simulation of bioprocesses'
+    - unode
+  name:
+    "BioFerm: A web application used for kinetic modeling, parameter estimation
+    and simulation of bioprocesses"
   participants:
-  - olayile
-  graduated: true
-- description: "This project will investigate existing literature on the benefits,\
+    - olayile
+  status: graduated
+- description:
+    "This project will investigate existing literature on the benefits,\
     \ risks, and limitations of open data practices in Australian environmental archaeology,\
     \ seeking to characterise the ethical and practical issues associated with the\
     \ dissemination of data owned or stewarded (either wholly or in part) by Indigenous\
@@ -212,54 +223,58 @@
     \ archaeologists and palaeoecologists seeking to work openly while supporting\
     \ the rights of Indigenous communities to manage access as they consider appropriate."
   keywords:
-  - Australian archaeology
-  - Open data
-  - Indigenous Knowledge
+    - Australian archaeology
+    - Open data
+    - Indigenous Knowledge
   mentors:
-  - estherplomp
+    - estherplomp
   name: Intellectual Property, Indigenous Knowledges, and the Rise of Open Data in Australian Environmental Archaeology
   participants:
-  - cemonks
-  graduated: true
-- description: The MiSET initiative aims to develop a minimum set of quality standards
+    - cemonks
+  status: graduated
+- description:
+    The MiSET initiative aims to develop a minimum set of quality standards
     in the form of a quality assessment tool that evaluates the technical aspects
     of cytometry publications, and to fully integrate these flow cytometry standards
     into grant submission and publication requirements across scientific fields (Lucas
     et al., Cytometry A 2019).
   keywords:
-  - rigor
-  - reproducibility
-  - peer-review
-  - publishing
-  - research quality defects
-  - experimental methods
-  - flow cytometry
-  - tool
-  - AI-assisted peer-review
+    - rigor
+    - reproducibility
+    - peer-review
+    - publishing
+    - research quality defects
+    - experimental methods
+    - flow cytometry
+    - tool
+    - AI-assisted peer-review
   mentors:
-  - tsonika
-  name: 'MiSET Publication Standards: A tool for AI-assisted peer-review of experimental
-    information'
+    - tsonika
+  name:
+    "MiSET Publication Standards: A tool for AI-assisted peer-review of experimental
+    information"
   participants:
-  - fabienne-lucas
-  graduated: true
-- description: Genetic variants of APOL1 commonly found in people of recent African
+    - fabienne-lucas
+  status: graduated
+- description:
+    Genetic variants of APOL1 commonly found in people of recent African
     ancestry can predispose to chronic kidney disease. It is however unknown if and
     to what extent the variants are present outside of Africa. This project aims to
     create a visual representation of the global distribution of the frequencies of
     these genetic variants, by mining genomic information from publicly available
     datasets.
   keywords:
-  - bioinformatics
-  - data visualization
-  - open educational resource
+    - bioinformatics
+    - data visualization
+    - open educational resource
   mentors:
-  - dimmestp
-  - yochannah
+    - dimmestp
+    - yochannah
   name: Global Distribution of APOL1 Genetic variants
   participants:
-  - john-ogunsola
-- description: "LA-CoNGA physics is an Erasmus+ project, an European-Latinamerican\
+    - john-ogunsola
+- description:
+    "LA-CoNGA physics is an Erasmus+ project, an European-Latinamerican\
     \ network of 11 universities, 9 research institutions and 3 industrial partners\
     \ (2 of them being in the data science field) in advanced physics. We aim to create\
     \ a set of postgraduate courses in Advanced Physics (high energy physics and complex\
@@ -277,18 +292,20 @@
     \ and applied from the first day\n\nOur website: https://laconga.redclara.net\n\
     Our github repository: https://github.com/LA-CoNGA"
   keywords:
-  - Open educational content
-  - Data science training
-  - Open science training
+    - Open educational content
+    - Data science training
+    - Open science training
   mentors:
-  - lauracion
-  name: LA-CoNGA physics (Latin American alliance for Capacity buildiNG in Advanced
+    - lauracion
+  name:
+    LA-CoNGA physics (Latin American alliance for Capacity buildiNG in Advanced
     physics)
   participants:
-  - camachoreina
-  - mxrtinez
-  graduated: true
-- description: Inspired by the social clubs founded by Benjamin Franklin, the Junto
+    - camachoreina
+    - mxrtinez
+  status: graduated
+- description:
+    Inspired by the social clubs founded by Benjamin Franklin, the Junto
     Labs initiative seeks to provide life science researchers with an online space
     for pursuing collaborative research and supporting active learning. Life science
     laboratories can be open and highly collaborative spaces for in person research,
@@ -305,17 +322,19 @@
     or universities where opportunities to participate in life science research are
     limited or nonexistent.
   keywords:
-  - online research
-  - mentorship
-  - virtual environments
-  - Jupyter notebooks
+    - online research
+    - mentorship
+    - virtual environments
+    - Jupyter notebooks
   mentors:
-  - burkemlou
-  name: Junto Labs - Advancing Virtual Environments for Life Science Research and
+    - burkemlou
+  name:
+    Junto Labs - Advancing Virtual Environments for Life Science Research and
     Active Learning
   participants:
-  - lomaxboydphd
-- description: 'The emergence of short-read NGS technologies have brought a profound
+    - lomaxboydphd
+- description:
+    "The emergence of short-read NGS technologies have brought a profound
     knowledge to the field of microbial ecology/evolution through the taxonomic identification
     of microbial communities - metabarcoding. Although its main limitation resides
     on their short read-length that has been suppressed by long-read/real-time sequencing
@@ -330,18 +349,19 @@
     references of software used. The report built would ensure reproducibility, transparency,
     acknowledgement and could be used as supplementary material of papers. metaNanoPype
     could be publicly available on github (open source) with further documentation
-    published with github pages.'
+    published with github pages."
   keywords:
-  - metabarcoding
-  - python pipeline
-  - reproducible
+    - metabarcoding
+    - python pipeline
+    - reproducible
   mentors:
-  - hrhotz
-  name: 'metaNanoPype: a reproducible Nanopore python pipeline for metabarcoding'
+    - hrhotz
+  name: "metaNanoPype: a reproducible Nanopore python pipeline for metabarcoding"
   participants:
-  - antonioggsousa
-  graduated: true
-- description: The field of molecular biology is a concept to discover, identify and
+    - antonioggsousa
+  status: graduated
+- description:
+    The field of molecular biology is a concept to discover, identify and
     explain mechanisms of everything about DNA, RNA and protein level in a cell. Despite
     it is a relatively young discipline, its prominence in the life sciences is becoming
     more and more popular. Within the scope of my project, I aim to evaluate the paper
@@ -357,18 +377,19 @@
     researchers in this field of science to improve knowledge, share and even find
     new ideas.
   keywords:
-  - open educational resource
-  - open-collaborative
-  - molecular biology
+    - open educational resource
+    - open-collaborative
+    - molecular biology
   mentors:
-  - landimi2
-  - unode
-  - tobyhodges
-  name: 'MBiO: Designing an open-collaborative website in the field of molecular biology'
+    - landimi2
+    - unode
+    - tobyhodges
+  name: "MBiO: Designing an open-collaborative website in the field of molecular biology"
   participants:
-  - nihan-sultan-milat
-  graduated: true
-- description: OLS is a great platform to open life science with the objective of
+    - nihan-sultan-milat
+  status: graduated
+- description:
+    OLS is a great platform to open life science with the objective of
     train young researchers towards the practices in open science skills. I am a graduand
     of OLS-2 that recently concluded and coming out of that program I felt that there
     is tremendous value in the program. However, this might not be reaching out to
@@ -381,19 +402,21 @@
     and having this it self as a project with the goal of coming up as a tangible
     document in the form of a publication to be shared with the community at large.
   keywords:
-  - value of OLS
-  - participant perspective
-  - internalize openess
-  - pendown
+    - value of OLS
+    - participant perspective
+    - internalize openess
+    - pendown
   mentors:
-  - bebatut
-  - yochannah
-  - malvikasharan
-  name: 'Open Life Science (OLS) Program, a driver of open science skills among early
-    stage researchers and young leaders: mentee perspective'
+    - bebatut
+    - yochannah
+    - malvikasharan
+  name:
+    "Open Life Science (OLS) Program, a driver of open science skills among early
+    stage researchers and young leaders: mentee perspective"
   participants:
-  - muhammetcelik
-- description: sktime is a new Python toolbox for machine learning with time series
+    - muhammetcelik
+- description:
+    sktime is a new Python toolbox for machine learning with time series
     (https://github.com/alan-turing-institute/sktime). It provides state-of-the-art
     time series algorithms and scikit-learn compatible tools for building, tuning
     and evaluating complex models. The goal of this project is to improve sktime’s
@@ -412,18 +435,19 @@
     generation of this documentation by making use of the existing documentation and
     other components such as CODEOWNERS file and __author__ strings in Python files.
   keywords:
-  - sktime
-  - documentation
-  - algorithm maintainer
-  - codeowner
+    - sktime
+    - documentation
+    - algorithm maintainer
+    - codeowner
   mentors:
-  - tobyhodges
+    - tobyhodges
   name: Documentation enhancement with open science practices in sktime
   participants:
-  - afzal442
-  - abdulelahsm
-  graduated: true
-- description: 'This project is to develop a Turing Service Area in Open Source that
+    - afzal442
+    - abdulelahsm
+  status: graduated
+- description:
+    "This project is to develop a Turing Service Area in Open Source that
     will provide formal support in open working and embedding best practices of open
     software development into Turing projects. This service area will create an Open
     Developer Advocate position whose role will be to work with and guide projects
@@ -434,18 +458,19 @@
     sessions and would address roadmapping of the project in terms of its open goals,
     and developing project policies for engaging openly. The area would work with
     the Turing Way project to draw on existing material and contribute new processes
-    there.'
+    there."
   keywords:
-  - open-source
-  - research
-  - strategy
+    - open-source
+    - research
+    - strategy
   mentors:
-  - meagdoh
+    - meagdoh
   name: An Open Source Service Area for Turing research projects
   participants:
-  - sgibson91
-  graduated: true
-- description: 'Phytoliths are microfossils of plants used world-wide to address a
+    - sgibson91
+  status: graduated
+- description:
+    "Phytoliths are microfossils of plants used world-wide to address a
     variety of questions in fields like archaeology, palaeoecology and palaeontology.
     Diverse laboratory procedures, analyses and identification criteria are used resulting
     from different research traditions. Some steps, such as the normalisation of nomenclature
@@ -461,24 +486,25 @@
     data: an evaluation of sharing practices in phytolith research; the creation of
     a GitHub repository for collaborative use by this working group and in the forthcoming
     FAIRification project; and the development of a webpage to provide the community
-    with information as the project proceeds.'
+    with information as the project proceeds."
   keywords:
-  - FAIR
-  - data sharing
-  - palaeobotany
-  - phytolith research
-  - archaeology
-  - palaeoecology
+    - FAIR
+    - data sharing
+    - palaeobotany
+    - phytolith research
+    - archaeology
+    - palaeoecology
   mentors:
-  - ekaroune
+    - ekaroune
   name: Towards FAIRer phytolith data
   participants:
-  - javier-ruiz-pérez
-  - juan-josé-garcía-granero
-  - cl379
-  - marco-madella
-  graduated: true
-- description: Obesity causes approximately 4.7 million premature deaths annually,
+    - javier-ruiz-pérez
+    - juan-josé-garcía-granero
+    - cl379
+    - marco-madella
+  status: graduated
+- description:
+    Obesity causes approximately 4.7 million premature deaths annually,
     which accounts for a loss of ca. 8% globally. Obesity is an outcome of complex,
     heritable, and multi-factorial interaction of multiple genes, environmental factors,
     and behavioral traits that makes management and prevention challenging in the
@@ -495,43 +521,46 @@
     the genes common to these complex diseases using a systems genomic integrated
     approach, thereby using Galaxy as a platform.
   keywords:
-  - Obesity
-  - Diabetes
-  - Gut microbiome
-  - Linkage disequilibrium
-  - pleiotropy
+    - Obesity
+    - Diabetes
+    - Gut microbiome
+    - Linkage disequilibrium
+    - pleiotropy
   mentors:
-  - prashbio
-  - harpreetsingh05
-  - bebatut
-  name: 'Systems Genomic Integration of Diabetes Related Genes: A Quest for Development
-    of Biomarkers'
+    - prashbio
+    - harpreetsingh05
+    - bebatut
+  name:
+    "Systems Genomic Integration of Diabetes Related Genes: A Quest for Development
+    of Biomarkers"
   participants:
-  - arvinpreet-kaur
-  - ashutosh-tiwari
-  - robandeep-kaur
-  - mehak-chopra
-  - harpreetsingh05
-  - prashbio
-  graduated: true
-- description: AKADEMISI PREPRINTS is a free distribution service of preprints from
+    - arvinpreet-kaur
+    - ashutosh-tiwari
+    - robandeep-kaur
+    - mehak-chopra
+    - harpreetsingh05
+    - prashbio
+  status: graduated
+- description:
+    AKADEMISI PREPRINTS is a free distribution service of preprints from
     multidisciplinary fields. The server plans to include connection hub to journals
     and open peer review community. By doing so, we hope to promote the transparency
     and quick visibility of research results to the public.
   keywords:
-  - preprints
-  - open resource
-  - open access
-  - publishing
+    - preprints
+    - open resource
+    - open access
+    - publishing
   mentors:
-  - iratxepuebla
+    - iratxepuebla
   name: Boosting research visibility using Preprints
   participants:
-  - didik-utomo
-  - hzahroh
-  - zenita-milla-luthfiya
-  graduated: true
-- description: Although there is an increasing number of initiatives in Saudi Arabia
+    - didik-utomo
+    - hzahroh
+    - zenita-milla-luthfiya
+  status: graduated
+- description:
+    Although there is an increasing number of initiatives in Saudi Arabia
     to raise awareness in Data Science (DS) and connect researchers in artificial
     intelligence (AI), there is no single community dedicated to stimulating responsible
     research practices and Open Science policies. I wish (with the help of a mentor)
@@ -539,16 +568,17 @@
     researchers and students who are open and curious about open science but have
     little to no experience with open science practices.
   keywords:
-  - Open science
-  - Saudi Arabia
-  - Community
+    - Open science
+    - Saudi Arabia
+    - Community
   mentors:
-  - anelda
+    - anelda
   name: Open Science Community in Saudi Arabia
   participants:
-  - batoolmm
-  graduated: true
-- description: 'Biological activity data was retrieved from the ChEMBL database and
+    - batoolmm
+  status: graduated
+- description:
+    "Biological activity data was retrieved from the ChEMBL database and
     pre-processed by selecting the target which was SARS coronavirus 3C-like proteinase
     in the project and the data frame of the target protein was filtered by removing
     the molecules which do not have the standard type as IC50 and those having missing
@@ -559,33 +589,34 @@
     The SMILES notation (representing the unique chemical structure of compounds)
     from the dataset was used to compute the molecular descriptors.
 
-    Lipinski''s descriptors are used in the project which considers molecular weight,
+    Lipinski's descriptors are used in the project which considers molecular weight,
     LogP, number of hydrogen bond donors, and number of hydrogen bond acceptors. These
     descriptors are related to the pharmacokinetic properties of molecules.
 
-    The exploratory data analysis was performed via Lipinski''s descriptors. Simple
+    The exploratory data analysis was performed via Lipinski's descriptors. Simple
     box plots and scatter plots were plotted to discern differences between the active
     and inactive sets of compounds.
 
     Mann-Whitney U test was performed for each descriptor to determine the statistically
-    significant difference between active and inactive molecules.'
+    significant difference between active and inactive molecules."
   keywords:
-  - SARS coronavirus 3C-like proteinase
-  - IC50
-  - pIC50
-  - Bioactivity
-  - Lipinski's rule
-  - Scatter plot
-  - Frequency plot
-  - Box plot
-  - Mann-Whitney test
+    - SARS coronavirus 3C-like proteinase
+    - IC50
+    - pIC50
+    - Bioactivity
+    - Lipinski's rule
+    - Scatter plot
+    - Frequency plot
+    - Box plot
+    - Mann-Whitney test
   mentors:
-  - yochannah
+    - yochannah
   name: COMPUTATIONAL DRUG DISCOVERY (CORONAVIRUS)
   participants:
-  - anshika-sah
-  graduated: true   
-- description: I aim to develop training materials to support the use of open data
+    - anshika-sah
+  status: graduated
+- description:
+    I aim to develop training materials to support the use of open data
     by researchers working on agrobiodiversity conservation. At CONABIO (Mexico),
     a governmental agency that coordinates biodiversity data collection, I collaborate
     in the development of an Agrobiodiversity Information System (SIAgroBD); my role
@@ -603,16 +634,17 @@
     expect this serves as a prototype for advanced training modules that could be
     used by future contributors or other researchers working on agrobiodiversity topics.
   keywords:
-  - agrobiodiversity
-  - open data
-  - oer
+    - agrobiodiversity
+    - open data
+    - oer
   mentors:
-  - pivg
+    - pivg
   name: Skills for Open Agrobiodiversity Data
   participants:
-  - iramosp
-  graduated: true
-- description: "The project is an open notebook living systematic review of legal\
+    - iramosp
+  status: graduated
+- description:
+    "The project is an open notebook living systematic review of legal\
     \ documents related to postdoctoral scholars and appointments (postdocs). The\
     \ project aims to use the methods of empirical legal scholarship to describe and\
     \ categorize the ways postdoctoral scholars and their appointments have been involved\
@@ -628,22 +660,23 @@
     \ in a services market. \n\nMore information about the project is available on\
     \ GitHub https://github.com/JMMaok/postdoc/projects and Zotero https://www.zotero.org/groups/"
   keywords:
-  - postdoc
-  - empirical legal research
-  - systematic review
-  - public policy
-  - open notebook science
+    - postdoc
+    - empirical legal research
+    - systematic review
+    - public policy
+    - open notebook science
   mentors:
-  - bduckles
+    - bduckles
   name: Postdoc Empirical Legal Research Open Notebook
   participants:
-  - jmmaok
-  graduated: true
-- description: 'The mission of the UKCRC Tissue Directory and Coordination Centre
-    (UKCRC TDCC) is to maximise the use, value and impact of the UK''s human sample
+    - jmmaok
+  status: graduated
+- description:
+    "The mission of the UKCRC Tissue Directory and Coordination Centre
+    (UKCRC TDCC) is to maximise the use, value and impact of the UK's human sample
     resources in the UK, and beyond. The UKCRC TDCC is creating a world-leading, research-enabling,
     and networked biobanking infrastructure to facilitate the discovery and use of
-    the UK''s human samples and data.
+    the UK's human samples and data.
 
     The UKCRC TDCC works to help researchers discover samples and data, help sample
     resources improve their data systems for sharing, and harmonise policy relating
@@ -651,20 +684,20 @@
 
     The work of the UKCRC TDCC is guided by the belief that the biomedical research
     ecosystem should be based on open standards, open-science, and pre-competitive
-    collaboration.'
+    collaboration."
   keywords:
-  - Biobanking
-  - research
-  - samples
-  - biospecimens
-  - COVID19
+    - Biobanking
+    - research
+    - samples
+    - biospecimens
+    - COVID19
   mentors:
-  - sgibson91
+    - sgibson91
   name: The UKCRC Tissue Directory and Coordination Centre
   participants:
-  - emma-lawrence
-  - jessica-sims
-  graduated: true
+    - emma-lawrence
+    - jessica-sims
+  status: graduated
 # - description: This is a prototype for target approaches in the stages of disease
 #     prognosis. By creating a constructive study of liver disease and bioinformatics
 #     pipeline. Construction of bioinformatics study to find out the key enzymes responsible
@@ -680,7 +713,8 @@
 #   name: Target Approach in the Stages of Liver Cirrhosis to Reverse Back in Good Condition
 #   participants:
 #   - wasifarahman
-- description: "This work aims to create a Nigerian sentiment corpus, sentiment, and\
+- description:
+    "This work aims to create a Nigerian sentiment corpus, sentiment, and\
     \ hate speech lexicon through manual annotation for three different languages\
     \ (Hausa, Igbo, Yoruba). Our method for the creation of these language resources\
     \ is as follows: \n \n Nigerian Sentiment Corpus: To create the sentiment corpus,\
@@ -705,20 +739,21 @@
     \ guidelines provided by the project teams. \n \n HausaNLP aims to create more\
     \ language resources that can be used to train models in machine learning."
   keywords:
-  - Natural Language Processing
-  - ' Low-resources'
-  - ' Machine Learning'
-  - ' Corpus'
-  - ' Language resources'
+    - Natural Language Processing
+    - " Low-resources"
+    - " Machine Learning"
+    - " Corpus"
+    - " Language resources"
   mentors:
-  - lauracarter
+    - lauracarter
   name: Development of language resources for Hausa Natural Language Processing
   participants:
-  - shmuhammad2004
-  - isahmadbbr
-  - rukynas
-  graduated: true
-- description: In Europe, prostate cancer (PCa) is the second most frequent type of
+    - shmuhammad2004
+    - isahmadbbr
+    - rukynas
+  status: graduated
+- description:
+    In Europe, prostate cancer (PCa) is the second most frequent type of
     cancer in men and the third most lethal. Current clinical practices, often leading
     to overdiagnosis and overtreatment of indolent tumors, suffer from a lack of precision
     calling for advanced AI models to go beyond SoA. The ProCAncer-I project brings
@@ -736,17 +771,18 @@
     regulatory roadmap for validating the effectiveness of AI-based models for clinical
     decision making.
   keywords:
-  - Prostate Cancer
-  - ' Open Data'
-  - ' Pca'
+    - Prostate Cancer
+    - " Open Data"
+    - " Pca"
   mentors:
-  - harpreetsingh05
+    - harpreetsingh05
   name: ProCancer-I - An AI Platform integrating imaging data and models, supporting precision care through prostate cancer's continuum
   participants:
-  - kon0925
-  - sgsfak
-  graduated: true
-- description: "The long term project objective is to establish in my university a\
+    - kon0925
+    - sgsfak
+  status: graduated
+- description:
+    "The long term project objective is to establish in my university a\
     \ core-team/lab able to aid the community to design and implement open science\
     \ projects.\n In order to start this long term project I believe that working\
     \ on a use case would help various aspects.\n It will help to coalesce and uniform\
@@ -761,21 +797,22 @@
     \ can be great opportunity to learn the open science approach in an organic way\
     \ and to discover how to do it."
   keywords:
-  - community building
-  - ' Systems Biology'
-  - ' Metabolism'
-  - ' quantitative Life Science'
-  - ' technology'
-  - ' infrastructure'
+    - community building
+    - " Systems Biology"
+    - " Metabolism"
+    - " quantitative Life Science"
+    - " technology"
+    - " infrastructure"
   mentors:
-  - bebatut
+    - bebatut
   name: Seeding
   participants:
-  - pescini
-  - marzia-di-filippo
-  - chiara-damiani
-  - paolo-pedaletti
-- description: "This project will create a network of Open Science (OS) ambassadors\
+    - pescini
+    - marzia-di-filippo
+    - chiara-damiani
+    - paolo-pedaletti
+- description:
+    "This project will create a network of Open Science (OS) ambassadors\
     \ in Spanish Health Research Institutes (HRI). Thus, aiming to implement OS in\
     \ HRI by raising consciousness about its principles that apply to this particular\
     \ field (i.e., reproducibility, transparency, dissemination and data sharing).\
@@ -793,20 +830,22 @@
     \ principles in health research in their institutes. That would allow the progressive\
     \ implementation of OS in HRI."
   keywords:
-  - Health Research Institutes
-  - Network of Open Science Ambassadors
-  - Best practices' Toolkits
-  - Open Science implementation
+    - Health Research Institutes
+    - Network of Open Science Ambassadors
+    - Best practices' Toolkits
+    - Open Science implementation
   mentors:
-  - joyceykao
-  name: Creating a network of Open Science ambassadors in Spanish Health Research
+    - joyceykao
+  name:
+    Creating a network of Open Science ambassadors in Spanish Health Research
     Institutes
   participants:
-  - marta-marin
-  - santi-rello-varona
-  - irisbotas
-  graduated: true
-- description: "Multimodal and Functional Imaging Laboratory (MAFIL, http://mafil.ceitec.cz/en/)\
+    - marta-marin
+    - santi-rello-varona
+    - irisbotas
+  status: graduated
+- description:
+    "Multimodal and Functional Imaging Laboratory (MAFIL, http://mafil.ceitec.cz/en/)\
     \ is one of core facilities at CEITEC MUNI and part of national large research\
     \ infrastructure Czech-BioImaging and European research infrastructure Euro-BioImaging.\
     \ The main role is to provide access to medical imaging technologies – mainly\
@@ -824,16 +863,18 @@
     \ practise on FAIRification and anonymisation of neuroimaging datasets."
   keywords: []
   mentors:
-  - loubez
-  - bebatut
-  name: 'FAIR MAFIL: FAIRification of imaging/neurophysiological data of MAFIL CEITEC
-    MUNI laboratory for EOSC'
+    - loubez
+    - bebatut
+  name:
+    "FAIR MAFIL: FAIRification of imaging/neurophysiological data of MAFIL CEITEC
+    MUNI laboratory for EOSC"
   participants:
-  - michal-ruzicka
-  - michal-javornik
-  - dudova
-  graduated: true
-- description: "In The Turing Way, we want to systematically understand community\
+    - michal-ruzicka
+    - michal-javornik
+    - dudova
+  status: graduated
+- description:
+    "In The Turing Way, we want to systematically understand community\
     \ practices including the community engagement pathways, contributors’ roles and\
     \ nature of their participation that have been successful at supporting its community\
     \ of diverse contributors. Simultaneously, we want to identify factors that may\
@@ -852,11 +893,12 @@
     \ inviting their contributions and thoughts."
   keywords: []
   mentors:
-  - malvikasharan
+    - malvikasharan
   name: The Turing Way - Developing a community health report and assessing its impact on the wider data science community
   participants:
-  - ali-humayun
-- description: "I have just started a new role as a Research Application Manager at\
+    - ali-humayun
+- description:
+    "I have just started a new role as a Research Application Manager at\
     \ the Turing Institute. My responsibility is to define my own workplan as well\
     \ as guide the development of the workplans of 2 other Research Application Managers\
     \ once they are recruited. This is a new role and we do not yet have a blueprint\
@@ -868,18 +910,20 @@
     \ we create a good basis for open science practices within ASG and hopefully in\
     \ other parts of Turing that RAMs interface with."
   keywords:
-  - open science workflow
-  - ' open source code'
-  - ' stakeholder engagement'
-  - ' research application'
-  - ' ASG'
+    - open science workflow
+    - " open source code"
+    - " stakeholder engagement"
+    - " research application"
+    - " ASG"
   mentors:
-  - malvikasharan
-  name: Developing and embedding open science practices within the Research Application
+    - malvikasharan
+  name:
+    Developing and embedding open science practices within the Research Application
     Management team at Turing
   participants:
-  - aida-turing
-- description: Project aims to connect rural school students to the cities of Nepal
+    - aida-turing
+- description:
+    Project aims to connect rural school students to the cities of Nepal
     and other countries. Pandemic has helped few Nepalese rural schools get internet
     facilities. Our project will take help of internet, online conferencing tool and
     team of young people from different disciplines to connect our little heroes to
@@ -887,20 +931,21 @@
     meeting new friends, learning science, doing DIY innovations and initiating makerspace
     movement through virtual collaborative environment.
   keywords:
-  - online
-  - village
-  - education
-  - DIY
-  - Makerspace
+    - online
+    - village
+    - education
+    - DIY
+    - Makerspace
   mentors:
-  - tlaguna
-  name: 'GyaNamuna: Virtual School Connecting Rural Students To The World'
+    - tlaguna
+  name: "GyaNamuna: Virtual School Connecting Rural Students To The World"
   participants:
-  - prakriti-karki
-  - mohan-gupta
-  - ujwal-shrestha
-  graduated: true
-- description: "In The Turing Way, we define reproducible research as work that can\
+    - prakriti-karki
+    - mohan-gupta
+    - ujwal-shrestha
+  status: graduated
+- description:
+    "In The Turing Way, we define reproducible research as work that can\
     \ be independently recreated using the same data and code from the original study.\
     \ Reproducible research is necessary to ensure that scientific output can be trusted\
     \ and built upon. Despite this importance, many studies are difficult to reproduce,\
@@ -919,19 +964,20 @@
     \ will also curate relevant guidelines and expert-recommendations. The findings\
     \ will be collaboratively reported as chapters in The Turing Way."
   keywords:
-  - Reproducibility
-  - ' AI trends'
-  - ' Data Science'
-  - ' Reproducible research practices'
-  - ' Computational research methods'
-  - ' Research software'
+    - Reproducibility
+    - " AI trends"
+    - " Data Science"
+    - " Reproducible research practices"
+    - " Computational research methods"
+    - " Research software"
   mentors:
-  - annakrystalli
+    - annakrystalli
   name: Open Source Project for Evaluating Reproducibility Trends in AI Research Projects
   participants:
-  - martinagvilas
-  graduated: true
-- description: This project aims to devise, develop and implement an online tool that
+    - martinagvilas
+  status: graduated
+- description:
+    This project aims to devise, develop and implement an online tool that
     allows interested users to suggest or contribute to training courses in an open
     source fashion. The tool could involve a GitHub repository where users can suggest
     training ideas, review and comment on existing courses, or share their resources
@@ -940,19 +986,21 @@
     be well placed to support such an engagement stream with the wider community of
     trainers and researchers.
   keywords:
-  - education
-  - ' training'
-  - ' data science'
-  - ' AI'
-  - ' open infrastructure'
-  - ' community'
+    - education
+    - " training"
+    - " data science"
+    - " AI"
+    - " open infrastructure"
+    - " community"
   mentors:
-  - jezcope
-  name: Towards an infrastructure for open-source (online) training in data science
+    - jezcope
+  name:
+    Towards an infrastructure for open-source (online) training in data science
     and AI
   participants:
-  - mihaelanemes
-- description: "As part of the Street Science Community, we successfully developed\
+    - mihaelanemes
+- description:
+    "As part of the Street Science Community, we successfully developed\
     \ the BeerDeCoded project: a hands-on workshop for pupils and citizens with the\
     \ general aim of scientific outreach. During these workshops, we help participants\
     \ to extract and identify different yeasts contained in a beer sample. The identification\
@@ -970,17 +1018,18 @@
     \ with the Galaxy community on the technical part and with teachers on the pedagogical\
     \ and gamification side."
   keywords:
-  - citizens science
-  - ' DNA sequencing'
-  - ' metagenomics'
-  - ' Galaxy'
+    - citizens science
+    - " DNA sequencing"
+    - " metagenomics"
+    - " Galaxy"
   mentors:
-  - yvanlebras
-  name: Implementing a series of pedagogical games to teach pupils and citizens (metagenomic)
+    - yvanlebras
+  name:
+    Implementing a series of pedagogical games to teach pupils and citizens (metagenomic)
     data analysis
   participants:
-  - teresa-m
-  - khanteymoori
-  - masako-kaufmann
-  - heylf
-  graduated: true
+    - teresa-m
+    - khanteymoori
+    - masako-kaufmann
+    - heylf
+  status: graduated

--- a/_data/ols-4-projects.yaml
+++ b/_data/ols-4-projects.yaml
@@ -2,7 +2,8 @@
 #
 # Check previous OLS for examples
 ---
-- description: "This project aims to create an **open educational resource** that\
+- description:
+    "This project aims to create an **open educational resource** that\
     \ introduces important concepts for aspiring Bioinformaticians, **written in Spanish**.\
     \ Topics included in this resource are:\n\n* The basics of GNU/Linux\n* Jupyter\
     \ Lab\n* Terminal usage\n* Text and file processing command-line tools (i.e. grep,\
@@ -17,17 +18,19 @@
     \ permissions to use external images, and other topics that it would be nice to\
     \ learn at the *OLS-4*."
   keywords:
-  - version control
-  - training and education
-  - programming
+    - version control
+    - training and education
+    - programming
   mentors:
-  - mxrtinez
-  - jcolomb
-  name: An open educational resource to introduce fundamental concepts of GNU/Linux,
+    - mxrtinez
+    - jcolomb
+  name:
+    An open educational resource to introduce fundamental concepts of GNU/Linux,
     terminal usage, Bash/AWK scripting, and Git/GitHub for Bioinformatics
   participants:
-  - sayalaruano
-- description: "I want to develop [Genestorian](https://www.genestorian.org/), a web\
+    - sayalaruano
+- description:
+    "I want to develop [Genestorian](https://www.genestorian.org/), a web\
     \ application to manage collections of model organism strains and recombinant\
     \ DNA, which will store the genetic engineering steps followed to generate new\
     \ entities from existing ones. The project would consist on developing:\n\n1.\
@@ -47,15 +50,16 @@
     : 3,\n        \"method\": {...},\n        \"proofs\": [{...},{...}]\n        },\n\
     \        {...}\n    ]\n}\n```"
   keywords:
-  - web application
-  - genetic engineering
-  - reproducible research
+    - web application
+    - genetic engineering
+    - reproducible research
   mentors:
-  - dimmestp
-  name: 'Genestorian: An Open Source web application for model organism collections'
+    - dimmestp
+  name: "Genestorian: An Open Source web application for model organism collections"
   participants:
-  - manulera
-- description: Recent developments in electron microscopy have led to a significant
+    - manulera
+- description:
+    Recent developments in electron microscopy have led to a significant
     scale-up in the imaging of biological tissues, making throughput a major bottleneck
     for further progress. Electron microscopes are inherently throughput limited.
     A new type of scanning electron microscopy, the multibeam electron microscopy,
@@ -68,16 +72,17 @@
     We would like to apply the multibeam electron microscope to study mitotic cells,
     zebrafish development and pancreatic stress.
   keywords:
-  - electoron microscopy and imaging
-  - deep learning
+    - electoron microscopy and imaging
+    - deep learning
   mentors:
-  - estherplomp
-  - martlj
+    - estherplomp
+    - martlj
   name: Multibeam electron microscopy for imaging large tissue volumes
   participants:
-  - arentkievits
-  graduated: true
-- description: We propose to build a database that compiles literature data for the
+    - arentkievits
+  status: graduated
+- description:
+    We propose to build a database that compiles literature data for the
     Stöber synthesis of sílica nanoparticles. This data is aimed to generate a database
     for other studies, such as statistical and machine learning models to guide the
     design and synthesis of calibrated and monodispersed silica nanoparticles by the
@@ -89,18 +94,19 @@
     that the nanosynthesis research community opens and shares its data as this will
     advance the nanosynthesis field in a more sustainable way globally.
   keywords:
-  - database
-  - FAIR principles
-  - research community
+    - database
+    - FAIR principles
+    - research community
   mentors:
-  - graciellehigino
+    - graciellehigino
   name: Open data for nanosystem synthesis experimental conditions
   participants:
-  - guille1107
-  - diegoonna
-  - princehoodie
-  graduated: true
-- description: "[**Bio-IT**](https://bio-it.embl.de) project at the [European Molecular Biology\
+    - guille1107
+    - diegoonna
+    - princehoodie
+  status: graduated
+- description:
+    "[**Bio-IT**](https://bio-it.embl.de) project at the [European Molecular Biology\
     \ Laboratory](https://www.embl.org) (EMBL) is a community initiative aiming at: \n\n- delivering\
     \ **training** in computational research skills;\n- creating connections between\
     \ **community** members;\n- developing and maintaining resources and supporting\
@@ -122,16 +128,17 @@
     \ and give them visibility,\n- renewing the **community interest** in Bio-IT and\
     \ computational best practices."
   keywords:
-  - training and education
-  - research community
-  - peer consulting
+    - training and education
+    - research community
+    - peer consulting
   mentors:
-  - emmyft
-  - tnabtaf
-  name: 'Grassroots: Nurturing the EMBL Bio-IT Community'
+    - emmyft
+    - tnabtaf
+  name: "Grassroots: Nurturing the EMBL Bio-IT Community"
   participants:
-  - lisanna
-- description: "Balconnect is a social and environmental intervention with the long-term\
+    - lisanna
+- description:
+    "Balconnect is a social and environmental intervention with the long-term\
     \ goal of using open-source, emerging data-driven technologies and open science\
     \ tools to motivate and enable urbanites to bring active daily experiences of\
     \ real nature into their lives, as well as to provide them with tools not only\
@@ -149,18 +156,20 @@
     \ urban green inequalities.\n- Influence local government decisions on city planning,\
     \ green infrastructure and nature-based solutions."
   keywords:
-  - biodiversity
-  - research community
-  - green infrastructure
-  - policymaking
+    - biodiversity
+    - research community
+    - green infrastructure
+    - policymaking
   mentors:
-  - ekaroune
-  name: Balconnect - A network of private outdoor areas improving urban ecoliteracy
+    - ekaroune
+  name:
+    Balconnect - A network of private outdoor areas improving urban ecoliteracy
     and biodiversity
   participants:
-  - gedaloop
-  graduated: true
-- description: "In my project, I want to interview several colleagues/peers who were\
+    - gedaloop
+  status: graduated
+- description:
+    "In my project, I want to interview several colleagues/peers who were\
     \ hired or recently started working as generic data stewards at Dutch universities,\
     \ and, to some extent, Dutch Universities of Applied Sciences – I am one of them.\
     \ I will rework these interviews into blog posts and analyse what I learnt from\
@@ -176,17 +185,19 @@
     \ VU, which is meant to showcase the RDM Community. This is a possible location\
     \ for my blogs and other progress made in the project."
   keywords:
-  - data stewards
-  - research community
-  - interview
+    - data stewards
+    - research community
+    - interview
   mentors:
-  - cemonks
-  - alexandra-holinski
-  name: 'Generic data stewards in the Netherlands: who they are, what they do, and
-    who they could become'
+    - cemonks
+    - alexandra-holinski
+  name:
+    "Generic data stewards in the Netherlands: who they are, what they do, and
+    who they could become"
   participants:
-  - elisa-on-github
-- description: "My project aims to tackle the big gap between the new trend of RNA\
+    - elisa-on-github
+- description:
+    "My project aims to tackle the big gap between the new trend of RNA\
     \ sequencing analysis and massive expansion of datasets, and the difficulties\
     \ for wet lab scientists to use this data and even review it when being published.\
     \ I would also like to create awareness in my community about the necessity on\
@@ -198,16 +209,17 @@
     \ reproducibility basics such as version control and workflows, so researchers\
     \ can see how the tutorial would work from an existent example."
   keywords:
-  - training and education
-  - reproducible research
-  - sequencing
+    - training and education
+    - reproducible research
+    - sequencing
   mentors:
-  - hrhotz
+    - hrhotz
   name: Open and reproducible data analysis for wet lab neuroscientists
   participants:
-  - saravilla
-  graduated: true
-- description: We plan to create a "Research Software Engineering Association in Asia
+    - saravilla
+  status: graduated
+- description:
+    We plan to create a "Research Software Engineering Association in Asia
     region -- RSE Association (Asia) ". The motive of this association would be to
     emphasize the importance of good software practices to be adopted by researchers
     in the Asian academia. Software and programming plays an important part of most
@@ -225,15 +237,16 @@
     in the UK.  Saranjeet Kaur Bhogal is the primary applicant of this project, and
     the one who initiated the project, and came up with the idea.
   keywords:
-  - research community
-  - research software engineering
+    - research community
+    - research software engineering
   mentors:
-  - annefou
+    - annefou
   name: Building the Research Software Engineering (RSE) Association in Asia region
   participants:
-  - saranjeetkaur
-  graduated: true
-- description: "Operating from a place of data for co-liberation, we have three complementary\
+    - saranjeetkaur
+  status: graduated
+- description:
+    "Operating from a place of data for co-liberation, we have three complementary\
     \ goals: conduct a landscape analysis of open source synthetic data projects,\
     \ ask critical questions about the embedded assumptions and ethical considerations\
     \ in generating synthetic data, and recommend appropriate approaches to synthetic\
@@ -252,16 +265,18 @@
     \ the political nature of data production and openly consider questions of bias,\
     \ fairness, and ethical AI."
   keywords:
-  - synthetic data
-  - Ethical AI
+    - synthetic data
+    - Ethical AI
   mentors:
-  - fpsom
-  name: Encouraging Responsible AI Through An Open Framework for Synthetic Data Generation
+    - fpsom
+  name:
+    Encouraging Responsible AI Through An Open Framework for Synthetic Data Generation
     and Assessment
   participants:
-  - ecsalomon
-  - augustincaitlin
-- description: 'Our initiative is called “Talleres Open Source” (Open Source Workshops
+    - ecsalomon
+    - augustincaitlin
+- description:
+    "Our initiative is called “Talleres Open Source” (Open Source Workshops
     in Spanish), a community of scientists teaching and learning about open source
     tools in Spanish. We organize workshops in which a trainer with experience in
     a certain method shows others how to apply it using open source tools, and attendees
@@ -276,18 +291,19 @@
     Each of these workshops serve as a way to connect people facing the same problem,
     introduce them to open source tools and concepts, and enable sharing resources.
     We hope attendees finish each workshop with a concrete first impression about
-    the method and hands-on experience with the tool to reduce the barrier to adoption.'
+    the method and hands-on experience with the tool to reduce the barrier to adoption."
   keywords:
-  - training and education
-  - data visualisation
-  - research community
+    - training and education
+    - data visualisation
+    - research community
   mentors:
-  - yochannah
+    - yochannah
   name: Talleres Open Source community platform
   participants:
-  - chucklesongithub
-  graduated: true
-- description: There is a considerable gap in cases of sub-Saharan African countries
+    - chucklesongithub
+  status: graduated
+- description:
+    There is a considerable gap in cases of sub-Saharan African countries
     regarding assessment of embodied energy of building materials and operational
     energy of various building types. Lack of open data remains a critical barrier
     to closing this gap. Creating an open and accessible database of embodied energy
@@ -299,17 +315,18 @@
     for carbon foot printing of buildings in Ghana, following best practice in open
     science principles.
   keywords:
-  - energy
-  - database
-  - carbon footprinting
+    - energy
+    - database
+    - carbon footprinting
   mentors:
-  - yvanlebras
-  - katesimpson
+    - yvanlebras
+    - katesimpson
   name: Creating an open database for carbon foot printing of buildings in Ghana
   participants:
-  - michael-addy
-  graduated: true
-- description: "Portable land is an urban DIY Agriculture project which aims to create\
+    - michael-addy
+  status: graduated
+- description:
+    "Portable land is an urban DIY Agriculture project which aims to create\
     \ a distributed farm. Currently we have four dedicated sites based in the West\
     \ Midlands - a washyard which has been converted into a growing space, a community\
     \ grow room, a patio for urban farming and an indoor DIY aquaponics setup. We\
@@ -321,15 +338,16 @@
     \ quality and biodiversity across our sites as well as shared repositories of\
     \ data and reports."
   keywords:
-  - agriculture
-  - DIY and makerspace
-  - biodiversity
+    - agriculture
+    - DIY and makerspace
+    - biodiversity
   mentors:
-  - lwinfree
+    - lwinfree
   name: Environmental mapping for urban farming project
   participants:
-  - biscuitnapper
-- description: "We are working on establishing a Research Hub in the National Guard.
+    - biscuitnapper
+- description:
+    "We are working on establishing a Research Hub in the National Guard.
     \ This hub is a virtual platform linked to TDM to support academics\
     \ (particularly young Female researchers), scientists, and physicians.\
     \ It aims to bridge the boundaries between research, cross-subject collaboration,\
@@ -353,20 +371,21 @@
     \ Saudi Arabia and bring awareness about the role of Citizen Science in research as
     \ part of the Research Hub."
   keywords:
-  - citizen science
-  - therapeutics
-  - soil sample
-  - sequencing
-  - metagenomics
+    - citizen science
+    - therapeutics
+    - soil sample
+    - sequencing
+    - metagenomics
   mentors:
-  - bebatut
+    - bebatut
   name: Culture-independent discovery of natural products from soil metagenomes
   participants:
-  - mai-alajaji
-  - batoolmm
-  - lalmehlisy
-  graduated: true
-- description: 'I aim to develop a Python library which allows to call and apply several
+    - mai-alajaji
+    - batoolmm
+    - lalmehlisy
+  status: graduated
+- description:
+    "I aim to develop a Python library which allows to call and apply several
     measures of emergence and complexity to either empirical or simulated data, and
     provide guidance for comparisons among and conclusions about different measures.
     &nbsp;
@@ -392,19 +411,20 @@
 
     A way to easily use & compare a set of state of the art emergence and complexity
     measures by using a few lines of code is thus missing – this is the gap that I’d  like
-    to fill.'
+    to fill."
   keywords:
-  - complexity measures
-  - programming
-  - Python library
+    - complexity measures
+    - programming
+    - Python library
   mentors:
-  - pescini
-  - abretaud
+    - pescini
+    - abretaud
   name: Developing a library in Python for applying measures of emergence and complexity
   participants:
-  - nadinespy
-  graduated: true
-- description: "We propose a **living**, **free** and **open** document, named The\
+    - nadinespy
+  status: graduated
+- description:
+    "We propose a **living**, **free** and **open** document, named The\
     \ Environmental AI book, compiling research in the application of AI and Data\
     \ Science for monitoring and modelling a wide diversity of settings of the natural\
     \ and urban environments.\n\nThrough a set of **interactive use-cases**, the document,\
@@ -423,17 +443,18 @@
     \ interested in **reproducibility**, **inclusive**, **shareable** and **collaborative**\
     \ AI and data science for environmental applications."
   keywords:
-  - artificial intelligence
-  - data science
-  - reproducible research
-  - research community
+    - artificial intelligence
+    - data science
+    - reproducible research
+    - research community
   mentors:
-  - delphine-l
+    - delphine-l
   name: The Environmental AI Book
   participants:
-  - acocac
-  graduated: true
-- description: Bioinformatics Secondary School Outreach (BSSO) is an initiative to  develop
+    - acocac
+  status: graduated
+- description:
+    Bioinformatics Secondary School Outreach (BSSO) is an initiative to  develop
     bioinformatics capacity among  High school students in Nigeria and this will  create
     early interest in genomics data analysis among the students and equip them with
     the relevant skills and knowledge in Bioinformatics.  Bioinformatics Hub Nigeria
@@ -442,31 +463,33 @@
     visited schools to facilitate the trainings. We would be working alongside with
     other sister organizations to achieve this goal
   keywords:
-  - outreach
-  - secondary school outreach
-  - training and education
+    - outreach
+    - secondary school outreach
+    - training and education
   mentors:
-  - meagdoh
+    - meagdoh
   name: Bioinformatics Secondary school Outreach in Nigeria
   participants:
-  - emmanuel19-ada
-- description: I want to develop a project that gives iNaturalist citizen scientists
+    - emmanuel19-ada
+- description:
+    I want to develop a project that gives iNaturalist citizen scientists
     the chance to move from data collectors to data explorers. I want to use my programming
     skills and outreach experience to create an online tool  where users can browse
     through  iNaturalist and environmental data. By creating online data exploration
     tools,  I want  users to form their own questions and look for answer to their
     questions.
   keywords:
-  - citizen science
-  - environmental data
-  - outreach
+    - citizen science
+    - environmental data
+    - outreach
   mentors:
-  - bruno-soares
+    - bruno-soares
   name: Citizen Scientists as Data Explorers
   participants:
-  - wykhuh
-  graduated: true
-- description: 'Established in 2018, EROS (education researchers for open science)
+    - wykhuh
+  status: graduated
+- description:
+    "Established in 2018, EROS (education researchers for open science)
     is an open research working group at the University of York. We monitor and communicate
     ongoing developments within the open research landscape, provide guidance and
     training on adopting open practices, and influence incentive structures to recognise
@@ -484,25 +507,27 @@
     practice. The less experienced partner (who may be senior) commits to reading
     at least one primer on a particular open research practice, and then leads a conversation
     with their partner, asking about their experiences, motivations, and insights
-    and top tips for working with the practice. 
+    and top tips for working with the practice.
 
 
     The project will help the EROS community build a shared repertoire of experiences,
     stories, tools and ways of addressing common challenges in doing open, inclusive
-    research.'
+    research."
   keywords:
-  - research community
-  - case study
-  - training
+    - research community
+    - case study
+    - training
   mentors:
-  - karvovskaya
-  - estherplomp
-  name: 'EROS Stories: Conversation and case studies in open research across educational
-    disciplines'
+    - karvovskaya
+    - estherplomp
+  name:
+    "EROS Stories: Conversation and case studies in open research across educational
+    disciplines"
   participants:
-  - cbolibaugh
-  - gill-francis
-- description: The project focuses on building tools to understand the evolution of
+    - cbolibaugh
+    - gill-francis
+- description:
+    The project focuses on building tools to understand the evolution of
     life. We develop bioinformatic tools to determine evolutionary processes to detect
     early stage life development. The project looks at data from two specific parts
     of detecting life - co-evolution of life and environment and biosignature assessment
@@ -515,16 +540,18 @@
     tools to help detect biosignature, assess habitability, promote involvement within
     astrobiology.
   keywords:
-  - astrobiology
-  - environmental data
-  - citizen science
+    - astrobiology
+    - environmental data
+    - citizen science
   mentors:
-  - harpreetsingh05
-  name: FarawayFermi- A platform for open source bioinformatic tools to detect biosignatures
+    - harpreetsingh05
+  name:
+    FarawayFermi- A platform for open source bioinformatic tools to detect biosignatures
     in astrobiology
   participants:
-  - thatspacegirl
-- description: In academia today there is a certain pressure for young research to
+    - thatspacegirl
+- description:
+    In academia today there is a certain pressure for young research to
     publish, and given the time constraints and continuous deadlines, the aspects
     of reproducibility and replicability are often overlooked. The Turing Way is a
     great starting point and a guide for people that want get familiar with what needs
@@ -539,14 +566,15 @@
     a way of thinking in a way and contain resources that help you consider reproducibility
     towards the entire research.
   keywords:
-  - reproducible research
-  - data science
+    - reproducible research
+    - data science
   mentors:
-  - jessicas11
+    - jessicas11
   name: A guide towards reproducible research for Decision Sciences researchers
   participants:
-  - andreea-avramescu
-- description: Although my research areas are mostly related to wet-lab, with the
+    - andreea-avramescu
+- description:
+    Although my research areas are mostly related to wet-lab, with the
     developed technologies, I am aware that computational and data analysis approaches
     in research promise great opportunities. Therefore, I am proposing the Open Life
     Science Survey analysis project to participate in the Open Life Science (OLS)
@@ -561,16 +589,17 @@
     perspectives in open research, which are different from but beneficial for my
     current research.
   keywords:
-  - survey data
-  - data visualisation
-  - programming
+    - survey data
+    - data visualisation
+    - programming
   mentors:
-  - bduckles
+    - bduckles
   name: Building Open Science and Data Analysis Skills by Leading the OLS Survey Data Project
   participants:
-  - burce-elbasan
-  graduated: true
-- description: Binderhub is a service that allows users to share reproducible interactive
+    - burce-elbasan
+  status: graduated
+- description:
+    Binderhub is a service that allows users to share reproducible interactive
     computing environments through public code repositories. The subject of our project,
     Hub23, is an organisational deployment of Binderhub, designed to allow Turing
     Researchers to use binder (the user interface) to collaborate on repositories
@@ -586,16 +615,17 @@
     used to create an internal binderhub deployment, allowing other organisations
     to do so.
   keywords:
-  - research community
-  - technical development
+    - research community
+    - technical development
   mentors:
-  - unode
+    - unode
   name: "Hub23: An open source community and infrastructure for Turing's BinderHub"
   participants:
-  - lydia-france
-  - lukehare
-  - callummole
-- description: The project is about the conception, organization, and coordination
+    - lydia-france
+    - lukehare
+    - callummole
+- description:
+    The project is about the conception, organization, and coordination
     of an online event with a focus on identifying the key driving factors for a scientific
     career as a woman in data sciences. During the event, we will try to get to the
     bottom of the large gender gap in the data science field and present efforts to
@@ -606,16 +636,17 @@
     and demand were so great that we decided to held the meeting again in autumn 2021
     with a slightly different thematic focus.
   keywords:
-  - scientific events
-  - data science
-  - gender equality
+    - scientific events
+    - data science
+    - gender equality
   mentors:
-  - iratxepuebla
+    - iratxepuebla
   name: Online event "Women in Data Science - Perspectives in Industry and Academia" Part II
   participants:
-  - irena-maus
-  graduated: true
-- description: "The international and open RIVER UNIVERSITY started in Poland with\
+    - irena-maus
+  status: graduated
+- description:
+    "The international and open RIVER UNIVERSITY started in Poland with\
     \ its pilot in 2018 and the 1st edition in 2020.\nIts professional river education\
     \ has the ambition to change the reality by creating a strong center/network of\
     \ modern knowledge, linking experts and giving the opportunity to participants\
@@ -653,17 +684,18 @@
     \ and practitioners, e.g.: the University of Lausanne, Warsaw University of Life\n\
     Sciences, Leibniz Institute of Freshwater Ecology and Inland Fisheries."
   keywords:
-  - biodiversity
-  - training and education
-  - river and freshwater ecology
-  - environmental data
+    - biodiversity
+    - training and education
+    - river and freshwater ecology
+    - environmental data
   mentors:
-  - ealescak
+    - ealescak
   name: open and international River University
   participants:
-  - ewa-leś
-  graduated: true
-- description: 'In _The Turing Way,_ we want to systematically understand community
+    - ewa-leś
+  status: graduated
+- description:
+    'In _The Turing Way,_ we want to systematically understand community
     practices including the community engagement pathways, contributors'' roles and
     nature of their participation that have been successful at supporting its community
     of diverse contributors. Simultaneously, we want to identify factors that may
@@ -683,12 +715,13 @@
     designed with other community members by actively inviting their contributions
     and thoughts.'
   keywords:
-  - research community
-  - community health metric
-  - reproducible research
+    - research community
+    - community health metric
+    - reproducible research
   mentors:
-  - arielle-bennett
-  name: Learning about open science communities and help build "community health"
+    - arielle-bennett
+  name:
+    Learning about open science communities and help build "community health"
     report for The Turing Way
   participants:
-  - alihumayun
+    - alihumayun

--- a/_data/ols-5-projects.yaml
+++ b/_data/ols-5-projects.yaml
@@ -17,7 +17,6 @@
   name: 'Multilingual Open Science: Creating Open Educational Resources in Central Asian Languages'
   participants:
   - sarenaz
-  graduated:
 - description: 'Our initiative is called "Training Latin American scientists community to create high-quality open journals with good editorial standards". We intend to build a community of native spanish speaking scientists who teach and learn about creating editorial boards and open access scientific journals that meet international high editorial quality standards. We intend to organise hands-on workshops about different steps in the editorial process of creating scientific open access journals, with experienced trainers and with open source tools. Some of the topics we would like to cover are:
 
 - Acquiring ISSN code for online journals,
@@ -45,7 +44,7 @@ These workshops would merge synchronic and asynchronic activities throughout  a 
   - andre-vargas-de
   - nelson-franco
   - jvillcavillegas
-  graduated: true
+  status: graduated
 - description: 'Cloud-SPAN trains researchers, and the research software engineers that support them, to run specialised analyses for environmental omics datasets on cloud-based high-performance computing infrastructure. It is a collaboration between the University of York and The Software Sustainability Institute funded by the UKRI Innovation Scholars award (Project Reference: MR/V038680/1). The primary objective of the project is to generate training materials and opportunities which are open, accessible and reusable (FAIR) for all researchers. We aim to build an engaged community of practice around the participation in, and the development and maintenance of, the materials. The community-building element would be the main focus of the OLS scheme project.'
   keywords:
   - Education
@@ -58,7 +57,7 @@ These workshops would merge synchronic and asynchronic activities throughout  a 
   name: Building a Cloud-SPAN community of practice
   participants:
   - evelyngreeves
-  graduated: true
+  status: graduated
 - description: There is a considerable gap in cases of sub-Saharan African countries regarding assessment of embodied energy of building materials and operational energy of various building types. Lack of data remains a critical barrier to closing this gap. Creating a database of embodied energy of building materials and operational energy of building typologies will be key in establishing the carbon footprint of buildings in Ghana. The development of an online platform will also allow interested groups, individuals and cooperation's to submit key information needed for the computation of energy outputs in buildings.  The aim of this project is to explore the scope and path towards establishing an open database and an inclusive community.
   keywords:
   - Sustainabilty
@@ -103,7 +102,7 @@ The plan needs to integrate as much as possible open science principles such as 
   name: Publishing development plan for the Open access journals of TU Delft OPEN Publishing
   participants:
   - fredbelliard
-  graduated: true
+  status: graduated
 - description: This project is envisioned as one that ends up as something that can explain the “why” when encouraging people from legal backgrounds to learn R and some data science. A case for open and reproducible research in a field that does not typically use R and qualitative methods. The idea is to get to that point by creating different data sets derived from commonly used legal sources that law students or graduates would be familiar with and incorporating them into a single platform with a few examples of practical use and application as well as code to encourage such persons to see the “why”. On this platform, I would like to share resources to places where the intro to R courses are available, etc. At this stage, this is an idea I have and I hope to develop it as the week's progress.
   keywords:
   - Rstudio
@@ -116,7 +115,7 @@ The plan needs to integrate as much as possible open science principles such as 
   name: Why R, for those with legal backgrounds using examples from South Africa
   participants:
   - b14-rsa
-  graduated: true
+  status: graduated
 - description: Next-generation sequencing (NGS) is a revolutionary technique with wide applications in biology. Its applications are widely being used from young researchers to pioneer researchers of the field. The NGS data analysis has various approaches and many resources are explaining these methods. However, it can be difficult for beginners in this field to quickly understand and apply these methods. Also, beginner researchers might not have enough knowledge to overcome the most common errors that are encountered during these analyses. Due to the challenges that we mentioned above, in this project, we aimed to create a comprehensive open educational resource explaining NGS data analysis and its different methods and offer an example for the application of methodology and solutions to the most common errors. We believe that this project will be enlightening for anyone interested in NGS data analysis by providing a necessary roadmap.
   keywords:
   - Next-generation sequencing
@@ -217,7 +216,7 @@ The issue was that a simple SMILES representation of a molecular scaffold does n
   name: Increasing the usability of ChemSpaX, a Python tool for chemical space exploration
   participants:
   - akalikadien
-  graduated: true
+  status: graduated
 - description: We have created the [Ersilia Model Hub](https://github.com/ersilia-os/ersilia), a FLOSS platform containing AI/ML models for infectious and neglected disease research . These models can be accessed with little to no-coding expertise, solving a major roadblock in the applicability of such technologies to day-to-day research. The Hub currently includes a hundred open source models, both from the literature and developed by the [Ersilia organization](https://ersilia.io). With this project, we aim to open the Hub to the whole computer science community, encouraging third-author model depositions so that the code they develop is not simply open source but also deployed in a user-friendly manner. By leveraging the Hub architecture, computer scientists can reach more users, interact with them and further the impact of the assets they have developed by facilitating its implementation in real case scenarios. To this end, the project will focus on establishing clear guidelines on the quality of the software and its reproducibility (as it won't necessarily be yet peer-reviewed) and creating a standard model deposition form and minimum required documentation. The ultimate goal of the project is to build a community of contributors by facilitating their access.
   keywords:
   - reproducibility
@@ -230,7 +229,7 @@ The issue was that a simple SMILES representation of a molecular scaffold does n
   name: 'The Ersilia Model Hub: encouraging deployment of computer-based research tools for non-expert usage'
   participants:
   - gemmaturon
-  graduated: true
+  status: graduated
 - description: Living in South Africa, and in much of the world, you can see a large gap in the accessibility of healthcare resources based on a person's income and education level. I am privileged enough to have had access to good quality healthcare resources throughout my life, which resulted in me being seen by numerous different therapists, counsellors and psychologists and being diagnosed with Autism Spectrum Disorder, more specifically Asperger's syndrome. I am also privileged in that I am able to comfortably speak and read English.   Unfortunately, a large percentage of our country has a very poor level of education, often not being able to read or speak English very well. Most South African resources I have found for individuals with, and parents of children with, autism are only available in English. My project aims to create a database of resources in a variety of South African languages, both written and as a video format (due to poor literacy rates, especially among older generations due to historical discrimination), in easy to understand language and with concepts that are easy to grasp. This is also useful as more people will be able to access online resources than resources at a healthcare facility.
   keywords:
   - free resources
@@ -255,7 +254,7 @@ The issue was that a simple SMILES representation of a molecular scaffold does n
   participants:
   - malvikasharan
   - aleesteele
-  graduated: true
+  status: graduated
 - description: "The International Committee on Open Phytolith Science (ICOPS) was initiated as a new committee within the International Phytolith Society in September 2021 and the first committee meeting took place in December 2021. This committee aims to increase the knowledge of and implementation of open science practices in phytolith research. We are embracing an open source approach to our work in this committee so that the work of our committee is transparent. This will include open documentation, regularly communicating with our community, and providing guidelines and communication channels to enable our community to engage with us. Therefore, we want to establish a solid base for this work going forward by further developing our GitHub repository - adding clear contributing guidelines and documentation on how the committee   is to be run. All members of the committee will also benefit from training in  all aspects of open science practices. This will allow us to gain further insight into the training and initiatives that we want to work on with our community.
 
 We will also start to develop training packages specific to phytolith research such as in open publishing and open and FAIR data."
@@ -281,7 +280,7 @@ We will also start to develop training packages specific to phytolith research s
   - cel31
   - zdunseth
   - juanjo-garcía-granero
-  graduated: true
+  status: graduated
 - description: The Turing-Roche strategic partnership was established in June 2021 with the goal of establishing a collaboration in advanced analytics between the two organisations to develop new data science methods to investigate large, complex, clinical and healthcare datasets to better understand how and why patients respond differently to treatment, and how treatment can be improved.  As Community Manager for the project I am developing a collaborative and open community between both organisations and beyond. As the partnership is just beginning and is flexible in nature there are opportunities to embed open practices such as open publication,   reproducibility, open data, training, co-working as well as establishing networks such as an early career researchers.
   keywords:
   - treatment heterogeneity
@@ -311,7 +310,7 @@ We will also start to develop training packages specific to phytolith research s
   name: An Incomplete History of Research Ethics
   participants:
   - ismael-kg
-  graduated: true
+  status: graduated
 - description: 'This study aims to develop a diagnostic LAMP kit that''s sensitive and robust to Plasmodium falciparum from saliva and urine to enhance simple and easy non-invasive molecular testing. The first phase of this study involved target validation, primer, and probe design using open-access tools. Here, a principal component analysis (PCA) of the R/adegenet package (Jombart et al, 2010) and phylogenetic tree (Neighbour-joining) using R/ape package (Paradis et al, 2004) to cluster repeats of the chosen amplification target. These clusters were aligned to generate a consensus sequence for designing primers and probes for establishing the LAMP assay. I have designed an incorporated strand displacement probe using the engineering guideline of Juan et al, 2015 and the open-access Nupack software tool. The assay has and the master mix is being lyophilized for further experimental evaluation.
 
 
@@ -327,7 +326,7 @@ The sensitivity of this kit will be evaluated on extracted DNA from three sample
   name: Developing thermally stable loop mediated isothermal amplification kit for a non invasive detection of malaria
   participants:
   - mgawe-cavin
-  graduated: true
+  status: graduated
 - description: In October 2021, the RSE Asia Association was launched. This was done to create awareness in the Asia region about the field of Research Software Engineering. The digital infrastructure for the association has been built during the Open Life Science Cohort 4 (OLS-4) program. The webpage is in place, the contact addresses have also been created for communication with people. A small community has also started emerging. It is time that the community can expand. With the expanding community, it is now required that we create well-defined pathways for people to get onboard to the association. This project aims at building such pathways. Also, a basic Code of Conduct is already present on the RSE Asia webpage. It is to be modified to make it more appropriate for the Asian region.
   keywords:
   - Community Building
@@ -339,7 +338,7 @@ The sensitivity of this kit will be evaluated on extracted DNA from three sample
   name: Building Pathways for Onboarding to Research Software Engineering (RSE) Asia Association and Adoption of Code of Conduct
   participants:
   - jyoti-bhogal
-  graduated: true
+  status: graduated
 - description: "We are to process bladder cancer RNA-Seq datasets that are publicly available. The co-authors of this manuscript will work on the analysis and apply bioinformatics methods for analysis of this large scale, heterogeneous RNA-sequencing dataset (20 + samples - 3Gb) that will be downloaded from any of the following databases; Genome Atlas (TCGA) database, Genotype-Tissue Expression (GTEx), cBio Cancer GenCancer Genomics Portal (cBioPortal) database and SRA NCBI database (choose any suitable database you are familiar with). The biological questions of particular interest include
 
 1. identification of differentially expressed transcripts (DEGs)
@@ -386,7 +385,7 @@ Open source software such as R/Bioconductor (DESeq2), Unix/Linux, Python and Jup
   name: OpenGHG - a cloud platform for greenhouse gas data analysis and collaboration
   participants:
   - gareth-j
-  graduated: true
+  status: graduated
 - description: '**Visualization of participants by their countries**  I would like to work on a project ''Visualization of participants by their countries'' from the projects listed [here](https://github.com/open-life-science/open-life-science.github.io/issues/297).
 
 
@@ -422,7 +421,7 @@ The first Open Science MOOC started in 2018 and on average the course attracts a
   participants:
   - alecandian
   - lisanne-walma
-  graduated: true
+  status: graduated
 - description: "Binderhub is a service that allows users to share reproducible interactive computing environments through public code repositories. The subject of our project, Hub23, is an organisational deployment of Binderhub, designed to allow Turing Researchers to use binder (the user interface) to collaborate on repositories internal to Turing. This is sometimes necessary if the underlying repository can not be shared for some reason, or is not yet ready to publish openly. During the OLS program, we aim to build an open community around Hub23 to help to guide future technical developments, and encourage use and contributions from the wider Turing community. We will host a series of Zero-to-Binder workshops aimed at introducing Turing researchers to regular binder, followed by structured discussion of what the ideal features of a collaborative reproducible environment for research would be. Any conclusions and subsequent technical development will be fed upstream to Binderhub, and we also aim to open source the methodologies used to create an internal binderhub deployment, allowing other organisations to do so."
   keywords:
   - Open Source
@@ -437,7 +436,7 @@ The first Open Science MOOC started in 2018 and on average the course attracts a
   - callummole
   - lydiafrance
   - lukehare
-  graduated: true
+  status: graduated
 - description: "We aim to build an online platform and community that allows open sharing, storage, and synthesis of clinical (meta)data, crucial for the development of modern, transdiagnostic, FAIR neuropsychology. First, published peer-reviewed papers will be scrapped to collect already available (meta)data. Second, our platform will allow direct uploading of clinical brain maps and their corresponding metadata.
 
 
@@ -467,7 +466,7 @@ A basic automated preprocessing and data-quality check pipeline will be implemen
   - complexbrains
   - pinheirochagas
   - sladjana-lukic
-  graduated: true
+  status: graduated
 - description: 'Open science is vital for reproducible, fair, and rigorous research. For its principles to thrive, we need OS practices to be shared and adopted by as many scientists as possible, from the earliest stages of their career. A 2017 survey by the European Commission reports that, among 1277 researchers at all career stages, the majority were unaware of the OS concept, and had never attended an OS initiative (from the Open Science Skills Working Group Report, July 2017).
 
 
@@ -512,7 +511,7 @@ Diagnosis of cancer relies on histology in nearly 80% of cases, cytology in 10%,
   - jafsia
   - fadanka
   - agossoubido2021
-  graduated: true
+  status: graduated
 - description: The "AI for Science and Government" (ASG) programme at The Alan Turing Institute seeks to produce three community-led white papers that will capture the outcomes of research into deploying AI and data science in priority areas to support the UK's economy. The papers will also highlight advances in practices towards open and reproducible research in the fields of AI and data science. The process of authoring the white papers will itself be collaborative, open and transparent, soliciting contributions from the wider ASG community at every step of the way.
   keywords:
   - community management
@@ -524,7 +523,7 @@ Diagnosis of cancer relies on histology in nearly 80% of cases, cytology in 10%,
   name: Cultivating a Community of Practice of AI researchers
   participants:
   - raoofphysics
-  graduated: true
+  status: graduated
 - description: "ARPHAI is an interdisciplinary research consortium, whose mission is to develop technological tools and recommendations to anticipate and manage epidemiological events. ARPHAI pilots data-driven open source tools using artificial intelligence and data science towards upgrading Argentina's electronic health record (EHR) system. ARPHAI is part of the [Global South AI4COVID Program](https://covidsouth.ai/).
 
 
@@ -548,7 +547,7 @@ There are two additional lines of work ARPHAI undertakes that are transversal to
   - vickygisel
   - federico-cestares
   - lauracion
-  graduated: true
+  status: graduated
 - description: The project focuses on building tools to understand the evolution of life. We develop bioinformatic tools to determine evolutionary processes to detect early stage life development. The project looks at data from two specific parts of detecting life - co-evolution of life and environment and biosignature assessment within the context of habitability. We use data from current experimental projects and develop new models to aid the growth of astrobiology search for life. The platform will cater to multiple sections such as- data management from all astrobiology projects, experiments, research labs and conferences; new tools to analyse data, predictive model section to simulations from the data set and collaborative forum to encourage citizen science.The platform will help create open source bioinformatic tools to help detect biosignature, assess habitability, promote involvement within  astrobiology. In addition to using bioinformatic tools, a part of the platform will use game theory and gamification to test the citizen science component. Using both the platform as a destination for tool testing and science education, we hope to advance the research in astrobiology.
   keywords:
   - Bioinformatics

--- a/_ols-1/projects-participants.md
+++ b/_ols-1/projects-participants.md
@@ -48,6 +48,10 @@ For the first round of the Open Life Science program, we are happy to have [{{ p
 
 **Mentored by**: {{ p-mentors | remove_first: 'with ' }}
 
+{% if project.status %}
+**Status**: {{ project.status }}
+{% endif %}
+
 {{ project.description }}
 
     {% endif %}

--- a/_ols-2/projects-participants.md
+++ b/_ols-2/projects-participants.md
@@ -48,6 +48,10 @@ For the second round of the Open Life Science program, we are happy to have [{{ 
 
 **Mentored by**: {{ p-mentors | remove_first: 'with ' }}
 
+{% if project.status %}
+**Status**: {{ project.status }}
+{% endif %}
+
 {{ project.description }}
 
     {% endif %}

--- a/_ols-3/projects-participants.md
+++ b/_ols-3/projects-participants.md
@@ -48,6 +48,10 @@ For the third round of the Open Life Science program, we are happy to have [{{ p
 
 **Mentored by**: {{ p-mentors | remove_first: 'with ' }}
 
+{% if project.status %}
+**Status**: {{ project.status }}
+{% endif %}
+
     {% capture difference %} {{ project.keywords | size | minus:1 }} {% endcapture %}
     {% unless difference contains '-' %}
 **Keywords**: {{ project.keywords | join: ', ' }}

--- a/_ols-4/projects-participants.md
+++ b/_ols-4/projects-participants.md
@@ -48,6 +48,10 @@ For the third round of the Open Life Science program, we are happy to have [{{ p
 
 **Mentored by**: {{ p-mentors | remove_first: 'with ' }}
 
+{% if project.status %}
+**Status**: {{ project.status }}
+{% endif %}
+
     {% capture difference %} {{ project.keywords | size | minus:1 }} {% endcapture %}
     {% unless difference contains '-' %}
 **Keywords**: {{ project.keywords | join: ', ' }}

--- a/_ols-5/projects-participants.md
+++ b/_ols-5/projects-participants.md
@@ -48,6 +48,10 @@ For the third round of the Open Life Science program, we are happy to have [{{ p
 
 **Mentored by**: {{ p-mentors | remove_first: 'with ' }}
 
+{% if project.status %}
+**Status**: {{ project.status }}
+{% endif %}
+
     {% capture difference %} {{ project.keywords | size | minus:1 }} {% endcapture %}
     {% unless difference contains '-' %}
 **Keywords**: {{ project.keywords | join: ', ' }}

--- a/_ols-6/projects-participants.md
+++ b/_ols-6/projects-participants.md
@@ -23,7 +23,7 @@ photos:
 
 Participants join this program with a project that they either are already working on or want to develop during this program.
 
-For the sixth round of the OLS program, we are happy to have [{{ p-participants | size }} participants](#participants) with [{{ projects | size }} projects](#projects). 
+For the sixth round of the OLS program, we are happy to have [{{ p-participants | size }} participants](#participants) with [{{ projects | size }} projects](#projects).
 
 # Projects
 
@@ -31,22 +31,26 @@ For the sixth round of the OLS program, we are happy to have [{{ p-participants 
     {% if project.visible != false %}
 
         {% assign p-pparticipants = '' %}
-        
+
         {% for p in project.participants %}
             {% capture p-pparticipants %}{{ p-pparticipants }}, ![](https://avatars.githubusercontent.com/{{ p }}){: .people-badge} [{{ people[p].first-name }} {{ people[p].last-name }}](#{{ p }}){% endcapture %}
         {% endfor %}
-        
+
         {% assign mentor = project.mentor %}
         {% capture p-mentors %}
         {% for p in project.mentors %}with ![](https://avatars.githubusercontent.com/{{ p }}){: .people-badge} [{{ people[p].first-name }} {{ people[p].last-name }}](/people#{{ p }})
         {% endfor %}
-        {% endcapture %} 
+        {% endcapture %}
 
 ## {{ project.name }}
 
 **By**: {{ p-pparticipants | remove_first: ', ' }}
 
 **Mentored by**: {{ p-mentors | remove_first: 'with ' }}
+
+{% if project.status %}
+**Status**: {{ project.status }}
+{% endif %}
 
     {% capture difference %} {{ project.keywords | size | minus:1 }} {% endcapture %}
     {% unless difference contains '-' %}

--- a/_ols-7/projects-participants.md
+++ b/_ols-7/projects-participants.md
@@ -23,7 +23,7 @@ photos:
 
 Participants join this program with a project that they either are already working on or want to develop during this program.
 
-For the third round of the OLS program, we are happy to have [{{ p-participants | size }} participants](#participants) with [{{ projects | size }} projects](#projects). 
+For the third round of the OLS program, we are happy to have [{{ p-participants | size }} participants](#participants) with [{{ projects | size }} projects](#projects).
 
 # Projects
 
@@ -31,22 +31,26 @@ For the third round of the OLS program, we are happy to have [{{ p-participants 
     {% if project.visible != false %}
 
         {% assign p-pparticipants = '' %}
-        
+
         {% for p in project.participants %}
             {% capture p-pparticipants %}{{ p-pparticipants }}, ![](https://avatars.githubusercontent.com/{{ p }}){: .people-badge} [{{ people[p].first-name }} {{ people[p].last-name }}](#{{ p }}){% endcapture %}
         {% endfor %}
-        
+
         {% assign mentor = project.mentor %}
         {% capture p-mentors %}
         {% for p in project.mentors %}with ![](https://avatars.githubusercontent.com/{{ p }}){: .people-badge} [{{ people[p].first-name }} {{ people[p].last-name }}](/peopls#{{ p }})
         {% endfor %}
-        {% endcapture %} 
+        {% endcapture %}
 
 ## {{ project.name }}
 
 **By**: {{ p-pparticipants | remove_first: ', ' }}
 
 **Mentored by**: {{ p-mentors | remove_first: 'with ' }}
+
+{% if project.status %}
+**Status**: {{ project.status }}
+{% endif %}
 
     {% capture difference %} {{ project.keywords | size | minus:1 }} {% endcapture %}
     {% unless difference contains '-' %}

--- a/_ols-8/projects-participants.md
+++ b/_ols-8/projects-participants.md
@@ -23,7 +23,7 @@ photos:
 
 Participants join this program with a project that they either are already working on or want to develop during this program.
 
-For the third round of the OLS program, we are happy to have [{{ p-participants | size }} participants](#participants) with [{{ projects | size }} projects](#projects). 
+For the third round of the OLS program, we are happy to have [{{ p-participants | size }} participants](#participants) with [{{ projects | size }} projects](#projects).
 
 # Projects
 
@@ -31,22 +31,26 @@ For the third round of the OLS program, we are happy to have [{{ p-participants 
     {% if project.visible != false %}
 
         {% assign p-pparticipants = '' %}
-        
+
         {% for p in project.participants %}
             {% capture p-pparticipants %}{{ p-pparticipants }}, ![](https://avatars.githubusercontent.com/{{ p }}){: .people-badge} [{{ people[p].first-name }} {{ people[p].last-name }}](#{{ p }}){% endcapture %}
         {% endfor %}
-        
+
         {% assign mentor = project.mentor %}
         {% capture p-mentors %}
         {% for p in project.mentors %}with ![](https://avatars.githubusercontent.com/{{ p }}){: .people-badge} [{{ people[p].first-name }} {{ people[p].last-name }}](/people#{{ p }})
         {% endfor %}
-        {% endcapture %} 
+        {% endcapture %}
 
 ## {{ project.name }}
 
 **By**: {{ p-pparticipants | remove_first: ', ' }}
 
 **Mentored by**: {{ p-mentors | remove_first: 'with ' }}
+
+{% if project.status %}
+**Status**: {{ project.status }}
+{% endif %}
 
     {% capture difference %} {{ project.keywords | size | minus:1 }} {% endcapture %}
     {% unless difference contains '-' %}

--- a/_posts/2020-05-27-ols1-wrapup.md
+++ b/_posts/2020-05-27-ols1-wrapup.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: End of OLS-1 and OLS-2 Announcement post
-authors: 
+authors:
 - yochannah
 - bebatut
 - malvikasharan
@@ -20,7 +20,7 @@ photos:
 {% assign all-participants = '' %}
 {% assign all-mentors = '' %}
 {% for project in projects %}
-    {% if project.graduated %}
+    {% if project.status == 'graduated' %}
         {% capture grad-projects %}{{ grad-projects}}, {{ project.name }}{% endcapture %}
         {% for p in project.participants %}
             {% capture grad-participants %}{{ grad-participants}}, [{{ people[p].first-name }} {{ people[p].last-name }}](/ols-1/projects-participants#{{ p }}){% endcapture %}
@@ -29,7 +29,7 @@ photos:
             {% capture grad-mentors %}{{ grad-mentors }}, [{{ people[m].first-name }} {{ people[m].last-name }}](/ols-1#{{ m }}){% endcapture %}
         {% endfor %}
     {% endif %}
-    {% for p in project.participants %}    
+    {% for p in project.participants %}
         {% capture all-participants %}{{ all-participants}}, [{{ people[p].first-name }} {{ people[p].last-name }}](/ols-1/projects-participants#{{ p }}){% endcapture %}
     {% endfor %}
     {% for m in project.mentors %}
@@ -54,28 +54,27 @@ Last but not least, thanks to our expert community and speakers for sharing your
 ## Presentations - recap and common themes
 
 Let us recap it for you - we ran our first cohort from January to May 2020 with {{ all-participants | size }} mentees, {{ all-mentors | size }} mentors, and over 50 experts from Asian, African, European, Latin American, North American, and Russian countries.
-Our program introduced our mentees to a great deal of Open Science concepts that are directly applicable to their work. In addition, they also learned all about designing their project for inclusivity, establishing connections with others in the program, managing their communities, and working collaboratively. 
-Through this program, OLS helped design and implement projects to solve technical and cultural questions by collaboratively designing open source software, AI techniques, educational resources, culture movements, and global partnerships in their communities ([details](/ols-1/projects-participants/)). 
+Our program introduced our mentees to a great deal of Open Science concepts that are directly applicable to their work. In addition, they also learned all about designing their project for inclusivity, establishing connections with others in the program, managing their communities, and working collaboratively.
+Through this program, OLS helped design and implement projects to solve technical and cultural questions by collaboratively designing open source software, AI techniques, educational resources, culture movements, and global partnerships in their communities ([details](/ols-1/projects-participants/)).
 
 The final step to graduate Open Life Science is a short presentation about what you worked on. While we originally envisioned this being in April, COVID-19 brought a whole new set of pressures, so we decided to extend the deadlines for final presentations, as well as offering additional timeslots. The result - five calls - can all be viewed on [our YouTube channel](https://www.youtube.com/playlist?list=PL1CvC6Ez54KB6U9GtjOjwESMurHgT41qM&advanced_settings=1&disable_polymer=1)
- 
-Some of the common themes that surprised us and brought us joy during the presentations: 
-- The COVID-19 pandemic had an unexpected impact of our program beyond the initial goals as our mentees could transfer their OLS skills in other areas like establishing effective communication among the international COVID collaborations, designing the format of their lab meetings online, setting mentor-mentee relationships in their local networks, and connecting folk musicians and artists with each other in Nepal during the lockdown.
-- The [open canvas](https://docs.google.com/presentation/d/1MeJo0TyuMg_waLk1J4q9y1aAqKNMuRBlnmxEChSz-cQ/edit#slide=id.p) exercise was commonly useful for everyone. We presented this in [our first cohort call](/ols-1/week02/), but a large number of mentees found it so foundational they shared it even 3-4 months later in their presentations. 
-- Skills like collaborative work culture, self care, ally skills, giving and receiving feedback, agile management, and knowledge dissemination are valuable beyond research.  
-- Livestreaming and online engagement can make all the difference in helping your friends and family attend important events: 
 
-<blockquote class="twitter-tweet"><p lang="en" dir="ltr">The graduation was even more special because my <a href="https://twitter.com/hashtag/VUamsterdam?src=hash&amp;ref_src=twsrc%5Etfw">#VUamsterdam</a> family, <a href="https://twitter.com/gravana?ref_src=twsrc%5Etfw">@gravana</a>, and <a href="https://twitter.com/PhDToothFAIRy?ref_src=twsrc%5Etfw">@PhDToothFAIRy</a><br>were there 😍<br>AND, my mother watched my graduation in real-time. She had to miss both my wedding and PhD defense. It&#39;s the first event in my life abroad that she witnessed 👩‍👧 <a href="https://t.co/xWWaJ9kLhw">pic.twitter.com/xWWaJ9kLhw</a></p>&mdash; Lena Karvovskaya (@LangData) <a href="https://twitter.com/LangData/status/1263468708330078209?ref_src=twsrc%5Etfw">May 21, 2020</a></blockquote> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script> 
+Some of the common themes that surprised us and brought us joy during the presentations:
+- The COVID-19 pandemic had an unexpected impact of our program beyond the initial goals as our mentees could transfer their OLS skills in other areas like establishing effective communication among the international COVID collaborations, designing the format of their lab meetings online, setting mentor-mentee relationships in their local networks, and connecting folk musicians and artists with each other in Nepal during the lockdown.
+- The [open canvas](https://docs.google.com/presentation/d/1MeJo0TyuMg_waLk1J4q9y1aAqKNMuRBlnmxEChSz-cQ/edit#slide=id.p) exercise was commonly useful for everyone. We presented this in [our first cohort call](/ols-1/week02/), but a large number of mentees found it so foundational they shared it even 3-4 months later in their presentations.
+- Skills like collaborative work culture, self care, ally skills, giving and receiving feedback, agile management, and knowledge dissemination are valuable beyond research.
+- Livestreaming and online engagement can make all the difference in helping your friends and family attend important events:
+
+<blockquote class="twitter-tweet"><p lang="en" dir="ltr">The graduation was even more special because my <a href="https://twitter.com/hashtag/VUamsterdam?src=hash&amp;ref_src=twsrc%5Etfw">#VUamsterdam</a> family, <a href="https://twitter.com/gravana?ref_src=twsrc%5Etfw">@gravana</a>, and <a href="https://twitter.com/PhDToothFAIRy?ref_src=twsrc%5Etfw">@PhDToothFAIRy</a><br>were there 😍<br>AND, my mother watched my graduation in real-time. She had to miss both my wedding and PhD defense. It&#39;s the first event in my life abroad that she witnessed 👩‍👧 <a href="https://t.co/xWWaJ9kLhw">pic.twitter.com/xWWaJ9kLhw</a></p>&mdash; Lena Karvovskaya (@LangData) <a href="https://twitter.com/LangData/status/1263468708330078209?ref_src=twsrc%5Etfw">May 21, 2020</a></blockquote> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 
 Over the next weeks, we will be sharing reports from the individual projects and celebrate our new graduates for their thoughtful work and passion for Open Science!
 
-## Announcing OLS-2 - please share with your networks! 
+## Announcing OLS-2 - please share with your networks!
 
-Motivated by the overwhelming success of OLS so far, we're incredibly excited to announce that applications for round 2 of OLS are now officially open!  
+Motivated by the overwhelming success of OLS so far, we're incredibly excited to announce that applications for round 2 of OLS are now officially open!
 Whether you were excited by OLS-1 but missed the deadline, or whether you've heard about it for the first time today, you're welcome to apply.
 
 {% assign schedule = site.data.ols-2-schedule %}
 {% include _includes/timeline.md %}
 
 Questions, comments, looking for more advice? You're always welcome to email the OLS leadership at [{{ site.email|replace:'@','[at]' }}](mailto:{{ site.email }})- and attend our two pre-application webinars.
-


### PR DESCRIPTION
closes #198 

### **What this PR does**
This adds a `status` field for each project's participant.

### **How/Why**
I added the `status` inside an `if clause` to the `projects-participants.md`. I did this because we don't have all the status** data yet. This way the `status` will only show if it exists inside the `ols-x-projects.yaml`.

If this is ok, we could update the structure with this PR, and I can open a new issue to update the YAML files when the data is available.

** about the the status data: As @AndreaSanchezTapia pointed out, I found the `graduated:true` field, but only in the `ols-1-projects.yaml`

### **Some images of the new behaviour 😉**
without status
![Screen Shot 2022-10-22 at 12 32 39](https://user-images.githubusercontent.com/87862340/197347804-2ffa7a08-45c7-412e-bc53-7a8d3fd5db67.png)

with status
![Screen Shot 2022-10-22 at 12 32 20](https://user-images.githubusercontent.com/87862340/197347815-0795aab0-7b95-452f-ab15-a159c70de76e.png)
