### PR TITLE
Display the roles of members in their bio.

### DIFF
--- a/_includes/people.html
+++ b/_includes/people.html
@@ -52,13 +52,13 @@
 
     {% if roles or user.title %}
       <p class="people-description">
-         <p class="people-description-question">
-        Role in OLS:  <p class="people-description-question">
+        <p class="people-description-question">
+        Role in OLS:
         {% if user.title %}
           {{ user.title }}
         {% endif %}
         {% if roles %}
-          {{ roles | remove_first: ', ' | markdownify }}
+          {{ roles | remove_first: ', ' }}
         {% endif %}
         </p>
       </p>

--- a/_includes/people.html
+++ b/_includes/people.html
@@ -52,7 +52,6 @@
 
     {% if roles or user.title %}
     <p class="people-description">
-      <p class="people-description-question">
       Role in OLS:
       {% if user.title %}
         {{ user.title }}

--- a/_includes/people.html
+++ b/_includes/people.html
@@ -50,7 +50,7 @@
       </div>
     </div>
 
-    {% if ols-roles or user.title %}
+    {% if ols-roles and ols-roles != ''  or user.title %}
     <p class="people-description">
       Role in OLS:
       {% if user.title %}

--- a/_includes/people.html
+++ b/_includes/people.html
@@ -57,7 +57,7 @@
         {% if user.title %}
           {{ user.title }}
         {% endif %}
-        {% if user.title %}
+        {% if roles %}
           {{ roles | remove_first: ', ' | markdownify }}
         {% endif %}
         </p>

--- a/_includes/people.html
+++ b/_includes/people.html
@@ -57,7 +57,7 @@
         {{ user.title }}
       {% endif %}
       <br>
-      {% if roles %}
+      {% if ols-roles %}
         {{ ols-roles }}
       {% endif %}
       </p>

--- a/_includes/people.html
+++ b/_includes/people.html
@@ -50,19 +50,20 @@
       </div>
     </div>
 
-    {% if user.roles or user.title %}
-    <p class="people-description">
-      {% if user.roles %}
-      <p class="people-description-question">
-        Role in OLS: {% if user.title %}<a class="card-toggle">{{ user.title }} <i class="fa fa-angle-down"></i></a>{% endif %}
+    {% if roles or user.title %}
+      <p class="people-description">
+        {% if user.title %}
+        <p class="people-description-question">
+          Role in OLS:
+          <a class="card-toggle">{{ user.title }} <i class="fa fa-angle-down"></i></a>
+        </p>
+        <div class="content is-hidden">
+          {{ roles | markdownify }}
+        </div>
+        {% else %}
+        <p class="people-description-question">Role in OLS: <strong>{{ roles | remove_first: ', ' }}</strong></p>
       </p>
-      <div class="content is-hidden">
-        {{ user.roles | markdownify }}
-      </div>
-      {% else %}
-      <p class="people-description-question">Role in OLS: <strong>{{ user.title }}</strong></p>
       {% endif %}
-    </p>
     {% endif %}
 
     {% if user.expertise %}

--- a/_includes/people.html
+++ b/_includes/people.html
@@ -50,7 +50,7 @@
       </div>
     </div>
 
-    {% if roles or user.title %}
+    {% if ols-roles or user.title %}
     <p class="people-description">
       Role in OLS:
       {% if user.title %}

--- a/_includes/people.html
+++ b/_includes/people.html
@@ -51,17 +51,17 @@
     </div>
 
     {% if roles or user.title %}
-      <p class="people-description">
-        <p class="people-description-question">
-        Role in OLS:
-        {% if user.title %}
-          {{ user.title }}
-        {% endif %}
-        {% if roles %}
-          {{ roles | remove_first: ', ' }}
-        {% endif %}
-        </p>
+    <p class="people-description">
+      <p class="people-description-question">
+      Role in OLS:
+      {% if user.title %}
+        {{ user.title }}
+      {% endif %}
+      {% if roles %}
+        {{ ols-roles }}
+      {% endif %}
       </p>
+    </p>
     {% endif %}
 
     {% if user.expertise %}

--- a/_includes/people.html
+++ b/_includes/people.html
@@ -62,7 +62,6 @@
         {% endif %}
         </p>
       </p>
-      {% endif %}
     {% endif %}
 
     {% if user.expertise %}

--- a/_includes/people.html
+++ b/_includes/people.html
@@ -57,8 +57,9 @@
       {% if user.title %}
         {{ user.title }}
       {% endif %}
+      <br>
       {% if roles %}
-        {{ ols-roles }}
+        {{ ols-roles | remove_first: ', ' }}
       {% endif %}
       </p>
     </p>

--- a/_includes/people.html
+++ b/_includes/people.html
@@ -52,16 +52,15 @@
 
     {% if roles or user.title %}
       <p class="people-description">
+         <p class="people-description-question">
+        Role in OLS:  <p class="people-description-question">
         {% if user.title %}
-        <p class="people-description-question">
-          Role in OLS:
-          <a class="card-toggle">{{ user.title }} <i class="fa fa-angle-down"></i></a>
+          {{ user.title }}
+        {% endif %}
+        {% if user.title %}
+          {{ roles | remove_first: ', ' | markdownify }}
+        {% endif %}
         </p>
-        <div class="content is-hidden">
-          {{ roles | markdownify }}
-        </div>
-        {% else %}
-        <p class="people-description-question">Role in OLS: <strong>{{ roles | remove_first: ', ' }}</strong></p>
       </p>
       {% endif %}
     {% endif %}

--- a/_includes/people.html
+++ b/_includes/people.html
@@ -57,7 +57,7 @@
         {{ user.title }}
       {% endif %}
       <br>
-      {% if ols-roles %}
+      {% if ols-roles and ols-roles != ''  %}
         {{ ols-roles }}
       {% endif %}
       </p>

--- a/_includes/people.html
+++ b/_includes/people.html
@@ -59,7 +59,7 @@
       {% endif %}
       <br>
       {% if roles %}
-        {{ ols-roles | remove_first: ', ' }}
+        {{ ols-roles }}
       {% endif %}
       </p>
     </p>

--- a/_layouts/people.html
+++ b/_layouts/people.html
@@ -54,9 +54,9 @@ we ask that you follow our <a href="/code-of-conduct">code of conduct</a> in all
 <!-- extract experts and organizers -->
 {% assign ols-1-experts = site.data.ols-1-metadata.experts | join: ' ' %}
 {% assign ols-1-organizers = site.data.ols-1-metadata.organizers | join: ' ' %}
-<!-- extract speakers and call hosts -->
+<!-- extract speakers and call facilitators -->
 {% assign ols-1-speakers = '' %}
-{% assign ols-1-hosts = '' %}
+{% assign ols-1-facilitators = '' %}
 {% for w in site.data.ols-1-schedule %}
     {% for c in w[1].calls %}
         {% if c.type == 'Cohort' %}
