### PR TITLE
Resolve members with double profiles

### DIFF
--- a/_data/ols-3-metadata.yaml
+++ b/_data/ols-3-metadata.yaml
@@ -7,7 +7,7 @@
 experts:
 - adam-gristwood
 - aidanbudd
-- alexandra-holinski
+- alexholinski
 - alexwlchan
 - anenadic
 - annakrystalli

--- a/_data/ols-3-projects.yaml
+++ b/_data/ols-3-projects.yaml
@@ -272,7 +272,7 @@
     - yochannah
   name: Global Distribution of APOL1 Genetic variants
   participants:
-    - john-ogunsola
+    - dadditolu
 - description:
     "LA-CoNGA physics is an Erasmus+ project, an European-Latinamerican\
     \ network of 11 universities, 9 research institutions and 3 industrial partners\

--- a/_data/ols-3-projects.yaml
+++ b/_data/ols-3-projects.yaml
@@ -896,7 +896,7 @@
     - malvikasharan
   name: The Turing Way - Developing a community health report and assessing its impact on the wider data science community
   participants:
-    - ali-humayun
+    - alihumayun
 - description:
     "I have just started a new role as a Research Application Manager at\
     \ the Turing Institute. My responsibility is to define my own workplan as well\

--- a/_data/ols-3-projects.yaml
+++ b/_data/ols-3-projects.yaml
@@ -499,7 +499,7 @@
   name: Towards FAIRer phytolith data
   participants:
     - javier-ruiz-pérez
-    - juan-josé-garcía-granero
+    - juanjo-garcía-granero
     - cl379
     - marco-madella
   status: graduated

--- a/_data/ols-3-projects.yaml
+++ b/_data/ols-3-projects.yaml
@@ -386,7 +386,7 @@
     - tobyhodges
   name: "MBiO: Designing an open-collaborative website in the field of molecular biology"
   participants:
-    - nihan-sultan-milat
+    - nihansultan
   status: graduated
 - description:
     OLS is a great platform to open life science with the objective of

--- a/_data/ols-4-metadata.yaml
+++ b/_data/ols-4-metadata.yaml
@@ -6,7 +6,7 @@
 ---
 experts:
 - ajstewartlang
-- alexandra-holinski
+- alexholinski
 - alexwlchan
 - anayan321
 - annefou

--- a/_data/ols-4-projects.yaml
+++ b/_data/ols-4-projects.yaml
@@ -190,7 +190,7 @@
     - interview
   mentors:
     - cemonks
-    - alexandra-holinski
+    - alexholinski
   name:
     "Generic data stewards in the Netherlands: who they are, what they do, and
     who they could become"

--- a/_data/ols-4-projects.yaml
+++ b/_data/ols-4-projects.yaml
@@ -596,7 +596,7 @@
     - bduckles
   name: Building Open Science and Data Analysis Skills by Leading the OLS Survey Data Project
   participants:
-    - burce-elbasan
+    - burceelbasan
   status: graduated
 - description:
     Binderhub is a service that allows users to share reproducible interactive

--- a/_data/ols-4-projects.yaml
+++ b/_data/ols-4-projects.yaml
@@ -621,7 +621,7 @@
     - unode
   name: "Hub23: An open source community and infrastructure for Turing's BinderHub"
   participants:
-    - lydia-france
+    - lydiafrance
     - lukehare
     - callummole
 - description:

--- a/_data/ols-6-projects.yaml
+++ b/_data/ols-6-projects.yaml
@@ -228,7 +228,7 @@
   - health outcomes
   mentors:
   - lisanna
-  - john-ogunsola
+  - dadditolu
   name: Developing effective online communities to build tools for genomic equity
   participants:
   - marie-nugent

--- a/_data/people.yaml
+++ b/_data/people.yaml
@@ -361,7 +361,6 @@ alihumayun:
   - Legal
   - Diversity issues
   first-name: Ali
-  github: false
   last-name: Humayun
   pronouns: He/Him
 aliaslaurel:

--- a/_data/people.yaml
+++ b/_data/people.yaml
@@ -5674,7 +5674,7 @@ shmuhammad2004:
   - Machine learning
   - R
   first-name: Shamsuddeen
-  last-name: Muhamamd
+  last-name: Muhammad
   orcid: 0000-0001-7708-0799
   pronouns: He/Him
   twitter: shmuhammadd

--- a/_data/people.yaml
+++ b/_data/people.yaml
@@ -3124,6 +3124,7 @@ juanjo-garcía-granero:
   expertise:
   - Archaeology
   first-name: Juan José
