### PR TITLE
Issue488: Fix multiple authors text and avatar alignment

### DIFF
--- a/css/custom.scss
+++ b/css/custom.scss
@@ -184,6 +184,7 @@ $link-active: $link-hover;
   border-radius: 50%;
   margin-left: 0.25em;
   margin-right: 0.25em;
+  vertical-align: middle;
 }
 
 .entities {


### PR DESCRIPTION
closes #488 

### What this PR does
This aligns text and avatars by their middle.

### How/Why
It was looking a bit messy, so I just added a `vertical-alignment` to `people-badge `

### Image of the new behavior 😉 
<img width="435" alt="Screen Shot 2022-10-24 at 14 13 52" src="https://user-images.githubusercontent.com/87862340/197586968-80f2e83e-d59c-4e0b-88de-6f948a1d1822.png">