@@ -66,15 +66,15 @@ we ask that you follow our <a href="/code-of-conduct">code of conduct</a> in all
                 {% endif %}
             {% endfor %}
         {% endif %}
-        {% if c.hosts %}
-            {% for h in c.hosts %}
-                {% capture ols-1-hosts %}{{ ols-1-hosts}} {{ h }}{% endcapture %}
+        {% if c.facilitators %}
+            {% for h in c.facilitators %}
+                {% capture ols-1-facilitators %}{{ ols-1-facilitators}} {{ h }}{% endcapture %}
             {% endfor %}
         {% endif %}
     {% endfor %}
 {% endfor %}
 <!-- combine all -->
-{% capture ols-1-people %}{{ ols-1-participants }} {{ ols-1-experts }} {{ ols-1-mentors }} {{ ols-1-organizers }} {{ ols-1-speakers }} {{ ols-1-hosts }}{% endcapture %}
+{% capture ols-1-people %}{{ ols-1-participants }} {{ ols-1-experts }} {{ ols-1-mentors }} {{ ols-1-organizers }} {{ ols-1-speakers }} {{ ols-1-facilitators }}{% endcapture %}
 
 <!-- OLS-2 -->
 <!-- extract participants and mentors -->
@@ -92,9 +92,9 @@ we ask that you follow our <a href="/code-of-conduct">code of conduct</a> in all
 <!-- extract experts and organizers -->
 {% assign ols-2-experts = site.data.ols-2-metadata.experts %}
 {% assign ols-2-organizers = site.data.ols-2-metadata.organizers %}
-<!-- extract speakers and call hosts -->
+<!-- extract speakers and call facilitators -->
 {% assign ols-2-speakers = '' %}
-{% assign ols-2-hosts = '' %}
+{% assign ols-2-facilitators = '' %}
 {% for w in site.data.ols-2-schedule %}
     {% for c in w[1].calls %}
         {% if c.type == 'Cohort' %}
@@ -104,15 +104,15 @@ we ask that you follow our <a href="/code-of-conduct">code of conduct</a> in all
                 {% endif %}
             {% endfor %}
         {% endif %}
-        {% if c.hosts %}
-            {% for h in c.hosts %}
-                {% capture ols-2-hosts %}{{ ols-2-hosts}} {{ h }}{% endcapture %}
+        {% if c.facilitators %}
+            {% for h in c.facilitators %}
+                {% capture ols-2-facilitators %}{{ ols-2-facilitators}} {{ h }}{% endcapture %}
             {% endfor %}
         {% endif %}
     {% endfor %}
 {% endfor %}
 <!-- combine all -->
-{% capture ols-2-people %}{{ ols-2-participants }} {{ ols-2-experts }} {{ ols-2-mentors }} {{ ols-2-organizers }} {{ ols-2-speakers }} {{ ols-2-hosts }}{% endcapture %}
+{% capture ols-2-people %}{{ ols-2-participants }} {{ ols-2-experts }} {{ ols-2-mentors }} {{ ols-2-organizers }} {{ ols-2-speakers }} {{ ols-2-facilitators }}{% endcapture %}
 
 <!-- OLS-3 -->
 <!-- extract participants and mentors -->
@@ -130,9 +130,9 @@ we ask that you follow our <a href="/code-of-conduct">code of conduct</a> in all
 <!-- extract experts and organizers -->
 {% assign ols-3-experts = site.data.ols-3-metadata.experts %}
 {% assign ols-3-organizers = site.data.ols-3-metadata.organizers %}
-<!-- extract speakers and call hosts -->
+<!-- extract speakers and call facilitators -->
 {% assign ols-3-speakers = '' %}
-{% assign ols-3-hosts = '' %}
+{% assign ols-3-facilitators = '' %}
 {% for w in site.data.ols-3-schedule %}
     {% for c in w[1].calls %}
         {% if c.type == 'Cohort' %}
@@ -142,15 +142,15 @@ we ask that you follow our <a href="/code-of-conduct">code of conduct</a> in all
                 {% endif %}
             {% endfor %}
         {% endif %}
-        {% if c.hosts %}
-            {% for h in c.hosts %}
-                {% capture ols-3-hosts %}{{ ols-3-hosts}} {{ h }}{% endcapture %}
+        {% if c.facilitators %}
+            {% for h in c.facilitators %}
+                {% capture ols-3-facilitators %}{{ ols-3-facilitators}} {{ h }}{% endcapture %}
             {% endfor %}
         {% endif %}
     {% endfor %}
 {% endfor %}
 <!-- combine all -->
-{% capture ols-3-people %}{{ ols-3-participants }} {{ ols-3-experts }} {{ ols-3-mentors }} {{ ols-3-organizers }} {{ ols-3-speakers }} {{ ols-3-hosts }}{% endcapture %}
+{% capture ols-3-people %}{{ ols-3-participants }} {{ ols-3-experts }} {{ ols-3-mentors }} {{ ols-3-organizers }} {{ ols-3-speakers }} {{ ols-3-facilitators }}{% endcapture %}
 
 <!-- OLS-4 -->
 <!-- extract participants and mentors -->
@@ -168,9 +168,9 @@ we ask that you follow our <a href="/code-of-conduct">code of conduct</a> in all
 <!-- extract experts and organizers -->
 {% assign ols-4-experts = site.data.ols-4-metadata.experts %}
 {% assign ols-4-organizers = site.data.ols-4-metadata.organizers %}
-<!-- extract speakers and call hosts -->
+<!-- extract speakers and call facilitators -->
 {% assign ols-4-speakers = '' %}
-{% assign ols-4-hosts = '' %}
+{% assign ols-4-facilitators = '' %}
 {% for w in site.data.ols-4-schedule %}
     {% for c in w[1].calls %}
         {% if c.type == 'Cohort' %}
@@ -180,15 +180,15 @@ we ask that you follow our <a href="/code-of-conduct">code of conduct</a> in all
                 {% endif %}
             {% endfor %}
         {% endif %}
-        {% if c.hosts %}
-            {% for h in c.hosts %}
-                {% capture ols-4-hosts %}{{ ols-4-hosts}} {{ h }}{% endcapture %}
+        {% if c.facilitators %}
+            {% for h in c.facilitators %}
+                {% capture ols-4-facilitators %}{{ ols-4-facilitators}} {{ h }}{% endcapture %}
             {% endfor %}
         {% endif %}
     {% endfor %}
 {% endfor %}
 <!-- combine all -->
-{% capture ols-4-people %}{{ ols-4-participants }} {{ ols-4-experts }} {{ ols-4-mentors }} {{ ols-4-organizers }} {{ ols-4-speakers }} {{ ols-4-hosts }}{% endcapture %}
+{% capture ols-4-people %}{{ ols-4-participants }} {{ ols-4-experts }} {{ ols-4-mentors }} {{ ols-4-organizers }} {{ ols-4-speakers }} {{ ols-4-facilitators }}{% endcapture %}
 
 <!-- OLS-5 -->
 <!-- extract participants and mentors -->