+  github: false
   last-name: García-Granero
   orcid: 0000-0002-7546-2176
   pronouns: He/him/his

--- a/_data/people.yaml
+++ b/_data/people.yaml
@@ -1522,14 +1522,23 @@ da5nsy:
   twitter: da5nsy
   website: https://dannygarside.co.uk
 dadditolu:
-  bio: I am a scientist interested in host-parasite interactions who loves to learn
-    and help
+  affiliation: Institute Of Biodiversity, Animal Health & Comparative Medicine, University
+    Of Glasgow
+  bio: I am a budding scientist, interested in host-parasite interactions. I am open to 
+  continuous learning, and passionate about improving the health of man and animals.
+  city: Glasgow
+  country: United Kingdom
   expertise:
   - Genomics
   - Renal pathology
   - Trypanosome biology
+  - Biological sciences
+  - Trypanosomiasis
+  - Veterinary pathology
   first-name: John
   last-name: Ogunsola
+  pronouns: he/him
+  twitter: JohnOgunsola
 danae-carelis-davila-espinoza:
   bio: "Medical student\nAssociate editor of the Journal of the scientific society\
     \ of medical students of the Universidad Mayor de San Simón \"Revista Científica\
@@ -2841,7 +2850,7 @@ jesperdramsch:
   first-name: Jesper
   last-name: Dramsch
   orcid: 0000-0001-8273-905X
-  pronouns: they
+  pronouns: they/them
   twitter: jesperdramsch
   website: https://dramsch.net
 jessica-sims:
@@ -3024,22 +3033,6 @@ johav:
   orcid: 0000-0002-6157-1494
   twitter: openscicomm
   website: https://access2perspectives.com
-john-ogunsola:
-  affiliation: Institute Of Biodiversity, Animal Health & Comparative Medicine, University
-    Of Glasgow
-  bio: John is a budding scientist, open to continuously learning, and passionate
-    about improving the health of man and animals.
-  city: Glasgow
-  country: United Kingdom
-  expertise:
-  - Biological sciences
-  - Trypanosomiasis
-  - Veterinary pathology
-  first-name: John
-  github: false
-  last-name: Ogunsola
-  pronouns: he/him
-  twitter: JohnOgunsola
 jonny-heath:
   bio: I am a poet and performance artist. One of my main practices is 'empathic literature',
     in which a conversation with an individual leads to my creating a unique piece

--- a/_data/people.yaml
+++ b/_data/people.yaml
@@ -314,7 +314,7 @@ aleesteele:
   pronouns: she/her
   twitter: aleesteele
   website: https://www.aleesteele.com
-alexandra-holinski:
+alexholinski:
   affiliation: EMBL-EBI
   bio: I am working as a Scientific Training Officer at EMBL-EBI and dedicate my work
     time to developing and designing training in the field of biomedical sciences
@@ -339,9 +339,6 @@ alexandra-holinski:
   last-name: Holinski
   orcid: 0000-0003-2321-5568
   pronouns: She/her
-alexholinski:
-  first-name: Alexandra
-  last-name: Holinski
 alexwlchan:
   affiliation: Wellcome Collection
   country: United Kingdom
@@ -350,13 +347,19 @@ alexwlchan:
   pronouns: they/she
   twitter: alexwlchan
   website: https://alexwlchan.net
-ali-humayun:
+alihumayun:
   bio: I am 23 years old and currently working at a sports media company as an editor.
-    I graduated in October 2020 from UCL in MSc Digital Humanities and have a previous
-    background in history. I am extremely interested in the intersection between technology,
-    the law and society. Also, I'm very keen to help address educational inequity
-    as well as learning more about community building.
+    I graduated in October 2020 from UCL in MSc Digital Humanities, with a year of experience
+    in journalism. I also have a previous background in history, and I am about to embark on a
+    postgraduate diploma in law, with hopes of pursuing a career at the intersection of law and
+    technology. Also, I'm very keen to help address educational inequity as well as learning more
+    about community building and the open science community!
   city: London
+  country: United Kingdom
+  expertise:
+  - Editing
+  - Legal
+  - Diversity issues
   first-name: Ali
   github: false
   last-name: Humayun
@@ -378,20 +381,6 @@ aliaslaurel:
   pronouns: She/her/ella
   twitter: lauradaiana
   website: https://www.metadocencia.org/en/authors/laurel/
