### PR TITLE
Prevent Overflow of Text from Header 

### DIFF
--- a/css/custom.scss
+++ b/css/custom.scss
@@ -59,7 +59,7 @@ $link-active: $link-hover;
   background-position: center center;
   background-repeat: no-repeat;
   background-size: cover;
-  height: 450px;
+  height: auto;
   width: 100%;
 
   &.no-image {


### PR DESCRIPTION
Signed-off-by: Deborah Udoh <deborahudoh02@gmail.com>
This PR fixes issue #238.
An easy, straightforward solution to prevent the content of `<section class="hero">` from overflowing, is to give it a height of `auto`, rather than a fixed height.

![ols-pr-2](https://user-images.githubusercontent.com/105166953/195165517-93d9d6a0-10b0-406e-93fe-bf88f621aef9.png)

Please review this and suggest additional changes where necessary. Thank you!