@@ -206,9 +206,9 @@ we ask that you follow our <a href="/code-of-conduct">code of conduct</a> in all
 <!-- extract experts and organizers -->
 {% assign ols-5-experts = site.data.ols-5-metadata.experts %}
 {% assign ols-5-organizers = site.data.ols-5-metadata.organizers %}
-<!-- extract speakers and call hosts -->
+<!-- extract speakers and call facilitators -->
 {% assign ols-5-speakers = '' %}
-{% assign ols-5-hosts = '' %}
+{% assign ols-5-facilitators = '' %}
 {% for w in site.data.ols-5-schedule %}
     {% for c in w[1].calls %}
         {% if c.type == 'Cohort' %}
@@ -218,15 +218,15 @@ we ask that you follow our <a href="/code-of-conduct">code of conduct</a> in all
                 {% endif %}
             {% endfor %}
         {% endif %}
-        {% if c.hosts %}
-            {% for h in c.hosts %}
-                {% capture ols-5-hosts %}{{ ols-5-hosts}} {{ h }}{% endcapture %}
+        {% if c.facilitators %}
+            {% for h in c.facilitators %}
+                {% capture ols-5-facilitators %}{{ ols-5-facilitators}} {{ h }}{% endcapture %}
             {% endfor %}
         {% endif %}
     {% endfor %}
 {% endfor %}
 <!-- combine all -->
-{% capture ols-5-people %}{{ ols-5-participants }} {{ ols-5-experts }} {{ ols-5-mentors }} {{ ols-5-organizers }} {{ ols-5-speakers }} {{ ols-5-hosts }}{% endcapture %}
+{% capture ols-5-people %}{{ ols-5-participants }} {{ ols-5-experts }} {{ ols-5-mentors }} {{ ols-5-organizers }} {{ ols-5-speakers }} {{ ols-5-facilitators }}{% endcapture %}
 
 <!-- OLS-6 -->
 <!-- extract participants and mentors -->
@@ -244,9 +244,9 @@ we ask that you follow our <a href="/code-of-conduct">code of conduct</a> in all
 <!-- extract experts and organizers -->
 {% assign ols-6-experts = site.data.ols-6-metadata.experts %}
 {% assign ols-6-organizers = site.data.ols-6-metadata.organizers %}
-<!-- extract speakers and call hosts -->
+<!-- extract speakers and call facilitators -->
 {% assign ols-6-speakers = '' %}
-{% assign ols-6-hosts = '' %}
+{% assign ols-6-facilitators = '' %}
 {% for w in site.data.ols-6-schedule %}
     {% for c in w[1].calls %}
         {% if c.type == 'Cohort' %}
@@ -256,15 +256,15 @@ we ask that you follow our <a href="/code-of-conduct">code of conduct</a> in all
                 {% endif %}
             {% endfor %}
         {% endif %}
-        {% if c.hosts %}
-            {% for h in c.hosts %}
-                {% capture ols-6-hosts %}{{ ols-6-hosts}} {{ h }}{% endcapture %}
+        {% if c.facilitators %}
+            {% for h in c.facilitators %}
+                {% capture ols-6-facilitators %}{{ ols-6-facilitators}} {{ h }}{% endcapture %}
             {% endfor %}
         {% endif %}
     {% endfor %}
 {% endfor %}
 <!-- combine all -->
-{% capture ols-6-people %}{{ ols-6-participants }} {{ ols-6-experts }} {{ ols-6-mentors }} {{ ols-6-organizers }} {{ ols-6-speakers }} {{ ols-6-hosts }}{% endcapture %}
+{% capture ols-6-people %}{{ ols-6-participants }} {{ ols-6-experts }} {{ ols-6-mentors }} {{ ols-6-organizers }} {{ ols-6-speakers }} {{ ols-6-facilitators }}{% endcapture %}
 
 <div class="people">
     {% for entry in site.data.people %}
@@ -285,7 +285,7 @@ we ask that you follow our <a href="/code-of-conduct">code of conduct</a> in all
             {% if ols-1-speakers contains username %}
                 {% capture roles %}{{ roles }},OLS-1 speaker{% endcapture %}
             {% endif %}
-            {% if ols-1-hosts contains username %}
+            {% if ols-1-facilitators contains username %}
                 {% capture roles %}{{ roles }}, OLS-1 facilitator{% endcapture %}
             {% endif %}
             {% if ols-1-organizers contains username %}
@@ -307,7 +307,7 @@ we ask that you follow our <a href="/code-of-conduct">code of conduct</a> in all
             {% if ols-2-speakers contains username %}
                 {% capture roles %}{{ roles }}, OLS-2 speaker{% endcapture %}
             {% endif %}
-            {% if ols-2-hosts contains username %}
+            {% if ols-2-facilitators contains username %}
                 {% capture roles %}{{ roles }}, OLS-2 facilitator{% endcapture %}
             {% endif %}
             {% if ols-2-organizers contains username %}
@@ -329,7 +329,7 @@ we ask that you follow our <a href="/code-of-conduct">code of conduct</a> in all
             {% if ols-3-speakers contains username %}
                 {% capture roles %}{{ roles }}, OLS-3 speaker{% endcapture %}
             {% endif %}
-            {% if ols-3-hosts contains username %}
+            {% if ols-3-facilitators contains username %}
                 {% capture roles %}{{ roles }}, OLS-3 facilitator{% endcapture %}
             {% endif %}
             {% if ols-3-organizers contains username %}
@@ -351,7 +351,7 @@ we ask that you follow our <a href="/code-of-conduct">code of conduct</a> in all
             {% if ols-4-speakers contains username %}
                 {% capture roles %}{{ roles }}, OLS-4 speaker{% endcapture %}
             {% endif %}
-            {% if ols-4-hosts contains username %}
+            {% if ols-4-facilitators contains username %}
                 {% capture roles %}{{ roles }}, OLS-4 facilitator{% endcapture %}
             {% endif %}
             {% if ols-4-organizers contains username %}
@@ -373,7 +373,7 @@ we ask that you follow our <a href="/code-of-conduct">code of conduct</a> in all
             {% if ols-5-speakers contains username %}
                 {% capture roles %}{{ roles }}, OLS-5 speaker{% endcapture %}
             {% endif %}
-            {% if ols-5-hosts contains username %}
+            {% if ols-5-facilitators contains username %}
                 {% capture roles %}{{ roles }}, OLS-5 facilitator{% endcapture %}
             {% endif %}
             {% if ols-5-organizers contains username %}