-alihumayun:
-  bio: I am 23 years old and have completed a Masters in Digital Humanities as well
-    as a year of experience in journalism. I am about to embark on a postgraduate
-    diploma in law and hope to pursue a career at the intersection of law and technology.
-    I am also very keen to learn more about the open science community!
-  city: London
-  country: United Kingdom
-  expertise:
-  - Editing
-  - Legal
-  - Diversity issues
-  first-name: Ali
-  last-name: Humayun
-  pronouns: He/Him
 amangoel185:
   affiliation: University Of Delhi
   bio: I'm a recent Computer Science and Maths graduate from the University of Delhi

--- a/_data/people.yaml
+++ b/_data/people.yaml
@@ -3123,7 +3123,7 @@ juanjo-garcía-granero:
   country: Spain
   expertise:
   - Archaeology
-  first-name: Juanjo
+  first-name: Juan José
   last-name: García-Granero
   orcid: 0000-0002-7546-2176
   pronouns: He/him/his

--- a/_data/people.yaml
+++ b/_data/people.yaml
@@ -3763,7 +3763,7 @@ lydiafrance:
     mostly working with hawks and eagles! I recently joined the Alan Turing Institute
     as a research data scientist, working on lots of projects. I have great interest in
     education and awareness of reproducibility in science and research, especially for
-    life scientists. I am a self taught programmer and have been involved with Software
+    life scientists. I'm a self taught programmer and have been involved with Software
     Carpentries and The Turing Way.
   city: London
   country: United Kingdom
@@ -3911,13 +3911,6 @@ marco-madella:
   pronouns: he/his
   twitter: m4bcn
   website: https://www.upf.edu/web/cases
-margaret-wanjiku:
-  city: Nairobi
-  country: Kenya
-  first-name: Margaret
-  github: false
-  last-name: Wanjiku
-  twitter: meg_wanjiku
 maria-andrea-gonzales-castillo:
   bio: Maria Andrea Gonzales is a 4th year Bioengineering undergraduate in UTEC (Lima,
     Peru). She is currently working in a variety of biotechnology research projects

--- a/_data/people.yaml
+++ b/_data/people.yaml
@@ -4674,7 +4674,7 @@ nickynicolson:
   last-name: Nicolson
   orcid: 0000-0003-3700-4884
   twitter: nickynicolson
-nihan-sultan-milat:
+nihansultan:
   affiliation: Bezmialem Vakif University, Beykoz Institute Of Life Science And Biotechnology
   bio: I am trying to be a good molecular biologist. I think that learning new things
     and sharing them in this field is great.
@@ -4684,16 +4684,6 @@ nihan-sultan-milat:
   - Life Sciences
   - Molecular biology
   - Developmental Genetics
-  first-name: Nihan Sultan
-  github: false
-  last-name: Milat
-  twitter: MilatNihan
-nihansultan:
-  affiliation: Bezmialem Vakıf University
-  city: İstanbul
-  country: Turkey
-  expertise:
-  - Molecular biology
   first-name: Nihan Sultan
   last-name: Milat
   twitter: MilatNihan

--- a/_data/people.yaml
+++ b/_data/people.yaml
@@ -437,7 +437,7 @@ andreasancheztapia:
     (ENBT-JBRJ, Brazil). I am a member of RLadies and the Carpentries, and one of
     the leads for translation and localisation of The Turing Way.
   city: Merced, Ca
-  country: United States
+  country: United Statesa
   expertise:
   - Biodiversity informatics
   - Plant community ecology
@@ -3757,28 +3757,14 @@ lwinfree:
   pronouns: she/her
   twitter: lilscientista
   website: https://lwinfree.github.io/
-lydia-france:
-  affiliation: The Alan Turing Institute
-  bio: I have a PhD in bird flight aerodynamics, mostly working with hawks and eagles!
-    Now I'm working on lots of projects at The Alan Turing Institute, and feel very
-    strongly about teaching reproducible data science especially for life scientists.
-  city: London
-  country: United Kingdom
-  expertise:
-  - Biology
-  - Zoology
-  - Data science
-  first-name: Lydia
-  github: false
-  last-name: France
-  orcid: 0000-0003-4392-568X
 lydiafrance:
-  affiliation: Alan Turing Institute
-  bio: I'm Lydia, my background is in Zoology and the aerodynamics/control of bird
-    flight. I recently joined the Alan Turing Institute as a research data scientist
-    and have great interest in education and awareness of reproducibility in science
-    and research. I'm a self taught programmer and have been involved with Software
-    Carpentries and The Turing Way
+  affiliation: The Alan Turing Institute
+  bio: My background is in Zoology and I have a PhD in bird flight aerodynamics,
+    mostly working with hawks and eagles! I recently joined the Alan Turing Institute
+    as a research data scientist, working on lots of projects. I have great interest in
+    education and awareness of reproducibility in science and research, especially for
+    life scientists. I am a self taught programmer and have been involved with Software
+    Carpentries and The Turing Way.
   city: London
   country: United Kingdom
   expertise:
@@ -3787,9 +3773,10 @@ lydiafrance:
   - Binder
   - Biology
   - Zoology
+  - Data science
   first-name: Lydia
   last-name: France
-  orcid: ' 0000-0003-4392-568X'
+  orcid: 0000-0003-4392-568X 
 macelik:
   affiliation: Bezmialem Vakif University
   bio: He is a PhD student and his general interest lies in developing and applying

--- a/_data/people.yaml
+++ b/_data/people.yaml
@@ -1524,7 +1524,7 @@ dadditolu:
   affiliation: Institute Of Biodiversity, Animal Health & Comparative Medicine, University
     Of Glasgow
   bio: I am a budding scientist, interested in host-parasite interactions. I am open to 
-  continuous learning, and passionate about improving the health of man and animals.
+    continuous learning, and passionate about improving the health of man and animals.
   city: Glasgow
   country: United Kingdom
   expertise:

--- a/_data/people.yaml
+++ b/_data/people.yaml
@@ -437,7 +437,7 @@ andreasancheztapia:
     (ENBT-JBRJ, Brazil). I am a member of RLadies and the Carpentries, and one of
     the leads for translation and localisation of The Turing Way.
   city: Merced, Ca
-  country: United Statesa
+  country: United States
   expertise:
   - Biodiversity informatics
   - Plant community ecology

--- a/_data/people.yaml
+++ b/_data/people.yaml
@@ -3114,7 +3114,7 @@ jsheunis:
   pronouns: he/him
   twitter: fmrwhy
   website: https://jsheunis.github.io/
-juan-josé-garcía-granero:
+juanjo-garcía-granero:
   affiliation: Spanish National Research Council
   bio: I am an archaeobotanist interested in how late prehistoric societies interacted
     with their environment in terms of plant food acquisition and transformation practices,
@@ -3123,19 +3123,10 @@ juan-josé-garcía-granero:
   country: Spain
   expertise:
   - Archaeology
-  first-name: Juan José
-  github: false
-  last-name: García-Granero
-  orcid: 0000-0002-7546-2176
-  pronouns: He/him/his
-juanjo-garcía-granero:
-  affiliation: Spanish National Research Council
-  city: Barcelona
-  country: Spain
   first-name: Juanjo
   last-name: García-Granero
   orcid: 0000-0002-7546-2176
-  pronouns: he/his
+  pronouns: He/him/his
 jvillcavillegas:
   affiliation: Universidad Mayor De San Simon
   bio: Proactive, Courageous, Positive

--- a/_data/people.yaml
+++ b/_data/people.yaml
@@ -1151,17 +1151,12 @@ bruno-soares:
   pronouns: He/Him
   twitter: Bruno_E_Soares
   website: https://sites.google.com/view/bruno-eleres-soares
-burce-elbasan:
-  expertise:
-  - Cancer biology
-  - Brain tumors
-  first-name: Burce
-  github: false
-  last-name: Elbasan
 burceelbasan:
   affiliation: University Ulm
   country: Germany
   expertise:
+  - Cancer biology
+  - Brain tumors
   - Molecular genetics
   - Molecular mechanisms of cancer pathogenesis
   first-name: Burce

--- a/_data/people.yaml
+++ b/_data/people.yaml
@@ -2245,10 +2245,10 @@ gabimusaubach:
     ceramic residues and sediments in pre-Hispanic sites in Argentina.
   country: Argentina
   expertise:
-  - '"phytolith analysis"'
-  - '" pre-hispanic archaeology"'
-  - '"archaeobotany"'
-  - '"ancient starch analysis"'
+  - Phytolith analysis
+  - Pre-hispanic archaeology
+  - Archaeobotany
+  - Ancient starch analysis
   first-name: Maria Gabriela
   last-name: Musaubach
   orcid: 0000-0002-6770-7145


### PR DESCRIPTION
This PR fixes issue #504.
I merged the information about people with double profiles.

In addition, I noticed and corrected:
- an error in a member's **`expertise`** section.
- an omission of pronoun.
- a typo in `country` section.

![Screenshot (344)](https://user-images.githubusercontent.com/105166953/198346776-2940371b-ab73-4913-a927-2bf3973eb4d2.png)
![Screenshot (345)](https://user-images.githubusercontent.com/105166953/198346797-29b174a8-ee35-4770-ad00-adf015df82f8.png)