@@ -395,7 +395,7 @@ we ask that you follow our <a href="/code-of-conduct">code of conduct</a> in all
             {% if ols-6-speakers contains username %}
                 {% capture roles %}{{ roles }}, OLS-6 speaker{% endcapture %}
             {% endif %}
-            {% if ols-6-hosts contains username %}
+            {% if ols-6-facilitators contains username %}
                 {% capture roles %}{{ roles }}, OLS-6 facilitator{% endcapture %}
             {% endif %}
             {% if ols-6-organizers contains username %}
@@ -407,5 +407,3 @@ we ask that you follow our <a href="/code-of-conduct">code of conduct</a> in all
         {% include _includes/people.html username=username user=user ols-roles=ols-roles%}
     {% endfor %}
 </div>
-
-

--- a/_layouts/people.html
+++ b/_layouts/people.html
@@ -274,132 +274,132 @@ we ask that you follow our <a href="/code-of-conduct">code of conduct</a> in all
         {% if ols-1-people contains username %}
             {% assign roles = '' %}
             {% if ols-1-participants contains username %}
-                {% capture roles %}{{ roles }}, project lead{% endcapture %}
+                {% capture roles %}{{ roles }}, OLS-1 project lead{% endcapture %}
             {% endif %}
             {% if ols-1-mentors contains username %}
-                {% capture roles %}{{ roles }}, mentor{% endcapture %}
+                {% capture roles %}{{ roles }}, OLS-1 mentor{% endcapture %}
             {% endif %}
             {% if ols-1-experts contains username %}
-                {% capture roles %}{{ roles }}, expert{% endcapture %}
+                {% capture roles %}{{ roles }}, OLS-1 expert{% endcapture %}
             {% endif %}
             {% if ols-1-speakers contains username %}
-                {% capture roles %}{{ roles }}, speaker{% endcapture %}
+                {% capture roles %}{{ roles }},OLS-1 speaker{% endcapture %}
             {% endif %}
             {% if ols-1-hosts contains username %}
-                {% capture roles %}{{ roles }}, call host{% endcapture %}
+                {% capture roles %}{{ roles }}, OLS-1 call host{% endcapture %}
             {% endif %}
             {% if ols-1-organizers contains username %}
-                {% capture roles %}{{ roles }}, organizer{% endcapture %}
+                {% capture roles %}{{ roles }}, OLS-1 organizer{% endcapture %}
             {% endif %}
             {% capture ols-roles %}{{ ols-roles }} / OLS-1 {{ roles | remove_first: ', ' }}{% endcapture %}
         {% endif %}
         {% if ols-2-people contains username %}
             {% assign roles = '' %}
             {% if ols-2-participants contains username %}
-                {% capture roles %}{{ roles }}, project lead{% endcapture %}
+                {% capture roles %}{{ roles }}, OLS-2 project lead{% endcapture %}
             {% endif %}
             {% if ols-2-mentors contains username %}
-                {% capture roles %}{{ roles }}, mentor{% endcapture %}
+                {% capture roles %}{{ roles }}, OLS-2 mentor{% endcapture %}
             {% endif %}
             {% if ols-2-experts contains username %}
-                {% capture roles %}{{ roles }}, expert{% endcapture %}
+                {% capture roles %}{{ roles }}, OLS-2 expert{% endcapture %}
             {% endif %}
             {% if ols-2-speakers contains username %}
-                {% capture roles %}{{ roles }}, speaker{% endcapture %}
+                {% capture roles %}{{ roles }}, OLS-2 speaker{% endcapture %}
             {% endif %}
             {% if ols-2-hosts contains username %}
-                {% capture roles %}{{ roles }}, call host{% endcapture %}
+                {% capture roles %}{{ roles }}, OLS-2 call host{% endcapture %}
             {% endif %}
             {% if ols-2-organizers contains username %}
-                {% capture roles %}{{ roles }}, organizer{% endcapture %}
+                {% capture roles %}{{ roles }}, OLS-2 organizer{% endcapture %}
             {% endif %}
             {% capture ols-roles %}{{ ols-roles }} / OLS-2 {{ roles | remove_first: ', ' }}{% endcapture %}
         {% endif %}
         {% if ols-3-people contains username %}
             {% assign roles = '' %}
             {% if ols-3-participants contains username %}
-                {% capture roles %}{{ roles }}, project lead{% endcapture %}
+                {% capture roles %}{{ roles }}, OLS-3 project lead{% endcapture %}
             {% endif %}
             {% if ols-3-mentors contains username %}
-                {% capture roles %}{{ roles }}, mentor{% endcapture %}
+                {% capture roles %}{{ roles }}, OLS-3 mentor{% endcapture %}
             {% endif %}
             {% if ols-3-experts contains username %}
-                {% capture roles %}{{ roles }}, expert{% endcapture %}
+                {% capture roles %}{{ roles }}, OLS-3 expert{% endcapture %}
             {% endif %}
             {% if ols-3-speakers contains username %}
-                {% capture roles %}{{ roles }}, speaker{% endcapture %}
+                {% capture roles %}{{ roles }}, OLS-3 speaker{% endcapture %}
             {% endif %}
             {% if ols-3-hosts contains username %}
-                {% capture roles %}{{ roles }}, call host{% endcapture %}
+                {% capture roles %}{{ roles }}, OLS-3 call host{% endcapture %}
             {% endif %}
             {% if ols-3-organizers contains username %}
-                {% capture roles %}{{ roles }}, organizer{% endcapture %}
+                {% capture roles %}{{ roles }}, OLS-3 organizer{% endcapture %}
             {% endif %}
             {% capture ols-roles %}{{ ols-roles }} / OLS-3 {{ roles | remove_first: ', ' }}{% endcapture %}
         {% endif %}
         {% if ols-4-people contains username %}
             {% assign roles = '' %}
             {% if ols-4-participants contains username %}
-                {% capture roles %}{{ roles }}, project lead{% endcapture %}
+                {% capture roles %}{{ roles }}, OLS-4 project lead{% endcapture %}
             {% endif %}
             {% if ols-4-mentors contains username %}
-                {% capture roles %}{{ roles }}, mentor{% endcapture %}
+                {% capture roles %}{{ roles }}, OLS-4 mentor{% endcapture %}
             {% endif %}
             {% if ols-4-experts contains username %}
-                {% capture roles %}{{ roles }}, expert{% endcapture %}
+                {% capture roles %}{{ roles }}, OLS-4 expert{% endcapture %}
             {% endif %}
             {% if ols-4-speakers contains username %}
-                {% capture roles %}{{ roles }}, speaker{% endcapture %}
+                {% capture roles %}{{ roles }}, OLS-4 speaker{% endcapture %}
             {% endif %}
             {% if ols-4-hosts contains username %}
-                {% capture roles %}{{ roles }}, call host{% endcapture %}
+                {% capture roles %}{{ roles }}, OLS-4 call host{% endcapture %}
             {% endif %}
             {% if ols-4-organizers contains username %}
-                {% capture roles %}{{ roles }}, organizer{% endcapture %}
+                {% capture roles %}{{ roles }}, OLS-4 organizer{% endcapture %}
             {% endif %}
             {% capture ols-roles %}{{ ols-roles }} / OLS-4 {{ roles | remove_first: ', ' }}{% endcapture %}
         {% endif %}
         {% if ols-5-people contains username %}
             {% assign roles = '' %}
             {% if ols-5-participants contains username %}
-                {% capture roles %}{{ roles }}, project lead{% endcapture %}
+                {% capture roles %}{{ roles }}, OLS-5 project lead{% endcapture %}
             {% endif %}
             {% if ols-5-mentors contains username %}
-                {% capture roles %}{{ roles }}, mentor{% endcapture %}
+                {% capture roles %}{{ roles }}, OLS-5 mentor{% endcapture %}
             {% endif %}
             {% if ols-5-experts contains username %}
-                {% capture roles %}{{ roles }}, expert{% endcapture %}
+                {% capture roles %}{{ roles }}, OLS-5 expert{% endcapture %}
             {% endif %}
             {% if ols-5-speakers contains username %}
-                {% capture roles %}{{ roles }}, speaker{% endcapture %}
+                {% capture roles %}{{ roles }}, OLS-5 speaker{% endcapture %}
             {% endif %}
             {% if ols-5-hosts contains username %}
-                {% capture roles %}{{ roles }}, call host{% endcapture %}
+                {% capture roles %}{{ roles }}, OLS-5 call host{% endcapture %}
             {% endif %}
             {% if ols-5-organizers contains username %}
-                {% capture roles %}{{ roles }}, organizer{% endcapture %}
+                {% capture roles %}{{ roles }}, OLS-5 organizer{% endcapture %}
             {% endif %}
             {% capture ols-roles %}{{ ols-roles }} / OLS-5 {{ roles | remove_first: ', ' }}{% endcapture %}
         {% endif %}
         {% if ols-6-people contains username %}
             {% assign roles = '' %}
             {% if ols-6-participants contains username %}
-                {% capture roles %}{{ roles }}, project lead{% endcapture %}
+                {% capture roles %}{{ roles }}, OLS-6 project lead{% endcapture %}
             {% endif %}
             {% if ols-6-mentors contains username %}
-                {% capture roles %}{{ roles }}, mentor{% endcapture %}
+                {% capture roles %}{{ roles }}, OLS-6 mentor{% endcapture %}
             {% endif %}
             {% if ols-6-experts contains username %}
-                {% capture roles %}{{ roles }}, expert{% endcapture %}
+                {% capture roles %}{{ roles }}, OLS-6 expert{% endcapture %}
             {% endif %}
             {% if ols-6-speakers contains username %}
-                {% capture roles %}{{ roles }}, speaker{% endcapture %}
+                {% capture roles %}{{ roles }}, OLS-6 speaker{% endcapture %}
             {% endif %}
             {% if ols-6-hosts contains username %}
-                {% capture roles %}{{ roles }}, call host{% endcapture %}
+                {% capture roles %}{{ roles }}, OLS-6 call host{% endcapture %}
             {% endif %}
             {% if ols-6-organizers contains username %}
-                {% capture roles %}{{ roles }}, organizer{% endcapture %}
+                {% capture roles %}{{ roles }}, OLS-6 organizer{% endcapture %}
             {% endif %}
             {% capture ols-roles %}{{ ols-roles }} / OLS-6 {{ roles | remove_first: ', ' }}{% endcapture %}
         {% endif %}

--- a/_layouts/people.html
+++ b/_layouts/people.html
@@ -286,7 +286,7 @@ we ask that you follow our <a href="/code-of-conduct">code of conduct</a> in all
                 {% capture roles %}{{ roles }},OLS-1 speaker{% endcapture %}
             {% endif %}
             {% if ols-1-hosts contains username %}
-                {% capture roles %}{{ roles }}, OLS-1 call host{% endcapture %}
+                {% capture roles %}{{ roles }}, OLS-1 facilitator{% endcapture %}
             {% endif %}
             {% if ols-1-organizers contains username %}
                 {% capture roles %}{{ roles }}, OLS-1 organizer{% endcapture %}
@@ -308,7 +308,7 @@ we ask that you follow our <a href="/code-of-conduct">code of conduct</a> in all
                 {% capture roles %}{{ roles }}, OLS-2 speaker{% endcapture %}
             {% endif %}
             {% if ols-2-hosts contains username %}
-                {% capture roles %}{{ roles }}, OLS-2 call host{% endcapture %}
+                {% capture roles %}{{ roles }}, OLS-2 facilitator{% endcapture %}
             {% endif %}
             {% if ols-2-organizers contains username %}
                 {% capture roles %}{{ roles }}, OLS-2 organizer{% endcapture %}
@@ -330,7 +330,7 @@ we ask that you follow our <a href="/code-of-conduct">code of conduct</a> in all
                 {% capture roles %}{{ roles }}, OLS-3 speaker{% endcapture %}
             {% endif %}
             {% if ols-3-hosts contains username %}
-                {% capture roles %}{{ roles }}, OLS-3 call host{% endcapture %}
+                {% capture roles %}{{ roles }}, OLS-3 facilitator{% endcapture %}
             {% endif %}
             {% if ols-3-organizers contains username %}
                 {% capture roles %}{{ roles }}, OLS-3 organizer{% endcapture %}
@@ -352,7 +352,7 @@ we ask that you follow our <a href="/code-of-conduct">code of conduct</a> in all
                 {% capture roles %}{{ roles }}, OLS-4 speaker{% endcapture %}
             {% endif %}
             {% if ols-4-hosts contains username %}
-                {% capture roles %}{{ roles }}, OLS-4 call host{% endcapture %}
+                {% capture roles %}{{ roles }}, OLS-4 facilitator{% endcapture %}
             {% endif %}
             {% if ols-4-organizers contains username %}
                 {% capture roles %}{{ roles }}, OLS-4 organizer{% endcapture %}
@@ -374,7 +374,7 @@ we ask that you follow our <a href="/code-of-conduct">code of conduct</a> in all
                 {% capture roles %}{{ roles }}, OLS-5 speaker{% endcapture %}
             {% endif %}
             {% if ols-5-hosts contains username %}
-                {% capture roles %}{{ roles }}, OLS-5 call host{% endcapture %}
+                {% capture roles %}{{ roles }}, OLS-5 facilitator{% endcapture %}
             {% endif %}
             {% if ols-5-organizers contains username %}
                 {% capture roles %}{{ roles }}, OLS-5 organizer{% endcapture %}
@@ -396,7 +396,7 @@ we ask that you follow our <a href="/code-of-conduct">code of conduct</a> in all
                 {% capture roles %}{{ roles }}, OLS-6 speaker{% endcapture %}
             {% endif %}
             {% if ols-6-hosts contains username %}
-                {% capture roles %}{{ roles }}, OLS-6 call host{% endcapture %}
+                {% capture roles %}{{ roles }}, OLS-6 facilitator{% endcapture %}
             {% endif %}
             {% if ols-6-organizers contains username %}
                 {% capture roles %}{{ roles }}, OLS-6 organizer{% endcapture %}

--- a/_layouts/people.html
+++ b/_layouts/people.html
@@ -132,11 +132,6 @@ we ask that you follow our <a href="/code-of-conduct">code of conduct</a> in all
                 {% endif %}
             {% endfor %}
         {% endif %}
-        {% if c.facilitators %}
-            {% for h in c.facilitators %}
-                {% capture ols-3-facilitators %}{{ ols-3-facilitators}} {{ h }}{% endcapture %}
-            {% endfor %}
-        {% endif %}
     {% endfor %}
 {% endfor %}
 <!-- combine all -->
@@ -168,11 +163,6 @@ we ask that you follow our <a href="/code-of-conduct">code of conduct</a> in all
                 {% if r.type == 'slides' and r.speaker %}
                     {% capture ols-4-speakers %}{{ ols-4-speakers}} {{ r.speaker }}{% endcapture %}
                 {% endif %}
-            {% endfor %}
-        {% endif %}
-        {% if c.facilitators %}
-            {% for h in c.facilitators %}
-                {% capture ols-4-facilitators %}{{ ols-4-facilitators}} {{ h }}{% endcapture %}
             {% endfor %}
         {% endif %}
     {% endfor %}
@@ -208,11 +198,6 @@ we ask that you follow our <a href="/code-of-conduct">code of conduct</a> in all
                 {% endif %}
             {% endfor %}
         {% endif %}
-        {% if c.facilitators %}
-            {% for h in c.facilitators %}
-                {% capture ols-5-facilitators %}{{ ols-5-facilitators}} {{ h }}{% endcapture %}
-            {% endfor %}
-        {% endif %}
     {% endfor %}
 {% endfor %}
 <!-- combine all -->
@@ -244,11 +229,6 @@ we ask that you follow our <a href="/code-of-conduct">code of conduct</a> in all
                 {% if r.type == 'slides' and r.speaker %}
                     {% capture ols-6-speakers %}{{ ols-6-speakers}} {{ r.speaker }}{% endcapture %}
                 {% endif %}
-            {% endfor %}
-        {% endif %}
-        {% if c.facilitators %}
-            {% for h in c.facilitators %}
-                {% capture ols-6-facilitators %}{{ ols-6-facilitators}} {{ h }}{% endcapture %}
             {% endfor %}
         {% endif %}
     {% endfor %}

--- a/_layouts/people.html
+++ b/_layouts/people.html
@@ -119,10 +119,10 @@ we ask that you follow our <a href="/code-of-conduct">code of conduct</a> in all
 {% endfor %}
 <!-- extract experts and organizers -->
 {% assign ols-3-experts = site.data.ols-3-metadata.experts %}
+{% assign ols-3-facilitators = site.data.ols-3-metadata.facilitators %}
 {% assign ols-3-organizers = site.data.ols-3-metadata.organizers %}
 <!-- extract speakers and call facilitators -->
 {% assign ols-3-speakers = '' %}
-{% assign ols-3-facilitators = '' %}
 {% for w in site.data.ols-3-schedule %}
     {% for c in w[1].calls %}
         {% if c.type == 'Cohort' %}
@@ -157,10 +157,10 @@ we ask that you follow our <a href="/code-of-conduct">code of conduct</a> in all
 {% endfor %}
 <!-- extract experts and organizers -->
 {% assign ols-4-experts = site.data.ols-4-metadata.experts %}
+{% assign ols-4-facilitators = site.data.ols-4-metadata.facilitators %}
 {% assign ols-4-organizers = site.data.ols-4-metadata.organizers %}
 <!-- extract speakers and call facilitators -->
 {% assign ols-4-speakers = '' %}
-{% assign ols-4-facilitators = '' %}
 {% for w in site.data.ols-4-schedule %}
     {% for c in w[1].calls %}
         {% if c.type == 'Cohort' %}
@@ -195,10 +195,10 @@ we ask that you follow our <a href="/code-of-conduct">code of conduct</a> in all
 {% endfor %}
 <!-- extract experts and organizers -->
 {% assign ols-5-experts = site.data.ols-5-metadata.experts %}
+{% assign ols-5-facilitators = site.data.ols-5-metadata.facilitators %}
 {% assign ols-5-organizers = site.data.ols-5-metadata.organizers %}
 <!-- extract speakers and call facilitators -->
 {% assign ols-5-speakers = '' %}
-{% assign ols-5-facilitators = '' %}
 {% for w in site.data.ols-5-schedule %}
     {% for c in w[1].calls %}
         {% if c.type == 'Cohort' %}
@@ -233,10 +233,10 @@ we ask that you follow our <a href="/code-of-conduct">code of conduct</a> in all
 {% endfor %}
 <!-- extract experts and organizers -->
 {% assign ols-6-experts = site.data.ols-6-metadata.experts %}
+{% assign ols-6-facilitators = site.data.ols-6-metadata.facilitators %}
 {% assign ols-6-organizers = site.data.ols-6-metadata.organizers %}
 <!-- extract speakers and call facilitators -->
 {% assign ols-6-speakers = '' %}
-{% assign ols-6-facilitators = '' %}
 {% for w in site.data.ols-6-schedule %}
     {% for c in w[1].calls %}
         {% if c.type == 'Cohort' %}

--- a/_layouts/people.html
+++ b/_layouts/people.html
@@ -368,6 +368,6 @@ we ask that you follow our <a href="/code-of-conduct">code of conduct</a> in all
             {% capture ols-roles %}{{ ols-roles }} / OLS-6 {{ roles | remove_first: ', ' }}{% endcapture %}
         {% endif %}
         {% assign ols-roles = ols-roles | remove_first: ' / ' %}
-        {% include _includes/people.html username=username user=user ols-roles=ols-roles%}
+        {% include _includes/people.html username=username user=user ols-roles=ols-roles %}
     {% endfor %}
 </div>

--- a/_layouts/people.html
+++ b/_layouts/people.html
@@ -244,126 +244,126 @@ we ask that you follow our <a href="/code-of-conduct">code of conduct</a> in all
         {% if ols-1-people contains username %}
             {% assign roles = '' %}
             {% if ols-1-participants contains username %}
-                {% capture roles %}{{ roles }}, OLS-1 project lead{% endcapture %}
+                {% capture roles %}{{ roles }}, project lead{% endcapture %}
             {% endif %}
             {% if ols-1-mentors contains username %}
-                {% capture roles %}{{ roles }}, OLS-1 mentor{% endcapture %}
+                {% capture roles %}{{ roles }}, mentor{% endcapture %}
             {% endif %}
             {% if ols-1-experts contains username %}
-                {% capture roles %}{{ roles }}, OLS-1 expert{% endcapture %}
+                {% capture roles %}{{ roles }}, expert{% endcapture %}
             {% endif %}
             {% if ols-1-speakers contains username %}
-                {% capture roles %}{{ roles }},OLS-1 speaker{% endcapture %}
+                {% capture roles %}{{ roles }}, speaker{% endcapture %}
             {% endif %}
             {% if ols-1-organizers contains username %}
-                {% capture roles %}{{ roles }}, OLS-1 organizer{% endcapture %}
+                {% capture roles %}{{ roles }}, organizer{% endcapture %}
             {% endif %}
             {% capture ols-roles %}{{ ols-roles }} / OLS-1 {{ roles | remove_first: ', ' }}{% endcapture %}
         {% endif %}
         {% if ols-2-people contains username %}
             {% assign roles = '' %}
             {% if ols-2-participants contains username %}
-                {% capture roles %}{{ roles }}, OLS-2 project lead{% endcapture %}
+                {% capture roles %}{{ roles }}, project lead{% endcapture %}
             {% endif %}
             {% if ols-2-mentors contains username %}
-                {% capture roles %}{{ roles }}, OLS-2 mentor{% endcapture %}
+                {% capture roles %}{{ roles }}, mentor{% endcapture %}
             {% endif %}
             {% if ols-2-experts contains username %}
-                {% capture roles %}{{ roles }}, OLS-2 expert{% endcapture %}
+                {% capture roles %}{{ roles }}, expert{% endcapture %}
             {% endif %}
             {% if ols-2-speakers contains username %}
-                {% capture roles %}{{ roles }}, OLS-2 speaker{% endcapture %}
+                {% capture roles %}{{ roles }}, speaker{% endcapture %}
             {% endif %}
             {% if ols-2-organizers contains username %}
-                {% capture roles %}{{ roles }}, OLS-2 organizer{% endcapture %}
+                {% capture roles %}{{ roles }}, organizer{% endcapture %}
             {% endif %}
             {% capture ols-roles %}{{ ols-roles }} / OLS-2 {{ roles | remove_first: ', ' }}{% endcapture %}
         {% endif %}
         {% if ols-3-people contains username %}
             {% assign roles = '' %}
             {% if ols-3-participants contains username %}
-                {% capture roles %}{{ roles }}, OLS-3 project lead{% endcapture %}
+                {% capture roles %}{{ roles }}, project lead{% endcapture %}
             {% endif %}
             {% if ols-3-mentors contains username %}
-                {% capture roles %}{{ roles }}, OLS-3 mentor{% endcapture %}
+                {% capture roles %}{{ roles }}, mentor{% endcapture %}
             {% endif %}
             {% if ols-3-experts contains username %}
-                {% capture roles %}{{ roles }}, OLS-3 expert{% endcapture %}
+                {% capture roles %}{{ roles }}, expert{% endcapture %}
             {% endif %}
             {% if ols-3-speakers contains username %}
-                {% capture roles %}{{ roles }}, OLS-3 speaker{% endcapture %}
+                {% capture roles %}{{ roles }}, speaker{% endcapture %}
             {% endif %}
             {% if ols-3-facilitators contains username %}
-                {% capture roles %}{{ roles }}, OLS-3 facilitator{% endcapture %}
+                {% capture roles %}{{ roles }}, facilitator{% endcapture %}
             {% endif %}
             {% if ols-3-organizers contains username %}
-                {% capture roles %}{{ roles }}, OLS-3 organizer{% endcapture %}
+                {% capture roles %}{{ roles }}, organizer{% endcapture %}
             {% endif %}
             {% capture ols-roles %}{{ ols-roles }} / OLS-3 {{ roles | remove_first: ', ' }}{% endcapture %}
         {% endif %}
         {% if ols-4-people contains username %}
             {% assign roles = '' %}
             {% if ols-4-participants contains username %}
-                {% capture roles %}{{ roles }}, OLS-4 project lead{% endcapture %}
+                {% capture roles %}{{ roles }}, project lead{% endcapture %}
             {% endif %}
             {% if ols-4-mentors contains username %}
-                {% capture roles %}{{ roles }}, OLS-4 mentor{% endcapture %}
+                {% capture roles %}{{ roles }}, mentor{% endcapture %}
             {% endif %}
             {% if ols-4-experts contains username %}
-                {% capture roles %}{{ roles }}, OLS-4 expert{% endcapture %}
+                {% capture roles %}{{ roles }}, expert{% endcapture %}
             {% endif %}
             {% if ols-4-speakers contains username %}
-                {% capture roles %}{{ roles }}, OLS-4 speaker{% endcapture %}
+                {% capture roles %}{{ roles }}, speaker{% endcapture %}
             {% endif %}
             {% if ols-4-facilitators contains username %}
-                {% capture roles %}{{ roles }}, OLS-4 facilitator{% endcapture %}
+                {% capture roles %}{{ roles }}, facilitator{% endcapture %}
             {% endif %}
             {% if ols-4-organizers contains username %}
-                {% capture roles %}{{ roles }}, OLS-4 organizer{% endcapture %}
+                {% capture roles %}{{ roles }}, organizer{% endcapture %}
             {% endif %}
             {% capture ols-roles %}{{ ols-roles }} / OLS-4 {{ roles | remove_first: ', ' }}{% endcapture %}
         {% endif %}
         {% if ols-5-people contains username %}
             {% assign roles = '' %}
             {% if ols-5-participants contains username %}
-                {% capture roles %}{{ roles }}, OLS-5 project lead{% endcapture %}
+                {% capture roles %}{{ roles }}, project lead{% endcapture %}
             {% endif %}
             {% if ols-5-mentors contains username %}
-                {% capture roles %}{{ roles }}, OLS-5 mentor{% endcapture %}
+                {% capture roles %}{{ roles }}, mentor{% endcapture %}
             {% endif %}
             {% if ols-5-experts contains username %}
-                {% capture roles %}{{ roles }}, OLS-5 expert{% endcapture %}
+                {% capture roles %}{{ roles }}, expert{% endcapture %}
             {% endif %}
             {% if ols-5-speakers contains username %}
-                {% capture roles %}{{ roles }}, OLS-5 speaker{% endcapture %}
+                {% capture roles %}{{ roles }}, speaker{% endcapture %}
             {% endif %}
             {% if ols-5-facilitators contains username %}
-                {% capture roles %}{{ roles }}, OLS-5 facilitator{% endcapture %}
+                {% capture roles %}{{ roles }}, facilitator{% endcapture %}
             {% endif %}
             {% if ols-5-organizers contains username %}
-                {% capture roles %}{{ roles }}, OLS-5 organizer{% endcapture %}
+                {% capture roles %}{{ roles }}, organizer{% endcapture %}
             {% endif %}
             {% capture ols-roles %}{{ ols-roles }} / OLS-5 {{ roles | remove_first: ', ' }}{% endcapture %}
         {% endif %}
         {% if ols-6-people contains username %}
             {% assign roles = '' %}
             {% if ols-6-participants contains username %}
-                {% capture roles %}{{ roles }}, OLS-6 project lead{% endcapture %}
+                {% capture roles %}{{ roles }}, project lead{% endcapture %}
             {% endif %}
             {% if ols-6-mentors contains username %}
-                {% capture roles %}{{ roles }}, OLS-6 mentor{% endcapture %}
+                {% capture roles %}{{ roles }}, mentor{% endcapture %}
             {% endif %}
             {% if ols-6-experts contains username %}
-                {% capture roles %}{{ roles }}, OLS-6 expert{% endcapture %}
+                {% capture roles %}{{ roles }}, expert{% endcapture %}
             {% endif %}
             {% if ols-6-speakers contains username %}
-                {% capture roles %}{{ roles }}, OLS-6 speaker{% endcapture %}
+                {% capture roles %}{{ roles }}, speaker{% endcapture %}
             {% endif %}
             {% if ols-6-facilitators contains username %}
-                {% capture roles %}{{ roles }}, OLS-6 facilitator{% endcapture %}
+                {% capture roles %}{{ roles }}, facilitator{% endcapture %}
             {% endif %}
             {% if ols-6-organizers contains username %}
-                {% capture roles %}{{ roles }}, OLS-6 organizer{% endcapture %}
+                {% capture roles %}{{ roles }}, organizer{% endcapture %}
             {% endif %}
             {% capture ols-roles %}{{ ols-roles }} / OLS-6 {{ roles | remove_first: ', ' }}{% endcapture %}
         {% endif %}

--- a/_layouts/people.html
+++ b/_layouts/people.html
@@ -54,9 +54,9 @@ we ask that you follow our <a href="/code-of-conduct">code of conduct</a> in all
 <!-- extract experts and organizers -->
 {% assign ols-1-experts = site.data.ols-1-metadata.experts | join: ' ' %}
 {% assign ols-1-organizers = site.data.ols-1-metadata.organizers | join: ' ' %}
-<!-- extract speakers and call facilitators -->
+<!-- extract speakers -->
 {% assign ols-1-speakers = '' %}
-{% assign ols-1-facilitators = '' %}
+{% assign ols-1-hosts = '' %}
 {% for w in site.data.ols-1-schedule %}
     {% for c in w[1].calls %}
         {% if c.type == 'Cohort' %}
@@ -66,15 +66,10 @@ we ask that you follow our <a href="/code-of-conduct">code of conduct</a> in all
                 {% endif %}
             {% endfor %}
         {% endif %}
-        {% if c.facilitators %}
-            {% for h in c.facilitators %}
-                {% capture ols-1-facilitators %}{{ ols-1-facilitators}} {{ h }}{% endcapture %}
-            {% endfor %}
-        {% endif %}
     {% endfor %}
 {% endfor %}
 <!-- combine all -->
-{% capture ols-1-people %}{{ ols-1-participants }} {{ ols-1-experts }} {{ ols-1-mentors }} {{ ols-1-organizers }} {{ ols-1-speakers }} {{ ols-1-facilitators }}{% endcapture %}
+{% capture ols-1-people %}{{ ols-1-participants }} {{ ols-1-experts }} {{ ols-1-mentors }} {{ ols-1-organizers }} {{ ols-1-speakers }}{% endcapture %}
 
 <!-- OLS-2 -->
 <!-- extract participants and mentors -->
@@ -92,9 +87,9 @@ we ask that you follow our <a href="/code-of-conduct">code of conduct</a> in all
 <!-- extract experts and organizers -->
 {% assign ols-2-experts = site.data.ols-2-metadata.experts %}
 {% assign ols-2-organizers = site.data.ols-2-metadata.organizers %}
-<!-- extract speakers and call facilitators -->
+<!-- extract speakers -->
 {% assign ols-2-speakers = '' %}
-{% assign ols-2-facilitators = '' %}
+{% assign ols-2-hosts = '' %}
 {% for w in site.data.ols-2-schedule %}
     {% for c in w[1].calls %}
         {% if c.type == 'Cohort' %}
@@ -104,15 +99,10 @@ we ask that you follow our <a href="/code-of-conduct">code of conduct</a> in all
                 {% endif %}
             {% endfor %}
         {% endif %}
-        {% if c.facilitators %}
-            {% for h in c.facilitators %}
-                {% capture ols-2-facilitators %}{{ ols-2-facilitators}} {{ h }}{% endcapture %}
-            {% endfor %}
-        {% endif %}
     {% endfor %}
 {% endfor %}
 <!-- combine all -->
-{% capture ols-2-people %}{{ ols-2-participants }} {{ ols-2-experts }} {{ ols-2-mentors }} {{ ols-2-organizers }} {{ ols-2-speakers }} {{ ols-2-facilitators }}{% endcapture %}
+{% capture ols-2-people %}{{ ols-2-participants }} {{ ols-2-experts }} {{ ols-2-mentors }} {{ ols-2-organizers }} {{ ols-2-speakers }}{% endcapture %}
 
 <!-- OLS-3 -->
 <!-- extract participants and mentors -->
@@ -285,9 +275,6 @@ we ask that you follow our <a href="/code-of-conduct">code of conduct</a> in all
             {% if ols-1-speakers contains username %}
                 {% capture roles %}{{ roles }},OLS-1 speaker{% endcapture %}
             {% endif %}
-            {% if ols-1-facilitators contains username %}
-                {% capture roles %}{{ roles }}, OLS-1 facilitator{% endcapture %}
-            {% endif %}
             {% if ols-1-organizers contains username %}
                 {% capture roles %}{{ roles }}, OLS-1 organizer{% endcapture %}
             {% endif %}
@@ -306,9 +293,6 @@ we ask that you follow our <a href="/code-of-conduct">code of conduct</a> in all
             {% endif %}
             {% if ols-2-speakers contains username %}
                 {% capture roles %}{{ roles }}, OLS-2 speaker{% endcapture %}
-            {% endif %}
-            {% if ols-2-facilitators contains username %}
-                {% capture roles %}{{ roles }}, OLS-2 facilitator{% endcapture %}
             {% endif %}
             {% if ols-2-organizers contains username %}
                 {% capture roles %}{{ roles }}, OLS-2 organizer{% endcapture %}


### PR DESCRIPTION
This PR fixes, in part, issue #418.
The role of each member is now being displayed on their cards, as desired.

![Screenshot (330)](https://user-images.githubusercontent.com/105166953/197894659-97d89827-466a-44af-a0d1-106daf10c93f.png)

Please review these changes. Thank you!