### PR TITLE
Embed YouTube videos of cohort calls

### DIFF
--- a/_data/ols-1-schedule.yaml
+++ b/_data/ols-1-schedule.yaml
@@ -9,7 +9,7 @@
 #       duration: .. min
 #       title:
 #       date: Month Day, Year
-#       time: '14:00'
+#       time: '13:00'
 #       calendar-event: link to calendar event
 #       agenda: tldr
 #       notes: link to notes
@@ -88,7 +88,7 @@ weeks:
         duration: 60 min
         title: Mentor training
         date: January 17, 2020
-        time: '17:00'
+        time: '16:00'
         content: |
           During our first cohort call, you will:
           - Understand common successes and challenges in mentoring OLS participants.
@@ -98,7 +98,7 @@ weeks:
         duration: 60 min
         title: Mentor training
         date: January 20, 2020
-        time: '12:00'
+        time: '11:00'
         content: |
           During our first cohort call, you will:
           - Understand common successes and challenges in mentoring OLS participants.
@@ -111,7 +111,7 @@ weeks:
         duration: 90 min
         title: Welcome to Open Life Science!
         date: January 29, 2020
-        time: '14:00'
+        time: '13:00'
         calendar-event: https://calendar.google.com/event?action=TEMPLATE&tmeid=NmIzdWlmZTR2cG9uaXU5a2IxcGVvMm5icG8gbjNycWh2dWZmMDVvamtsMG9wZnN2aDQ5ZmtAZw&tmsrc=n3rqhvuff05ojkl0opfsvh49fk%40group.calendar.google.com
         agenda: Meet other members of your cohort, Share project vision, Intro to working openly (open canvas)
         notes: https://docs.google.com/document/d/1q9HnEKKX2y50JiovpTDaOziFI0iDmPGYxvelUXuES90/edit?usp=sharing
@@ -192,7 +192,7 @@ weeks:
         duration: 90 min
         title: Tooling and roadmapping for Open projects
         date: February 12, 2020
-        time: '19:00'
+        time: '18:00'
         calendar-event: https://calendar.google.com/event?action=TEMPLATE&tmeid=MTFnaW44c2RyYWprMGF0ZnFjdmxjcG82YTQgbjNycWh2dWZmMDVvamtsMG9wZnN2aDQ5ZmtAZw&tmsrc=n3rqhvuff05ojkl0opfsvh49fk%40group.calendar.google.com
         agenda: 'Working with GitHub as a community hub: Markdown as a tool to make websites, Licence, Goals and Roadmap, Contributors, Code of Conduct'
         notes: https://docs.google.com/document/d/1KmXb7Vf-J7J8YolTEhc-YFrDHfz6GfOS3LHxLTcrELs/edit?usp=sharing
@@ -256,7 +256,7 @@ weeks:
         duration: 90 min
         title: GitHub Tutorial
         date: February 19, 2020
-        time: '14:00'
+        time: '13:00'
         calendar-event: https://calendar.google.com/event?action=TEMPLATE&tmeid=MzEzaWltNDhrcThwZ3ZlOGdyZHAzMGRsNzEgbjNycWh2dWZmMDVvamtsMG9wZnN2aDQ5ZmtAZw&tmsrc=n3rqhvuff05ojkl0opfsvh49fk%40group.calendar.google.com
         notes: https://docs.google.com/document/d/1HeWcj5RuouvHjx2x-AgL92qEwhRosE_qRknaWmCBWM4/edit?usp=sharing
         recording: https://www.youtube.com/embed/QRUvQgKbVZQ
@@ -328,7 +328,7 @@ weeks:
         duration: 90 min
         title: 'Open Science I: Project Development'
         date: February 26, 2020
-        time: '14:00'
+        time: '13:00'
         calendar-event: https://calendar.google.com/event?action=TEMPLATE&tmeid=MHMyc3FzMmtxdDBtdWR1a2drcjdzMTFtdDkgbjNycWh2dWZmMDVvamtsMG9wZnN2aDQ5ZmtAZw&tmsrc=n3rqhvuff05ojkl0opfsvh49fk%40group.calendar.google.com
         agenda: 'Developing Open Projects: Open-Source, Software, Hardware, Data'
         notes: https://docs.google.com/document/d/1Nbu2XycI2q9kVg3YAY-LtWsGPYj63xlGLXEthCv_9SA/edit?usp=sharing
@@ -392,7 +392,7 @@ weeks:
         duration: 60 min
         title: Mentor training
         date: March 5, 2020
-        time: '20:30'
+        time: '19:30'
         content: |
           During our first cohort call, you will:
           - Share your experience been so far as a mentor in OLS-1
@@ -405,7 +405,7 @@ weeks:
         duration: 90 min
         title: 'Open Science II: Knowledge Dissemination'
         date: March 11, 2020
-        time: '19:00'
+        time: '18:00'
         calendar-event: https://calendar.google.com/event?action=TEMPLATE&tmeid=M3U0OGZjbGY1aTYxYW5ua3Z1YWYxbGV1cXQgbjNycWh2dWZmMDVvamtsMG9wZnN2aDQ5ZmtAZw&tmsrc=n3rqhvuff05ojkl0opfsvh49fk%40group.calendar.google.com
         agenda: 'Sharing Open Project: Preprint publications, DOI and citation, Open protocols, Open Education & Training'
         notes: https://docs.google.com/document/d/19o-BXGx6Q7Rc2-jlW76HRoi_onKmAidtIFWXvYVXqOA/edit?usp=sharing
@@ -487,7 +487,7 @@ weeks:
         duration: 90 min
         title: 'Designing & Empowering for inclusivity'
         date: March 25, 2020
-        time: '14:00'
+        time: '13:00'
         calendar-event: https://calendar.google.com/event?action=TEMPLATE&tmeid=MXA4Nm4wYXRqaG01ZmcwOHRzYjR1OWpqcTUgbjNycWh2dWZmMDVvamtsMG9wZnN2aDQ5ZmtAZw&tmsrc=n3rqhvuff05ojkl0opfsvh49fk%40group.calendar.google.com
         agenda: Personas and pathways for contributors, Implicit bias & mental health care, Community interactions & Ally-skill
         notes: https://docs.google.com/document/d/1YF3Uw-fU2-mhf-FyuPdx07KSTSlvnBZeMbQdQGJq4A4/edit?usp=sharing
@@ -561,7 +561,7 @@ weeks:
         duration: 90 min
         title: 'Mental health care, Ally skills and Career Guidance Call'
         date: April 1, 2020
-        time: '19:00'
+        time: '17:00'
         calendar-event: https://calendar.google.com/event?action=TEMPLATE&tmeid=MG1ra3N1cmlzM2ZobHVkOWo2YTc5cThodm8gbjNycWh2dWZmMDVvamtsMG9wZnN2aDQ5ZmtAZw&tmsrc=n3rqhvuff05ojkl0opfsvh49fk%40group.calendar.google.com
         notes: https://docs.google.com/document/d/1kKXcwsVRnM05W4ZWfGwnaTJlLXvqnP7JVCOpqcvo6vU/edit
         recording: https://www.youtube.com/embed/un4lsSMdAB0
@@ -631,7 +631,7 @@ weeks:
         duration: 90 min
         title: 'Open Agenda - Social Call'
         date: April 15, 2020
-        time: '14:00'
+        time: '12:00'
         calendar-event: https://calendar.google.com/event?action=TEMPLATE&tmeid=N2drNnZvbHRhY2ZxYjZhOTBlcWNqc29vYjAgbjNycWh2dWZmMDVvamtsMG9wZnN2aDQ5ZmtAZw&tmsrc=n3rqhvuff05ojkl0opfsvh49fk%40group.calendar.google.com
         notes: https://docs.google.com/document/d/1f2Y3SCB9OOuxdd5TDehOuynTXvWA6cc13lK5AovgEdI/edit?usp=sharing
         content: |
@@ -660,7 +660,7 @@ weeks:
         duration: 90 min
         title: 'Group 1 - Final presentation rehearsal'
         date: April 22, 2020
-        time: '19:00'
+        time: '17:00'
         calendar-event: https://calendar.google.com/event?action=TEMPLATE&tmeid=XzhjcTNhaGhwOG9wa2NiOW84Z29rNGI5azZzcjQyYmExODkwamViOW44bDFqMGNocDhjcjNhYzluODggYWd0cXA1Z2NyNXYycHBnNm5hZmtzMDlxbWNAZw&tmsrc=agtqp5gcr5v2ppg6nafks09qmc%40group.calendar.google.com
         agenda: Test of the final demos for the group 1
         notes: https://docs.google.com/document/d/1rM6Msvj2ReaUFkEy8CPKyXSAC3RY7xnamkttug0M6PM/edit?usp=sharing
@@ -699,7 +699,7 @@ weeks:
         duration: 90 min
         title: 'Group 1 - Final presentations & Graduation!'
         date: April 29, 2020
-        time: '19:00'
+        time: '17:00'
         calendar-event: https://calendar.google.com/event?action=TEMPLATE&tmeid=MnRsY291Y3U3ZmxuMDMxYmg3bnBnNTRtcTYgbjNycWh2dWZmMDVvamtsMG9wZnN2aDQ5ZmtAZw&tmsrc=n3rqhvuff05ojkl0opfsvh49fk%40group.calendar.google.com
         agenda: '5-minute demos of projects for group 1 (Audience: entire community & public, Open and recorded call)'
         notes: https://docs.google.com/document/d/1zfn5hLldbti-K4L244_4A6wGc80FymKTeixN8cWXq2Q/edit?usp=sharing
@@ -738,7 +738,7 @@ weeks:
         duration: 90 min
         title: 'Group 2 - Final presentation rehearsal'
         date: May 13, 2020
-        time: '19:00'
+        time: '17:00'
         calendar-event: https://calendar.google.com/event?action=TEMPLATE&tmeid=Xzg5MzNjY2E0ODkyazJiYTU4NHBqYWI5azcwbzQ2YjlwNzByajBiOW03MTJqOGMxbTZkMmo0Z2kxNm8gYWd0cXA1Z2NyNXYycHBnNm5hZmtzMDlxbWNAZw&tmsrc=agtqp5gcr5v2ppg6nafks09qmc%40group.calendar.google.com
         agenda: Test of the final demos for the group 2
         notes: https://docs.google.com/document/d/1PG3jXV1A9OjFR1EEZ0rNafbD-oJdp3R4rGL2VzPbAaA/edit?usp=sharing
@@ -777,7 +777,7 @@ weeks:
         duration: 90 min
         title: 'Group 2 - Final presentations & Graduation!'
         date: May 20, 2020
-        time: '19:00'
+        time: '17:00'
         calendar-event: https://calendar.google.com/event?action=TEMPLATE&tmeid=XzY5MGpjYzI1OGNvazJiYTM2NHBqNGI5azZjcTNpYmExODRvNDZiYTI4NTEzMGc5bTc0cmthaDI2NnMgYWd0cXA1Z2NyNXYycHBnNm5hZmtzMDlxbWNAZw&tmsrc=agtqp5gcr5v2ppg6nafks09qmc%40group.calendar.google.com
         agenda: '5-minute demos of projects for group 2 (Audience: entire community & public, Open and recorded call)'
         notes: https://docs.google.com/document/d/1idZpXvmqqRNYN1KfAbHKpeLToqIvlcm1SVc6ln-fRGA/edit?usp=sharing

--- a/_data/ols-1-schedule.yaml
+++ b/_data/ols-1-schedule.yaml
@@ -9,7 +9,7 @@
 #       duration: .. min
 #       title:
 #       date: Month Day, Year
-#       time: '13:00'
+#       time: '14:00'
 #       calendar-event: link to calendar event
 #       agenda: tldr
 #       notes: link to notes
@@ -88,7 +88,7 @@ weeks:
         duration: 60 min
         title: Mentor training
         date: January 17, 2020
-        time: '16:00'
+        time: '17:00'
         content: |
           During our first cohort call, you will:
           - Understand common successes and challenges in mentoring OLS participants.
@@ -98,7 +98,7 @@ weeks:
         duration: 60 min
         title: Mentor training
         date: January 20, 2020
-        time: '11:00'
+        time: '12:00'
         content: |
           During our first cohort call, you will:
           - Understand common successes and challenges in mentoring OLS participants.
@@ -111,11 +111,11 @@ weeks:
         duration: 90 min
         title: Welcome to Open Life Science!
         date: January 29, 2020
-        time: '13:00'
+        time: '14:00'
         calendar-event: https://calendar.google.com/event?action=TEMPLATE&tmeid=NmIzdWlmZTR2cG9uaXU5a2IxcGVvMm5icG8gbjNycWh2dWZmMDVvamtsMG9wZnN2aDQ5ZmtAZw&tmsrc=n3rqhvuff05ojkl0opfsvh49fk%40group.calendar.google.com
         agenda: Meet other members of your cohort, Share project vision, Intro to working openly (open canvas)
         notes: https://docs.google.com/document/d/1q9HnEKKX2y50JiovpTDaOziFI0iDmPGYxvelUXuES90/edit?usp=sharing
-        recording: https://youtu.be/3-cvl7UfSTY
+        recording: https://www.youtube.com/embed/3-cvl7UfSTY
         content: |
           During our first cohort call, we will:
           - Say hello and introduce ourselves.
@@ -192,11 +192,11 @@ weeks:
         duration: 90 min
         title: Tooling and roadmapping for Open projects
         date: February 12, 2020
-        time: '18:00'
+        time: '19:00'
         calendar-event: https://calendar.google.com/event?action=TEMPLATE&tmeid=MTFnaW44c2RyYWprMGF0ZnFjdmxjcG82YTQgbjNycWh2dWZmMDVvamtsMG9wZnN2aDQ5ZmtAZw&tmsrc=n3rqhvuff05ojkl0opfsvh49fk%40group.calendar.google.com
         agenda: 'Working with GitHub as a community hub: Markdown as a tool to make websites, Licence, Goals and Roadmap, Contributors, Code of Conduct'
         notes: https://docs.google.com/document/d/1KmXb7Vf-J7J8YolTEhc-YFrDHfz6GfOS3LHxLTcrELs/edit?usp=sharing
-        recording: https://www.youtube.com/watch?v=y9y8a3O4fjg
+        recording: https://www.youtube.com/embed/y9y8a3O4fjg
         content: |
           During this week's cohort call, we will:
           - Look at project structure as we build open projects
@@ -256,10 +256,10 @@ weeks:
         duration: 90 min
         title: GitHub Tutorial
         date: February 19, 2020
-        time: '13:00'
+        time: '14:00'
         calendar-event: https://calendar.google.com/event?action=TEMPLATE&tmeid=MzEzaWltNDhrcThwZ3ZlOGdyZHAzMGRsNzEgbjNycWh2dWZmMDVvamtsMG9wZnN2aDQ5ZmtAZw&tmsrc=n3rqhvuff05ojkl0opfsvh49fk%40group.calendar.google.com
         notes: https://docs.google.com/document/d/1HeWcj5RuouvHjx2x-AgL92qEwhRosE_qRknaWmCBWM4/edit?usp=sharing
-        recording: https://www.youtube.com/watch?v=QRUvQgKbVZQ
+        recording: https://www.youtube.com/embed/QRUvQgKbVZQ
         content: |
           During this week's cohort call, we will give you an optional 1 hour GitHub tutorial covering:
           - Creating a repository
@@ -328,11 +328,11 @@ weeks:
         duration: 90 min
         title: 'Open Science I: Project Development'
         date: February 26, 2020
-        time: '13:00'
+        time: '14:00'
         calendar-event: https://calendar.google.com/event?action=TEMPLATE&tmeid=MHMyc3FzMmtxdDBtdWR1a2drcjdzMTFtdDkgbjNycWh2dWZmMDVvamtsMG9wZnN2aDQ5ZmtAZw&tmsrc=n3rqhvuff05ojkl0opfsvh49fk%40group.calendar.google.com
         agenda: 'Developing Open Projects: Open-Source, Software, Hardware, Data'
         notes: https://docs.google.com/document/d/1Nbu2XycI2q9kVg3YAY-LtWsGPYj63xlGLXEthCv_9SA/edit?usp=sharing
-        recording: https://www.youtube.com/watch?v=hiLDGLfXa2s
+        recording: https://www.youtube.com/embed/hiLDGLfXa2s
         content: |
           During this week's cohort call, we will cover :
           - Agile and iterative project management methods
@@ -392,7 +392,7 @@ weeks:
         duration: 60 min
         title: Mentor training
         date: March 5, 2020
-        time: '19:30'
+        time: '20:30'
         content: |
           During our first cohort call, you will:
           - Share your experience been so far as a mentor in OLS-1
@@ -405,11 +405,11 @@ weeks:
         duration: 90 min
         title: 'Open Science II: Knowledge Dissemination'
         date: March 11, 2020
-        time: '18:00'
+        time: '19:00'
         calendar-event: https://calendar.google.com/event?action=TEMPLATE&tmeid=M3U0OGZjbGY1aTYxYW5ua3Z1YWYxbGV1cXQgbjNycWh2dWZmMDVvamtsMG9wZnN2aDQ5ZmtAZw&tmsrc=n3rqhvuff05ojkl0opfsvh49fk%40group.calendar.google.com
         agenda: 'Sharing Open Project: Preprint publications, DOI and citation, Open protocols, Open Education & Training'
         notes: https://docs.google.com/document/d/19o-BXGx6Q7Rc2-jlW76HRoi_onKmAidtIFWXvYVXqOA/edit?usp=sharing
-        recording: https://www.youtube.com/watch?v=HaQyv48sMPY&t=1s
+        recording: https://www.youtube.com/embed/HaQyv48sMPY
         content: |
           During this week's cohort call, we will discuss about Knowledge Dissemination with
           - Citizen Science (Open Humans)
@@ -487,11 +487,11 @@ weeks:
         duration: 90 min
         title: 'Designing & Empowering for inclusivity'
         date: March 25, 2020
-        time: '13:00'
+        time: '14:00'
         calendar-event: https://calendar.google.com/event?action=TEMPLATE&tmeid=MXA4Nm4wYXRqaG01ZmcwOHRzYjR1OWpqcTUgbjNycWh2dWZmMDVvamtsMG9wZnN2aDQ5ZmtAZw&tmsrc=n3rqhvuff05ojkl0opfsvh49fk%40group.calendar.google.com
         agenda: Personas and pathways for contributors, Implicit bias & mental health care, Community interactions & Ally-skill
         notes: https://docs.google.com/document/d/1YF3Uw-fU2-mhf-FyuPdx07KSTSlvnBZeMbQdQGJq4A4/edit?usp=sharing
-        recording: https://www.youtube.com/watch?v=81mG4L7S3Oc
+        recording: https://www.youtube.com/embed/81mG4L7S3Oc
         content: |
           During this week's cohort call, we will discuss about:
           - Designing for inclusion
@@ -561,10 +561,10 @@ weeks:
         duration: 90 min
         title: 'Mental health care, Ally skills and Career Guidance Call'
         date: April 1, 2020
-        time: '17:00'
+        time: '19:00'
         calendar-event: https://calendar.google.com/event?action=TEMPLATE&tmeid=MG1ra3N1cmlzM2ZobHVkOWo2YTc5cThodm8gbjNycWh2dWZmMDVvamtsMG9wZnN2aDQ5ZmtAZw&tmsrc=n3rqhvuff05ojkl0opfsvh49fk%40group.calendar.google.com
         notes: https://docs.google.com/document/d/1kKXcwsVRnM05W4ZWfGwnaTJlLXvqnP7JVCOpqcvo6vU/edit
-        recording: https://www.youtube.com/watch?v=un4lsSMdAB0
+        recording: https://www.youtube.com/embed/un4lsSMdAB0
         content: |
           During this week's cohort call, we will:
           - Discuss self-care plans and learn about Ally skills
@@ -631,7 +631,7 @@ weeks:
         duration: 90 min
         title: 'Open Agenda - Social Call'
         date: April 15, 2020
-        time: '12:00'
+        time: '14:00'
         calendar-event: https://calendar.google.com/event?action=TEMPLATE&tmeid=N2drNnZvbHRhY2ZxYjZhOTBlcWNqc29vYjAgbjNycWh2dWZmMDVvamtsMG9wZnN2aDQ5ZmtAZw&tmsrc=n3rqhvuff05ojkl0opfsvh49fk%40group.calendar.google.com
         notes: https://docs.google.com/document/d/1f2Y3SCB9OOuxdd5TDehOuynTXvWA6cc13lK5AovgEdI/edit?usp=sharing
         content: |
@@ -660,7 +660,7 @@ weeks:
         duration: 90 min
         title: 'Group 1 - Final presentation rehearsal'
         date: April 22, 2020
-        time: '17:00'
+        time: '19:00'
         calendar-event: https://calendar.google.com/event?action=TEMPLATE&tmeid=XzhjcTNhaGhwOG9wa2NiOW84Z29rNGI5azZzcjQyYmExODkwamViOW44bDFqMGNocDhjcjNhYzluODggYWd0cXA1Z2NyNXYycHBnNm5hZmtzMDlxbWNAZw&tmsrc=agtqp5gcr5v2ppg6nafks09qmc%40group.calendar.google.com
         agenda: Test of the final demos for the group 1
         notes: https://docs.google.com/document/d/1rM6Msvj2ReaUFkEy8CPKyXSAC3RY7xnamkttug0M6PM/edit?usp=sharing
@@ -699,7 +699,7 @@ weeks:
         duration: 90 min
         title: 'Group 1 - Final presentations & Graduation!'
         date: April 29, 2020
-        time: '17:00'
+        time: '19:00'
         calendar-event: https://calendar.google.com/event?action=TEMPLATE&tmeid=MnRsY291Y3U3ZmxuMDMxYmg3bnBnNTRtcTYgbjNycWh2dWZmMDVvamtsMG9wZnN2aDQ5ZmtAZw&tmsrc=n3rqhvuff05ojkl0opfsvh49fk%40group.calendar.google.com
         agenda: '5-minute demos of projects for group 1 (Audience: entire community & public, Open and recorded call)'
         notes: https://docs.google.com/document/d/1zfn5hLldbti-K4L244_4A6wGc80FymKTeixN8cWXq2Q/edit?usp=sharing
@@ -738,7 +738,7 @@ weeks:
         duration: 90 min
         title: 'Group 2 - Final presentation rehearsal'
         date: May 13, 2020
-        time: '17:00'
+        time: '19:00'
         calendar-event: https://calendar.google.com/event?action=TEMPLATE&tmeid=Xzg5MzNjY2E0ODkyazJiYTU4NHBqYWI5azcwbzQ2YjlwNzByajBiOW03MTJqOGMxbTZkMmo0Z2kxNm8gYWd0cXA1Z2NyNXYycHBnNm5hZmtzMDlxbWNAZw&tmsrc=agtqp5gcr5v2ppg6nafks09qmc%40group.calendar.google.com
         agenda: Test of the final demos for the group 2
         notes: https://docs.google.com/document/d/1PG3jXV1A9OjFR1EEZ0rNafbD-oJdp3R4rGL2VzPbAaA/edit?usp=sharing
@@ -777,7 +777,7 @@ weeks:
         duration: 90 min
         title: 'Group 2 - Final presentations & Graduation!'
         date: May 20, 2020
-        time: '17:00'
+        time: '19:00'
         calendar-event: https://calendar.google.com/event?action=TEMPLATE&tmeid=XzY5MGpjYzI1OGNvazJiYTM2NHBqNGI5azZjcTNpYmExODRvNDZiYTI4NTEzMGc5bTc0cmthaDI2NnMgYWd0cXA1Z2NyNXYycHBnNm5hZmtzMDlxbWNAZw&tmsrc=agtqp5gcr5v2ppg6nafks09qmc%40group.calendar.google.com
         agenda: '5-minute demos of projects for group 2 (Audience: entire community & public, Open and recorded call)'
         notes: https://docs.google.com/document/d/1idZpXvmqqRNYN1KfAbHKpeLToqIvlcm1SVc6ln-fRGA/edit?usp=sharing

--- a/_data/ols-2-schedule.yaml
+++ b/_data/ols-2-schedule.yaml
@@ -9,7 +9,7 @@
 #       duration: .. min
 #       title:
 #       date: Month Day, Year
-#       time: '14:00'
+#       time: '13:00'
 #       calendar-event: link to calendar event
 #       agenda: tldr
 #       notes: link to notes
@@ -105,7 +105,7 @@ weeks:
         duration: 60 min
         title: Mentor training
         date: September 1, 2020
-        time: '18:00'
+        time: '16:00'
         content: |
           During our first cohort call, you will:
           - Understand common successes and challenges in mentoring OLS participants.
@@ -115,7 +115,7 @@ weeks:
         duration: 60 min
         title: Mentor training
         date: September 4, 2020
-        time: '13:30'
+        time: '11:30'
         content: |
           During our first cohort call, you will:
           - Understand common successes and challenges in mentoring OLS participants.
@@ -128,19 +128,19 @@ weeks:
         duration: 180 min
         title: Mentoring workshop
         date: September 8, 2020
-        time: '11:00'
+        time: '09:00'
       -
         type: Mentor
         duration: 180 min
         title: Mentoring workshop
         date: September 8, 2020
-        time: '18:00'
+        time: '16:00'
       -
         type: Cohort
         duration: 90 min
         title: Welcome to Open Life Science!
         date: September 10, 2020
-        time: '10:00'
+        time: '08:00'
         hosts:
           - bebatut
           - yochannah
@@ -226,7 +226,7 @@ weeks:
         duration: 60 min
         title: 'Coworking on assignments, knowledge exchange and networking'
         date: September 17, 2020
-        time: '17:00'
+        time: '15:00'
         calendar-event: https://calendar.google.com/event?action=TEMPLATE&tmeid=NnY0ZGhkZ3M0OGEydWQ2OGRxc2VqNThuaW0gbjNycWh2dWZmMDVvamtsMG9wZnN2aDQ5ZmtAZw&tmsrc=n3rqhvuff05ojkl0opfsvh49fk%40group.calendar.google.com
         notes: https://hackmd.io/@ols-2/coworking#Week-3
         content: |
@@ -245,7 +245,7 @@ weeks:
         duration: 90 min
         title: Tooling and roadmapping for Open projects
         date: September 24, 2020
-        time: '18:30'
+        time: '16:30'
         hosts:
           - yochannah
           - malvikasharan
@@ -312,7 +312,7 @@ weeks:
         duration: 60 min
         title: Coworking on assignments, knowledge exchange and networking
         date: October 01, 2020
-        time: '17:00'
+        time: '15:00'
         notes: https://hackmd.io/@ols-2/coworking#Week-5
         hosts:
         - katesimpson
@@ -321,7 +321,7 @@ weeks:
         duration: 90 min
         title: 'Skill-up: GitHub tutorial for beginners'
         date: October 01, 2020
-        time: '13:30'
+        time: '11:30'
         hosts:
           - yochannah
           - malvikasharan
@@ -403,7 +403,7 @@ weeks:
         duration: 90 min
         title: 'Open Science I: Project Development'
         date: October 8, 2020
-        time: '10:00'
+        time: '08:00'
         calendar-event: https://calendar.google.com/event?action=TEMPLATE&tmeid=N3NvOWFoZTNncjkwaGE4ZXM4ZzdmYzlscXIgbjNycWh2dWZmMDVvamtsMG9wZnN2aDQ5ZmtAZw&tmsrc=n3rqhvuff05ojkl0opfsvh49fk%40group.calendar.google.com
         notes: https://hackmd.io/@ols-2/week-06
         recording: https://www.youtube.com/embed/fyz4gB4XPJk
@@ -475,7 +475,7 @@ weeks:
         duration: 60 min
         title: Coworking on assignments, knowledge exchange and networking
         date: October 12, 2020
-        time: '12:00'
+        time: '10:00'
         notes: https://hackmd.io/@ols-2/coworking#Week-7
         hosts:
         - lauracarter
@@ -497,7 +497,7 @@ weeks:
         duration: 90 min
         title: 'Open Science II: Knowledge Dissemination'
         date: October 22, 2020
-        time: '18:30'
+        time: '16:30'
         calendar-event: https://calendar.google.com/event?action=TEMPLATE&tmeid=NDVsa2s3bm5kdmlmcjgwNzMzaDB2NTg3aGcgbjNycWh2dWZmMDVvamtsMG9wZnN2aDQ5ZmtAZw&tmsrc=n3rqhvuff05ojkl0opfsvh49fk%40group.calendar.google.com
         notes: https://hackmd.io/@ols-2/week-08
         recording:
@@ -554,7 +554,7 @@ weeks:
         duration: 90 min
         title: "Skill-up: Personal Ecology and Ally Skills"
         date: October 29, 2020
-        time: '16:00'
+        time: '15:00'
         calendar-event: https://calendar.google.com/event?action=TEMPLATE&tmeid=MDhrYW1oZ2w5YXJyODFnam1vNGkycG9saDQgb3BlbmxpZmVzY2lAbQ&tmsrc=openlifesci%40gmail.com
         notes: https://hackmd.io/@ols-2/week-09
         recording: https://www.youtube.com/embed/8niC2UB25ys
@@ -629,7 +629,7 @@ weeks:
         duration: 90 min
         title: 'Open Science III: Next steps - applying FAIR research principles'
         date: November 5, 2020
-        time: '10:00'
+        time: '09:00'
         calendar-event: https://calendar.google.com/event?action=TEMPLATE&tmeid=NmdsajgyYTlqbmNpYmppanNkbWxsdW52N2UgbjNycWh2dWZmMDVvamtsMG9wZnN2aDQ5ZmtAZw&tmsrc=n3rqhvuff05ojkl0opfsvh49fk%40group.calendar.google.com
         notes: https://hackmd.io/@ols-2/week-10
         recording: https://www.youtube.com/embed/ylqDx_ELfus
@@ -700,7 +700,7 @@ weeks:
         duration: 90 min
         title: 'Open Leadership: Academia, industry and beyond!'
         date: November 19, 2020
-        time: '18:30'
+        time: '15:30'
         calendar-event: https://calendar.google.com/event?action=TEMPLATE&tmeid=MjZnMzY4cDQ2aGhucnRwcThnaWRnOGJpdWIgbjNycWh2dWZmMDVvamtsMG9wZnN2aDQ5ZmtAZw&tmsrc=n3rqhvuff05ojkl0opfsvh49fk%40group.calendar.google.com
         notes: https://hackmd.io/@ols-2/week-12
         recording: https://www.youtube.com/embed/hS-6GE0X2UY
@@ -760,7 +760,7 @@ weeks:
         duration: 60 min
         title: Pub Quiz!
         date: November 26, 2020
-        time: '15:00'
+        time: '14:00'
         calendar-event: https://calendar.google.com/event?action=TEMPLATE&tmeid=M2xtbjdpc2FqMjN0N3MzOTg5aWw3NGYyZnUgb3BlbmxpZmVzY2lAbQ&tmsrc=openlifesci%40gmail.com
         notes: https://hackmd.io/@ols-2/week-13
         hosts:
@@ -778,7 +778,7 @@ weeks:
         duration: 90 min
         title: 'Designing & Empowering for inclusivity'
         date: December 3, 2020
-        time: '10:00'
+        time: '09:00'
         calendar-event: https://calendar.google.com/event?action=TEMPLATE&tmeid=MzRkMjlycHQ3NWpxaXVidWhqY2Zya2hjazEgbjNycWh2dWZmMDVvamtsMG9wZnN2aDQ5ZmtAZw&tmsrc=n3rqhvuff05ojkl0opfsvh49fk%40group.calendar.google.com
         notes: https://hackmd.io/@ols-2/week-14
         recording: https://www.youtube.com/embed/Tl8MOTVznXs
@@ -838,7 +838,7 @@ weeks:
         duration: 90 min
         title: 'Final presentation rehearsal - Group 1'
         date: December 10, 2020
-        time: '10:00'
+        time: '09:00'
         notes: https://hackmd.io/@ols-2/week-15-gr1
         recording: https://www.youtube.com/embed/zFzNxxBjg4c
         hosts:
@@ -864,7 +864,7 @@ weeks:
         duration: 90 min
         title: 'Final presentation rehearsal - Group 2'
         date: December 10, 2020
-        time: '18:30'
+        time: '17:30'
         notes: https://hackmd.io/@ols-2/week-15-gr2
         hosts:
           - yochannah
@@ -892,7 +892,7 @@ weeks:
         duration: 60 min
         title: 'Final presentations & Graduation! - Group 1'
         date: December 15, 2020
-        time: '10:00'
+        time: '09:00'
         hosts:
           - yochannah
           - emmyft
@@ -915,7 +915,7 @@ weeks:
         duration: 60 min
         title: 'Final presentations & Graduation! - Group 2'
         date: December 16, 2020
-        time: '15:00'
+        time: '14:00'
         hosts:
           - yochannah
           - emmyft
@@ -937,7 +937,7 @@ weeks:
         duration: 60 min
         title: 'Final presentations & Graduation! - Group 3'
         date: December 17, 2020
-        time: '18:30'
+        time: '17:30'
         hosts:
           - yochannah
           - emmyft

--- a/_data/ols-2-schedule.yaml
+++ b/_data/ols-2-schedule.yaml
@@ -700,7 +700,7 @@ weeks:
         duration: 90 min
         title: 'Open Leadership: Academia, industry and beyond!'
         date: November 19, 2020
-        time: '15:30'
+        time: '17:30'
         calendar-event: https://calendar.google.com/event?action=TEMPLATE&tmeid=MjZnMzY4cDQ2aGhucnRwcThnaWRnOGJpdWIgbjNycWh2dWZmMDVvamtsMG9wZnN2aDQ5ZmtAZw&tmsrc=n3rqhvuff05ojkl0opfsvh49fk%40group.calendar.google.com
         notes: https://hackmd.io/@ols-2/week-12
         recording: https://www.youtube.com/embed/hS-6GE0X2UY

--- a/_data/ols-2-schedule.yaml
+++ b/_data/ols-2-schedule.yaml
@@ -9,7 +9,7 @@
 #       duration: .. min
 #       title:
 #       date: Month Day, Year
-#       time: '13:00'
+#       time: '14:00'
 #       calendar-event: link to calendar event
 #       agenda: tldr
 #       notes: link to notes
@@ -105,7 +105,7 @@ weeks:
         duration: 60 min
         title: Mentor training
         date: September 1, 2020
-        time: '16:00'
+        time: '18:00'
         content: |
           During our first cohort call, you will:
           - Understand common successes and challenges in mentoring OLS participants.
@@ -115,7 +115,7 @@ weeks:
         duration: 60 min
         title: Mentor training
         date: September 4, 2020
-        time: '11:30'
+        time: '13:30'
         content: |
           During our first cohort call, you will:
           - Understand common successes and challenges in mentoring OLS participants.
@@ -128,26 +128,26 @@ weeks:
         duration: 180 min
         title: Mentoring workshop
         date: September 8, 2020
-        time: '09:00'
+        time: '11:00'
       -
         type: Mentor
         duration: 180 min
         title: Mentoring workshop
         date: September 8, 2020
-        time: '16:00'
+        time: '18:00'
       -
         type: Cohort
         duration: 90 min
         title: Welcome to Open Life Science!
         date: September 10, 2020
-        time: '08:00'
+        time: '10:00'
         hosts:
           - bebatut
           - yochannah
           - malvikasharan
         calendar-event: https://calendar.google.com/event?action=TEMPLATE&tmeid=MXY5c2VocGhrY2hmbzFybGZobDQ1ZGV2c3UgbjNycWh2dWZmMDVvamtsMG9wZnN2aDQ5ZmtAZw&tmsrc=n3rqhvuff05ojkl0opfsvh49fk%40group.calendar.google.com
         notes: https://hackmd.io/@ols-2/week-02
-        recording: https://www.youtube.com/watch?v=5lkkHPm6aj8&list=PL1CvC6Ez54KBgzgA8eBQWjvF5rQex00cn&index=1
+        recording: https://www.youtube.com/embed/5lkkHPm6aj8
         agenda: Meet other members of your cohort, Share project vision, Intro to working openly (open canvas)
         content: |
           During our first cohort call, we will:
@@ -226,7 +226,7 @@ weeks:
         duration: 60 min
         title: 'Coworking on assignments, knowledge exchange and networking'
         date: September 17, 2020
-        time: '15:00'
+        time: '17:00'
         calendar-event: https://calendar.google.com/event?action=TEMPLATE&tmeid=NnY0ZGhkZ3M0OGEydWQ2OGRxc2VqNThuaW0gbjNycWh2dWZmMDVvamtsMG9wZnN2aDQ5ZmtAZw&tmsrc=n3rqhvuff05ojkl0opfsvh49fk%40group.calendar.google.com
         notes: https://hackmd.io/@ols-2/coworking#Week-3
         content: |
@@ -245,14 +245,14 @@ weeks:
         duration: 90 min
         title: Tooling and roadmapping for Open projects
         date: September 24, 2020
-        time: '16:30'
+        time: '18:30'
         hosts:
           - yochannah
           - malvikasharan
           - emmyft
         calendar-event: https://calendar.google.com/event?action=TEMPLATE&tmeid=NmM3OTVlMGFpbTJjajJhdXExZ2JvOGNlaDQgbjNycWh2dWZmMDVvamtsMG9wZnN2aDQ5ZmtAZw&tmsrc=n3rqhvuff05ojkl0opfsvh49fk%40group.calendar.google.com
         notes: https://hackmd.io/@ols-2/week-04
-        recording: https://www.youtube.com/watch?v=aX40ntw0uIg&list=PL1CvC6Ez54KBgzgA8eBQWjvF5rQex00cn&index=2
+        recording: https://www.youtube.com/embed/aX40ntw0uIg
         agenda: 'Working with GitHub as a community hub: Markdown as a tool to make websites, Licence, Goals and Roadmap, Contributors, Code of Conduct'
         content: |
           During this week's cohort call, we will:
@@ -312,7 +312,7 @@ weeks:
         duration: 60 min
         title: Coworking on assignments, knowledge exchange and networking
         date: October 01, 2020
-        time: '15:00'
+        time: '17:00'
         notes: https://hackmd.io/@ols-2/coworking#Week-5
         hosts:
         - katesimpson
@@ -321,7 +321,7 @@ weeks:
         duration: 90 min
         title: 'Skill-up: GitHub tutorial for beginners'
         date: October 01, 2020
-        time: '11:30'
+        time: '13:30'
         hosts:
           - yochannah
           - malvikasharan
@@ -329,7 +329,7 @@ weeks:
           - mloning
         calendar-event: https://calendar.google.com/event?action=TEMPLATE&tmeid=NnA4NzRzdWppbnN0NmU1YzBucTgwNGJsaTUgbjNycWh2dWZmMDVvamtsMG9wZnN2aDQ5ZmtAZw&tmsrc=n3rqhvuff05ojkl0opfsvh49fk%40group.calendar.google.com
         notes: https://hackmd.io/@ols-2/week-05
-        recording: https://www.youtube.com/watch?v=Wui21rKrCNk&list=PL1CvC6Ez54KBgzgA8eBQWjvF5rQex00cn&index=3
+        recording: https://www.youtube.com/embed/Wui21rKrCNk
         content: |
           During this week's cohort call, we will give you an optional 1 hour GitHub tutorial covering:
           - Creating a repository
@@ -403,10 +403,10 @@ weeks:
         duration: 90 min
         title: 'Open Science I: Project Development'
         date: October 8, 2020
-        time: '08:00'
+        time: '10:00'
         calendar-event: https://calendar.google.com/event?action=TEMPLATE&tmeid=N3NvOWFoZTNncjkwaGE4ZXM4ZzdmYzlscXIgbjNycWh2dWZmMDVvamtsMG9wZnN2aDQ5ZmtAZw&tmsrc=n3rqhvuff05ojkl0opfsvh49fk%40group.calendar.google.com
         notes: https://hackmd.io/@ols-2/week-06
-        recording: https://www.youtube.com/watch?v=fyz4gB4XPJk
+        recording: https://www.youtube.com/embed/fyz4gB4XPJk
         hosts:
           - yochannah
           - malvikasharan
@@ -475,7 +475,7 @@ weeks:
         duration: 60 min
         title: Coworking on assignments, knowledge exchange and networking
         date: October 12, 2020
-        time: '10:00'
+        time: '12:00'
         notes: https://hackmd.io/@ols-2/coworking#Week-7
         hosts:
         - lauracarter
@@ -497,7 +497,7 @@ weeks:
         duration: 90 min
         title: 'Open Science II: Knowledge Dissemination'
         date: October 22, 2020
-        time: '16:30'
+        time: '18:30'
         calendar-event: https://calendar.google.com/event?action=TEMPLATE&tmeid=NDVsa2s3bm5kdmlmcjgwNzMzaDB2NTg3aGcgbjNycWh2dWZmMDVvamtsMG9wZnN2aDQ5ZmtAZw&tmsrc=n3rqhvuff05ojkl0opfsvh49fk%40group.calendar.google.com
         notes: https://hackmd.io/@ols-2/week-08
         recording:
@@ -554,10 +554,10 @@ weeks:
         duration: 90 min
         title: "Skill-up: Personal Ecology and Ally Skills"
         date: October 29, 2020
-        time: '15:00'
+        time: '16:00'
         calendar-event: https://calendar.google.com/event?action=TEMPLATE&tmeid=MDhrYW1oZ2w5YXJyODFnam1vNGkycG9saDQgb3BlbmxpZmVzY2lAbQ&tmsrc=openlifesci%40gmail.com
         notes: https://hackmd.io/@ols-2/week-09
-        recording: https://www.youtube.com/watch?v=8niC2UB25ys
+        recording: https://www.youtube.com/embed/8niC2UB25ys
         content: |
           During this week's cohort call, we will hold a skill-up session on Personal Ecology and Ally Skills:
           - Discuss the importance of taking care your our mental health and avoiding burn out for both project leaders and community members
@@ -629,10 +629,10 @@ weeks:
         duration: 90 min
         title: 'Open Science III: Next steps - applying FAIR research principles'
         date: November 5, 2020
-        time: '09:00'
+        time: '10:00'
         calendar-event: https://calendar.google.com/event?action=TEMPLATE&tmeid=NmdsajgyYTlqbmNpYmppanNkbWxsdW52N2UgbjNycWh2dWZmMDVvamtsMG9wZnN2aDQ5ZmtAZw&tmsrc=n3rqhvuff05ojkl0opfsvh49fk%40group.calendar.google.com
         notes: https://hackmd.io/@ols-2/week-10
-        recording: https://www.youtube.com/watch?v=ylqDx_ELfus
+        recording: https://www.youtube.com/embed/ylqDx_ELfus
         agenda: FAIRification of existing or mature projects, etc
         hosts:
           - yochannah
@@ -700,10 +700,10 @@ weeks:
         duration: 90 min
         title: 'Open Leadership: Academia, industry and beyond!'
         date: November 19, 2020
-        time: '17:30'
+        time: '18:30'
         calendar-event: https://calendar.google.com/event?action=TEMPLATE&tmeid=MjZnMzY4cDQ2aGhucnRwcThnaWRnOGJpdWIgbjNycWh2dWZmMDVvamtsMG9wZnN2aDQ5ZmtAZw&tmsrc=n3rqhvuff05ojkl0opfsvh49fk%40group.calendar.google.com
         notes: https://hackmd.io/@ols-2/week-12
-        recording: https://www.youtube.com/watch?v=hS-6GE0X2UY
+        recording: https://www.youtube.com/embed/hS-6GE0X2UY
         hosts:
           - yochannah
           - emmyft
@@ -760,7 +760,7 @@ weeks:
         duration: 60 min
         title: Pub Quiz!
         date: November 26, 2020
-        time: '14:00'
+        time: '15:00'
         calendar-event: https://calendar.google.com/event?action=TEMPLATE&tmeid=M2xtbjdpc2FqMjN0N3MzOTg5aWw3NGYyZnUgb3BlbmxpZmVzY2lAbQ&tmsrc=openlifesci%40gmail.com
         notes: https://hackmd.io/@ols-2/week-13
         hosts:
@@ -778,10 +778,10 @@ weeks:
         duration: 90 min
         title: 'Designing & Empowering for inclusivity'
         date: December 3, 2020
-        time: '09:00'
+        time: '10:00'
         calendar-event: https://calendar.google.com/event?action=TEMPLATE&tmeid=MzRkMjlycHQ3NWpxaXVidWhqY2Zya2hjazEgbjNycWh2dWZmMDVvamtsMG9wZnN2aDQ5ZmtAZw&tmsrc=n3rqhvuff05ojkl0opfsvh49fk%40group.calendar.google.com
         notes: https://hackmd.io/@ols-2/week-14
-        recording: https://www.youtube.com/watch?v=Tl8MOTVznXs
+        recording: https://www.youtube.com/embed/Tl8MOTVznXs
         hosts:
           - emmyft
           - malvikasharan
@@ -838,9 +838,9 @@ weeks:
         duration: 90 min
         title: 'Final presentation rehearsal - Group 1'
         date: December 10, 2020
-        time: '09:00'
+        time: '10:00'
         notes: https://hackmd.io/@ols-2/week-15-gr1
-        recording: https://youtu.be/zFzNxxBjg4c
+        recording: https://www.youtube.com/embed/zFzNxxBjg4c
         hosts:
           - yochannah
           - emmyft
@@ -864,7 +864,7 @@ weeks:
         duration: 90 min
         title: 'Final presentation rehearsal - Group 2'
         date: December 10, 2020
-        time: '17:30'
+        time: '18:30'
         notes: https://hackmd.io/@ols-2/week-15-gr2
         hosts:
           - yochannah
@@ -892,14 +892,14 @@ weeks:
         duration: 60 min
         title: 'Final presentations & Graduation! - Group 1'
         date: December 15, 2020
-        time: '09:00'
+        time: '10:00'
         hosts:
           - yochannah
           - emmyft
           - malvikasharan
           - bebatut
         notes: https://hackmd.io/@ols-2/week-16-gr1
-        recording: https://youtu.be/IGyoiFnCvis
+        recording: https://www.youtube.com/embed/IGyoiFnCvis
         agenda: '5-minute demos of projects (Audience: entire community & public, Open and recorded call)'
         content: |
           During this week's cohort call, we will:
@@ -915,13 +915,13 @@ weeks:
         duration: 60 min
         title: 'Final presentations & Graduation! - Group 2'
         date: December 16, 2020
-        time: '14:00'
+        time: '15:00'
         hosts:
           - yochannah
           - emmyft
           - malvikasharan
         notes: https://hackmd.io/@ols-2/week-16-gr2
-        recording: https://youtu.be/28OiRoBz3ww
+        recording: https://www.youtube.com/embed/28OiRoBz3ww
         agenda: '5-minute demos of projects (Audience: entire community & public, Open and recorded call)'
         content: |
           During this week's cohort call, we will:
@@ -937,13 +937,13 @@ weeks:
         duration: 60 min
         title: 'Final presentations & Graduation! - Group 3'
         date: December 17, 2020
-        time: '17:30'
+        time: '18:30'
         hosts:
           - yochannah
           - emmyft
           - malvikasharan
         notes: https://hackmd.io/@ols-2/week-16-gr3
-        recording: https://youtu.be/wv8_0iOMpGs
+        recording: https://www.youtube.com/embed/wv8_0iOMpGs
         agenda: '5-minute demos of projects (Audience: entire community & public, Open and recorded call)'
         content: |
           During this week's cohort call, we will:

--- a/_data/ols-3-schedule.yaml
+++ b/_data/ols-3-schedule.yaml
@@ -8,7 +8,7 @@
 #       duration: .. min
 #       title:
 #       date: Month Day, Year
-#       time: '14:00'
+#       time: '13:00'
 #       calendar-event: link to calendar event
 #       agenda: tldr
 #       notes: link to notes
@@ -105,7 +105,7 @@ weeks:
       duration: 60 min
       title: Mentor training
       date: February 8, 2021
-      time: '18:30'
+      time: '17:30'
       content: |
         During our first mentor training onboarding session, you will:
         - Understand common successes and challenges in mentoring OLS participants.
@@ -114,7 +114,7 @@ weeks:
       duration: 60 min
       title: Mentor training
       date: February 9, 2021
-      time: '15:00'
+      time: '14:00'
       content: |
         (This session is identical to the session the previous day). During our first mentor training onboarding session, you will:
         - Understand common successes and challenges in mentoring OLS participants.
@@ -126,7 +126,7 @@ weeks:
       duration: 90 min
       title: Welcome to Open Life Science!
       date: February 17, 2021
-      time: '13:30'
+      time: '12:30'
       notes: https://bit.ly/ols-3-week-02-cohort-call
       recording: https://www.youtube.com/embed/lFaMk01Z_gY
       hosts:
@@ -182,13 +182,13 @@ weeks:
       duration: 180 min
       title: Mentoring workshop
       date: February 22, 2021
-      time: '10:00'
+      time: '09:00'
     -
       type: Mentor
       duration: 180 min
       title: Mentoring workshop
       date: February 23, 2021
-      time: '18:00'
+      time: '17:00'
     - type: Mentor-Mentee
       duration: 30 min
       title: Meet your mentor!
@@ -276,7 +276,7 @@ weeks:
         speaker: malvikasharan
         link: https://docs.google.com/presentation/d/e/2PACX-1vSohISYePu3i64JyoI3Lc_GRBTNuWT9x98uFd2HVI0zGQSODiNv03ZSGTcPZcm_cz38K-vhtRRzdhfI/pub?start=false&loop=false&delayms=3000
       date: March 03, 2021
-      time: '18:00'
+      time: '17:00'
       notes: https://bit.ly/ols-3-week-04-cohort-call
       recording: https://www.youtube.com/embed/Enn2NGMGC2k
       hosts:
@@ -345,7 +345,7 @@ weeks:
         title: Git workflow
         link: https://www.atlassian.com/git/tutorials/comparing-workflows
       date: March 10, 2021
-      time: '13:30'
+      time: '12:30'
       notes: https://bit.ly/ols-3-week-05
       recording: https://www.youtube.com/embed/Hj4kpy9LB6c
       hosts:
@@ -403,7 +403,7 @@ weeks:
         title: Project Development Plan
         link: https://docs.google.com/document/d/1bn4qR9b3XmAYXT8GZK9yI1xI3GE71GBMQ0ySkXtba4o/edit?usp=sharing
       date: March 17, 2021
-      time: '13:30'
+      time: '12:30'
       notes: https://bit.ly/ols-3-week-06-cohort-call
       recording: https://www.youtube.com/embed/XkzCr3fiSCg
       hosts:
@@ -428,7 +428,7 @@ weeks:
         - Share your experience been so far as a mentor in OLS-1
         - Learn about the GROW model
     - date: March 24, 2021
-      time: '18:00'
+      time: '17:00'
       duration: 30 min
       notes: https://bit.ly/ols-3-week-06-q-a
       type: Coworking
@@ -476,7 +476,7 @@ weeks:
         link: https://zenodo.org/record/4651431
         speaker: georgiahca
       date: March 31, 2021
-      time: '18:00'
+      time: '16:00'
       notes: https://bit.ly/ols-3-week-08-cohort-call
   09:
     start: April 5, 2021
@@ -538,7 +538,7 @@ weeks:
         title: Goal setting exercise
         link: https://files.frameshiftconsulting.com/Ally%20Skills%20Workshop%20goal-setting%20exercise%20-%20Letter.pdf
       date: April 07, 2021
-      time: '13:30'
+      time: '11:30'
       duration: 30 min
       notes: https://bit.ly/ols-3-week-09-q-a
       recording: https://www.youtube.com/embed/5BlB0RUY-7c
@@ -594,7 +594,7 @@ weeks:
         title: Good enough Practices in Scientific Computing
         link: https://doi.org/10.1371/journal.pcbi.1005510
       date: April 14, 2021
-      time: '13:30'
+      time: '11:30'
       notes: https://bit.ly/ols-3-week-10-cohort-call
       recording: https://www.youtube.com/embed/j-rPaiojNFk
   '11':
@@ -604,7 +604,7 @@ weeks:
       duration: 30 min
       title: Meet your mentor!
     - date: April 21, 2021
-      time: '18:00'
+      time: '16:00'
       duration: 30 min
       notes: https://bit.ly/ols-3-week-11-q-a
       type: Coworking
@@ -639,7 +639,7 @@ weeks:
         - on a scale of 1-10 (10 being the most), how much do you enjoy your current work?
         - do you want to switch your career or field? Why or why not?
       date: April 28, 2021
-      time: '18:00'
+      time: '16:00'
       notes: https://bit.ly/ols-3-week-12-cohort-call
       recording: https://www.youtube.com/embed/EMVGOapd0M4
   '13':
@@ -649,7 +649,7 @@ weeks:
       duration: 30 min
       title: Meet your mentor!
     - date: May 05, 2021
-      time: '13:30'
+      time: '11:30'
       duration: 90 min
       notes: https://docs.google.com/document/d/1tS7UG2PvZhcNhUQU1xyURTEuIh7QwQnlDyQU4libZ10/edit#
       type: Cohort
@@ -720,7 +720,7 @@ weeks:
         title: Community Interactions
         link: https://medium.com/mozilla-open-innovation/a-framework-of-open-practices-9a17fe1645a3
       date: May 12, 2021
-      time: '13:30'
+      time: '11:30'
       notes: https://bit.ly/ols-3-week-14-cohort-call
       recording: https://www.youtube.com/embed/GdZ3kfKP43A
   '15':
@@ -755,7 +755,7 @@ weeks:
         - Integrate changes suggested in this call to your final talk of 5 minutes to be presented a week later
       resources: null
       date: May 18, 2021
-      time: '09:00'
+      time: '07:00'
       notes: https://docs.google.com/document/d/1eyJba_7Ltrhxgbb4_vVYXylCXwsgjJRnWIn8XwIGkq4/edit#heading=h.9ukr4y4nfb16
     - type: Cohort
       duration: 60 min
@@ -776,7 +776,7 @@ weeks:
         - Integrate changes suggested in this call to your final talk of 5 minutes to be presented a week later
       resources: null
       date: May 19, 2021
-      time: '14:00'
+      time: '12:00'
       notes: https://docs.google.com/document/d/1eyJba_7Ltrhxgbb4_vVYXylCXwsgjJRnWIn8XwIGkq4/edit#heading=h.9ukr4y4nfb16
     - type: Cohort
       duration: 60 min
@@ -797,7 +797,7 @@ weeks:
         - Integrate changes suggested in this call to your final talk of 5 minutes to be presented a week later
       resources: null
       date: May 20, 2021
-      time: '17:00'
+      time: '15:00'
       notes: https://docs.google.com/document/d/1eyJba_7Ltrhxgbb4_vVYXylCXwsgjJRnWIn8XwIGkq4/edit#heading=h.9ukr4y4nfb16
   '16':
     start: May 24, 2021

--- a/_data/ols-3-schedule.yaml
+++ b/_data/ols-3-schedule.yaml
@@ -8,7 +8,7 @@
 #       duration: .. min
 #       title:
 #       date: Month Day, Year
-#       time: '13:00'
+#       time: '14:00'
 #       calendar-event: link to calendar event
 #       agenda: tldr
 #       notes: link to notes
@@ -105,7 +105,7 @@ weeks:
       duration: 60 min
       title: Mentor training
       date: February 8, 2021
-      time: '17:30'
+      time: '18:30'
       content: |
         During our first mentor training onboarding session, you will:
         - Understand common successes and challenges in mentoring OLS participants.
@@ -114,7 +114,7 @@ weeks:
       duration: 60 min
       title: Mentor training
       date: February 9, 2021
-      time: '14:00'
+      time: '15:00'
       content: |
         (This session is identical to the session the previous day). During our first mentor training onboarding session, you will:
         - Understand common successes and challenges in mentoring OLS participants.
@@ -126,9 +126,9 @@ weeks:
       duration: 90 min
       title: Welcome to Open Life Science!
       date: February 17, 2021
-      time: '12:30'
+      time: '13:30'
       notes: https://bit.ly/ols-3-week-02-cohort-call
-      recording: https://youtu.be/lFaMk01Z_gY
+      recording: https://www.youtube.com/embed/lFaMk01Z_gY
       hosts:
         - bebatut
         - yochannah
@@ -182,13 +182,13 @@ weeks:
       duration: 180 min
       title: Mentoring workshop
       date: February 22, 2021
-      time: '09:00'
+      time: '10:00'
     -
       type: Mentor
       duration: 180 min
       title: Mentoring workshop
       date: February 23, 2021
-      time: '17:00'
+      time: '18:00'
     - type: Mentor-Mentee
       duration: 30 min
       title: Meet your mentor!
@@ -218,7 +218,7 @@ weeks:
       duration: 30 min
       title: Open office hour, coworking on assignments, knowledge exchange and networking
       date: February 24, 2021
-      time: '17:00'
+      time: '18:00'
       notes: https://bit.ly/ols-3-week-03-q-a
       content: |
         During this week's coworking call, you will:
@@ -276,9 +276,9 @@ weeks:
         speaker: malvikasharan
         link: https://docs.google.com/presentation/d/e/2PACX-1vSohISYePu3i64JyoI3Lc_GRBTNuWT9x98uFd2HVI0zGQSODiNv03ZSGTcPZcm_cz38K-vhtRRzdhfI/pub?start=false&loop=false&delayms=3000
       date: March 03, 2021
-      time: '17:00'
+      time: '18:00'
       notes: https://bit.ly/ols-3-week-04-cohort-call
-      recording: https://youtu.be/Enn2NGMGC2k
+      recording: https://www.youtube.com/embed/Enn2NGMGC2k
       hosts:
         - yochannah
         - malvikasharan
@@ -345,9 +345,9 @@ weeks:
         title: Git workflow
         link: https://www.atlassian.com/git/tutorials/comparing-workflows
       date: March 10, 2021
-      time: '12:30'
+      time: '13:30'
       notes: https://bit.ly/ols-3-week-05
-      recording: https://youtu.be/Hj4kpy9LB6c
+      recording: https://www.youtube.com/embed/Hj4kpy9LB6c
       hosts:
         - yochannah
         - malvikasharan
@@ -403,9 +403,9 @@ weeks:
         title: Project Development Plan
         link: https://docs.google.com/document/d/1bn4qR9b3XmAYXT8GZK9yI1xI3GE71GBMQ0ySkXtba4o/edit?usp=sharing
       date: March 17, 2021
-      time: '12:30'
+      time: '13:30'
       notes: https://bit.ly/ols-3-week-06-cohort-call
-      recording: https://youtu.be/XkzCr3fiSCg
+      recording: https://www.youtube.com/embed/XkzCr3fiSCg
       hosts:
         - malvikasharan
         - bebatut
@@ -428,7 +428,7 @@ weeks:
         - Share your experience been so far as a mentor in OLS-1
         - Learn about the GROW model
     - date: March 24, 2021
-      time: '17:00'
+      time: '18:00'
       duration: 30 min
       notes: https://bit.ly/ols-3-week-06-q-a
       type: Coworking
@@ -461,7 +461,7 @@ weeks:
         - You can transfer your tasks to a project management or kanban tools such as GitHub projects ([short intro](https://unito.io/blog/github-projects-agile/)), [Trello](https://trello.com/templates/project-management), [Asana](https://asana.com/uses/kanban-boards?msclkid=c0e51366148511fc77394d30727faada&utm_source=bing&utm_medium=cpc&utm_campaign=NB%7CUK%7CEN%7CBoards%7CEX&utm_term=kanban%20board&utm_content=Kanban%20Board), [Zenhub in GitHub](https://www.zenhub.com/)
         - Make sure that by now you have added a license, contribution guideline and a Code of Conduct in your GitHub repository. If you feel stuck and don’t know where you start, take a look at [this repo](https://github.com/malvikasharan/developing_collaborative_document)
         - Look up two other projects and comment on [their issue](https://github.com/open-life-science/ols-3/issues) with feedback on their project
-      recording: https://www.youtube.com/watch?v=Vizk7fni5Eo
+      recording: https://www.youtube.com/embed/Vizk7fni5Eo
       resources:
       - type: slides
         title: Preprint, pre-registration, open review
@@ -476,7 +476,7 @@ weeks:
         link: https://zenodo.org/record/4651431
         speaker: georgiahca
       date: March 31, 2021
-      time: '16:00'
+      time: '18:00'
       notes: https://bit.ly/ols-3-week-08-cohort-call
   09:
     start: April 5, 2021
@@ -538,10 +538,10 @@ weeks:
         title: Goal setting exercise
         link: https://files.frameshiftconsulting.com/Ally%20Skills%20Workshop%20goal-setting%20exercise%20-%20Letter.pdf
       date: April 07, 2021
-      time: '11:30'
+      time: '13:30'
       duration: 30 min
       notes: https://bit.ly/ols-3-week-09-q-a
-      recording: https://youtu.be/5BlB0RUY-7c
+      recording: https://www.youtube.com/embed/5BlB0RUY-7c
   '10':
     start: April 12, 2021
     calls:
@@ -594,9 +594,9 @@ weeks:
         title: Good enough Practices in Scientific Computing
         link: https://doi.org/10.1371/journal.pcbi.1005510
       date: April 14, 2021
-      time: '11:30'
+      time: '13:30'
       notes: https://bit.ly/ols-3-week-10-cohort-call
-      recording: https://www.youtube.com/watch?v=j-rPaiojNFk
+      recording: https://www.youtube.com/embed/j-rPaiojNFk
   '11':
     start: April 19, 2021
     calls:
@@ -604,7 +604,7 @@ weeks:
       duration: 30 min
       title: Meet your mentor!
     - date: April 21, 2021
-      time: '16:00'
+      time: '18:00'
       duration: 30 min
       notes: https://bit.ly/ols-3-week-11-q-a
       type: Coworking
@@ -639,9 +639,9 @@ weeks:
         - on a scale of 1-10 (10 being the most), how much do you enjoy your current work?
         - do you want to switch your career or field? Why or why not?
       date: April 28, 2021
-      time: '16:00'
+      time: '18:00'
       notes: https://bit.ly/ols-3-week-12-cohort-call
-      recording: https://www.youtube.com/watch?v=EMVGOapd0M4
+      recording: https://www.youtube.com/embed/EMVGOapd0M4
   '13':
     start: May 3, 2021
     calls:
@@ -649,7 +649,7 @@ weeks:
       duration: 30 min
       title: Meet your mentor!
     - date: May 05, 2021
-      time: '11:30'
+      time: '13:30'
       duration: 90 min
       notes: https://docs.google.com/document/d/1tS7UG2PvZhcNhUQU1xyURTEuIh7QwQnlDyQU4libZ10/edit#
       type: Cohort
@@ -662,7 +662,7 @@ weeks:
         - Brew yourself a nice tea, coffee, or any drink of your choice and bring them along to this call.
       after: |
         - Continue on with your project, and connect with others on Slack or other social media platforms.
-      recording: https://www.youtube.com/watch?v=mHCYpX6WLZw
+      recording: https://www.youtube.com/embed/mHCYpX6WLZw
   '14':
     start: May 10, 2021
     calls:
@@ -720,9 +720,9 @@ weeks:
         title: Community Interactions
         link: https://medium.com/mozilla-open-innovation/a-framework-of-open-practices-9a17fe1645a3
       date: May 12, 2021
-      time: '11:30'
+      time: '13:30'
       notes: https://bit.ly/ols-3-week-14-cohort-call
-      recording: https://www.youtube.com/watch?v=GdZ3kfKP43A
+      recording: https://www.youtube.com/embed/GdZ3kfKP43A
   '15':
     start: May 17, 2021
     calls:
@@ -755,7 +755,7 @@ weeks:
         - Integrate changes suggested in this call to your final talk of 5 minutes to be presented a week later
       resources: null
       date: May 18, 2021
-      time: '07:00'
+      time: '09:00'
       notes: https://docs.google.com/document/d/1eyJba_7Ltrhxgbb4_vVYXylCXwsgjJRnWIn8XwIGkq4/edit#heading=h.9ukr4y4nfb16
     - type: Cohort
       duration: 60 min
@@ -776,7 +776,7 @@ weeks:
         - Integrate changes suggested in this call to your final talk of 5 minutes to be presented a week later
       resources: null
       date: May 19, 2021
-      time: '12:00'
+      time: '14:00'
       notes: https://docs.google.com/document/d/1eyJba_7Ltrhxgbb4_vVYXylCXwsgjJRnWIn8XwIGkq4/edit#heading=h.9ukr4y4nfb16
     - type: Cohort
       duration: 60 min
@@ -797,7 +797,7 @@ weeks:
         - Integrate changes suggested in this call to your final talk of 5 minutes to be presented a week later
       resources: null
       date: May 20, 2021
-      time: '15:00'
+      time: '17:00'
       notes: https://docs.google.com/document/d/1eyJba_7Ltrhxgbb4_vVYXylCXwsgjJRnWIn8XwIGkq4/edit#heading=h.9ukr4y4nfb16
   '16':
     start: May 24, 2021
@@ -818,7 +818,7 @@ weeks:
         - Celebrate your graduation from OLS-3!
       resources: null
       notes: https://pad.sfconservancy.org/p/ols-graduations-1
-      recording: https://youtu.be/pU-HosUM5-8
+      recording: https://www.youtube.com/embed/pU-HosUM5-8
     - type: Cohort
       duration: 60 min
       title: Final presentations & Graduation! - Group 2
@@ -834,7 +834,7 @@ weeks:
       after: |
         - Celebrate your graduation from OLS-3!
       notes: https://pad.sfconservancy.org/p/ols-graduations-2
-      recording: https://www.youtube.com/watch?v=kNQz0ap71yg
+      recording: https://www.youtube.com/embed/kNQz0ap71yg
       resources: null
     - type: Cohort
       duration: 60 min
@@ -851,7 +851,7 @@ weeks:
       after: |
         - Celebrate your graduation from OLS-3!
       notes: https://pad.sfconservancy.org/p/ols-graduations-3
-      recording: https://www.youtube.com/watch?v=2tezbbfJGu8
+      recording: https://www.youtube.com/embed/2tezbbfJGu8
       resources: null
     - type: Mentor
       duration: 60 min

--- a/_data/ols-3-schedule.yaml
+++ b/_data/ols-3-schedule.yaml
@@ -218,7 +218,7 @@ weeks:
       duration: 30 min
       title: Open office hour, coworking on assignments, knowledge exchange and networking
       date: February 24, 2021
-      time: '18:00'
+      time: '17:00'
       notes: https://bit.ly/ols-3-week-03-q-a
       content: |
         During this week's coworking call, you will:

--- a/_data/ols-4-schedule.yaml
+++ b/_data/ols-4-schedule.yaml
@@ -37,7 +37,7 @@ weeks:
       title: 1st mentor-mentee meeting
       type: Mentor-Mentee
     - date: September 16, 2021
-      time: '16:00'
+      time: '14:00'
       duration: 60 min
       content: |-
         In this call, participants will:
@@ -46,7 +46,7 @@ weeks:
       title: Mentor onboarding group 1
       type: Mentor
     - date: September 17, 2021
-      time: '10:00'
+      time: '08:00'
       duration: 60 min
       content: |-
         In this call, participants will:
@@ -58,7 +58,7 @@ weeks:
     start: September 20, 2021
     calls:
     - date: September 22, 2021
-      time: '13:30'
+      time: '11:30'
       duration: 90 min
       notes: https://bit.ly/ols-4-week-02
       content: |-
@@ -101,12 +101,12 @@ weeks:
       facilitators:
       - batoolmm
     - date: September 22, 2021
-      time: '18:00'
+      time: '16:00'
       duration: 180 min
       title: Mentor Skill Workshop by 360 Training - Group 1
       type: Mentor
     - date: September 23, 2021
-      time: '10:00'
+      time: '08:00'
       duration: 180 min
       title: Mentor Skill Workshop by 360 Training - Group 2
       type: Mentor
@@ -117,7 +117,7 @@ weeks:
       title: 2nd mentor-mentee meeting
       type: Mentor-Mentee
     - date: September 29, 2021
-      time: '18:00'
+      time: '16:00'
       duration: 90 min
       notes: https://bit.ly/ols-4-week-03
       content: |-
@@ -164,7 +164,7 @@ weeks:
     start: October 04, 2021
     calls:
     - date: October 06, 2021
-      time: '18:00'
+      time: '16:00'
       duration: 90 min
       notes: https://bit.ly/ols-4-week-04
       content: "In this call, participants will:\n- Look at project structure as we\
@@ -213,7 +213,7 @@ weeks:
       title: 3rd mentor-mentee meeting
       type: Mentor-Mentee
     - date: October 13, 2021
-      time: '13:30'
+      time: '11:30'
       duration: 90 min
       notes: https://bit.ly/ols-4-week-05
       content: |-
@@ -244,7 +244,7 @@ weeks:
     start: October 18, 2021
     calls:
     - date: October 20, 2021
-      time: '13:30'
+      time: '11:30'
       duration: 90 min
       notes: https://bit.ly/ols-4-week-06
       content: |-
@@ -294,7 +294,7 @@ weeks:
       title: 4th mentor-mentee meeting
       type: Mentor-Mentee
     - date: October 27, 2021
-      time: '18:00'
+      time: '16:00'
       duration: 30 min
       notes: https://bit.ly/ols-4-week-07
       title: Q&A call
@@ -303,7 +303,7 @@ weeks:
     start: November 01, 2021
     calls:
     - date: November 03, 2021
-      time: '18:00'
+      time: '16:00'
       duration: 90 min
       notes: https://bit.ly/ols-4-week-08
       content: |-
@@ -338,7 +338,7 @@ weeks:
       title: 5th mentor-mentee meeting
       type: Mentor-Mentee
     - date: November 10, 2021
-      time: '13:30'
+      time: '11:30'
       duration: 90 min
       notes: https://bit.ly/ols-4-week-09
       content: "In this call, participants will:\n- Hear from the professionals from\
@@ -380,7 +380,7 @@ weeks:
     start: November 15, 2021
     calls:
     - date: November 17, 2021
-      time: '13:30'
+      time: '12:30'
       duration: 90 min
       notes: https://bit.ly/ols-4-week-10
       content: |-
@@ -417,7 +417,7 @@ weeks:
       title: 6th mentor-mentee meeting
       type: Mentor-Mentee
     - date: November 24, 2021
-      time: '18:00'
+      time: '17:00'
       duration: 30 min
       notes: https://bit.ly/ols-4-week-11
       title: Q&A call
@@ -426,7 +426,7 @@ weeks:
     start: November 29, 2021
     calls:
     - date: December 01, 2021
-      time: '18:00'
+      time: '17:00'
       duration: 90 min
       notes: https://bit.ly/ols-4-week-12
       title: Diversity and Inclusion & Ally skills
@@ -457,7 +457,7 @@ weeks:
       title: 7th mentor-mentee meeting
       type: Mentor-Mentee
     - date: December 08, 2021
-      time: '13:30'
+      time: '12:30'
       duration: 90 min
       notes: https://bit.ly/ols-4-week-13
       content: |-
@@ -480,7 +480,7 @@ weeks:
     start: December 13, 2021
     calls:
     - date: December 15, 2021
-      time: '13:30'
+      time: '12:30'
       duration: 90 min
       notes: https://bit.ly/ols-4-week-14
       content: "In this call, participants will:\n- Learn how to apply FAIR research\

--- a/_data/ols-4-schedule.yaml
+++ b/_data/ols-4-schedule.yaml
@@ -37,7 +37,7 @@ weeks:
       title: 1st mentor-mentee meeting
       type: Mentor-Mentee
     - date: September 16, 2021
-      time: '14:00'
+      time: '16:00'
       duration: 60 min
       content: |-
         In this call, participants will:
@@ -46,7 +46,7 @@ weeks:
       title: Mentor onboarding group 1
       type: Mentor
     - date: September 17, 2021
-      time: '08:00'
+      time: '10:00'
       duration: 60 min
       content: |-
         In this call, participants will:
@@ -58,7 +58,7 @@ weeks:
     start: September 20, 2021
     calls:
     - date: September 22, 2021
-      time: '11:30'
+      time: '13:30'
       duration: 90 min
       notes: https://bit.ly/ols-4-week-02
       content: |-
@@ -93,7 +93,7 @@ weeks:
         - Start your [Roadmap](https://mozilla.github.io/open-leadership-training-series/articles/opening-your-project/start-your-project-roadmap/)
         - Comment on your issue with your draft Roadmap
         - Suggest a cohort name at the bottom of the shared notes and vote on your favorite with a +1
-      recording: https://www.youtube.com/watch?v=NsVX4a3ZOF8&t=1969s
+      recording: https://www.youtube.com/embed/NsVX4a3ZOF8
       hosts:
       - yochannah
       - emmyft
@@ -101,12 +101,12 @@ weeks:
       facilitators:
       - batoolmm
     - date: September 22, 2021
-      time: '16:00'
+      time: '18:00'
       duration: 180 min
       title: Mentor Skill Workshop by 360 Training - Group 1
       type: Mentor
     - date: September 23, 2021
-      time: '08:00'
+      time: '10:00'
       duration: 180 min
       title: Mentor Skill Workshop by 360 Training - Group 2
       type: Mentor
@@ -117,7 +117,7 @@ weeks:
       title: 2nd mentor-mentee meeting
       type: Mentor-Mentee
     - date: September 29, 2021
-      time: '16:00'
+      time: '18:00'
       duration: 90 min
       notes: https://bit.ly/ols-4-week-03
       content: |-
@@ -156,7 +156,7 @@ weeks:
       - yochannah
       - emmyft
       - malvikasharan
-      recording: https://www.youtube.com/watch?v=NsVX4a3ZOF8&t=1969s
+      recording: https://www.youtube.com/embed/NsVX4a3ZOF8
       facilitators:
       - batoolmm
       - ekaroune
@@ -164,7 +164,7 @@ weeks:
     start: October 04, 2021
     calls:
     - date: October 06, 2021
-      time: '16:00'
+      time: '18:00'
       duration: 90 min
       notes: https://bit.ly/ols-4-week-04
       content: "In this call, participants will:\n- Look at project structure as we\
@@ -205,7 +205,7 @@ weeks:
       - yochannah
       - emmyft
       - ekaroune
-      recording: https://youtu.be/kAxVZDI18RU
+      recording: https://www.youtube.com/embed/kAxVZDI18RU
   '05':
     start: October 11, 2021
     calls:
@@ -213,7 +213,7 @@ weeks:
       title: 3rd mentor-mentee meeting
       type: Mentor-Mentee
     - date: October 13, 2021
-      time: '11:30'
+      time: '13:30'
       duration: 90 min
       notes: https://bit.ly/ols-4-week-05
       content: |-
@@ -231,7 +231,7 @@ weeks:
         type: slides
         title: Introduction to GitHub
         speaker: malvikasharan
-      recording: https://youtu.be/lRW8mlpTw5M
+      recording: https://www.youtube.com/embed/lRW8mlpTw5M
       hosts:
       - yochannah
       - malvikasharan
@@ -244,7 +244,7 @@ weeks:
     start: October 18, 2021
     calls:
     - date: October 20, 2021
-      time: '11:30'
+      time: '13:30'
       duration: 90 min
       notes: https://bit.ly/ols-4-week-06
       content: |-
@@ -279,7 +279,7 @@ weeks:
           Assignment to help you use Agile methods to breakdown your milestones into smaller tasks and define a timeline for your milestones
           In your own time: After this assignment, you can transfer your tasks to a project management or kanban tools such as [GitHub projects](https://unito.io/blog/github-projects-agile/)), [Trello](https://trello.com/templates/project-management), [Asana](https://asana.com/uses/kanban-boards?msclkid=c0e51366148511fc77394d30727faada&utm_source=bing&utm_medium=cpc&utm_campaign=NB%7CUK%7CEN%7CBoards%7CEX&utm_term=kanban%20board&utm_content=Kanban%20Board), [Zenhub in GitHub](https://www.zenhub.com/)
         - Start creating a [contribution guideline](https://mozilla.github.io/open-leadership-training-series/articles/building-communities-of-contributors/write-contributor-guidelines/) for your communit
-      recording: https://www.youtube.com/watch?v=kjhrrfF2fvM
+      recording: https://www.youtube.com/embed/kjhrrfF2fvM
       hosts:
       - yochannah
       - malvikasharan
@@ -294,16 +294,16 @@ weeks:
       title: 4th mentor-mentee meeting
       type: Mentor-Mentee
     - date: October 27, 2021
-      time: '16:00'
+      time: '18:00'
       duration: 30 min
       notes: https://bit.ly/ols-4-week-07
       title: Q&A call
       type: Q&A
-  08:
+  '08':
     start: November 01, 2021
     calls:
     - date: November 03, 2021
-      time: '17:00'
+      time: '18:00'
       duration: 90 min
       notes: https://bit.ly/ols-4-week-08
       content: |-
@@ -331,14 +331,14 @@ weeks:
       - link: https://docs.google.com/presentation/d/1z8rPZbaxJCQaRvNMhy72sfq6xJcf9RSturrPQtugLGU/edit#slide=id.g6e991a6896_0_209
         type: slides
         title: Community interactions
-  09:
+  '09':
     start: November 08, 2021
     calls:
     - duration: 30 min
       title: 5th mentor-mentee meeting
       type: Mentor-Mentee
     - date: November 10, 2021
-      time: '12:30'
+      time: '13:30'
       duration: 90 min
       notes: https://bit.ly/ols-4-week-09
       content: "In this call, participants will:\n- Hear from the professionals from\
@@ -380,7 +380,7 @@ weeks:
     start: November 15, 2021
     calls:
     - date: November 17, 2021
-      time: '12:30'
+      time: '13:30'
       duration: 90 min
       notes: https://bit.ly/ols-4-week-10
       content: |-
@@ -417,7 +417,7 @@ weeks:
       title: 6th mentor-mentee meeting
       type: Mentor-Mentee
     - date: November 24, 2021
-      time: '17:00'
+      time: '18:00'
       duration: 30 min
       notes: https://bit.ly/ols-4-week-11
       title: Q&A call
@@ -426,7 +426,7 @@ weeks:
     start: November 29, 2021
     calls:
     - date: December 01, 2021
-      time: '17:00'
+      time: '18:00'
       duration: 90 min
       notes: https://bit.ly/ols-4-week-12
       title: Diversity and Inclusion & Ally skills
@@ -457,7 +457,7 @@ weeks:
       title: 7th mentor-mentee meeting
       type: Mentor-Mentee
     - date: December 08, 2021
-      time: '12:30'
+      time: '13:30'
       duration: 90 min
       notes: https://bit.ly/ols-4-week-13
       content: |-
@@ -480,7 +480,7 @@ weeks:
     start: December 13, 2021
     calls:
     - date: December 15, 2021
-      time: '12:30'
+      time: '13:30'
       duration: 90 min
       notes: https://bit.ly/ols-4-week-14
       content: "In this call, participants will:\n- Learn how to apply FAIR research\

--- a/_data/ols-4-schedule.yaml
+++ b/_data/ols-4-schedule.yaml
@@ -303,7 +303,7 @@ weeks:
     start: November 01, 2021
     calls:
     - date: November 03, 2021
-      time: '16:00'
+      time: '17:00'
       duration: 90 min
       notes: https://bit.ly/ols-4-week-08
       content: |-

--- a/_data/ols-4-schedule.yaml
+++ b/_data/ols-4-schedule.yaml
@@ -338,7 +338,7 @@ weeks:
       title: 5th mentor-mentee meeting
       type: Mentor-Mentee
     - date: November 10, 2021
-      time: '11:30'
+      time: '12:30'
       duration: 90 min
       notes: https://bit.ly/ols-4-week-09
       content: "In this call, participants will:\n- Hear from the professionals from\

--- a/_data/ols-5-schedule.yaml
+++ b/_data/ols-5-schedule.yaml
@@ -41,7 +41,7 @@ weeks:
       title: Mentor onboarding group 1
       type: Mentor
     - date: February 22, 2022
-      time: '10:00'
+      time: '09:00'
       duration: 180 min
       title: Mentor Skill Workshop by 360 Training - Group 1
       type: Mentor

--- a/_data/ols-5-schedule.yaml
+++ b/_data/ols-5-schedule.yaml
@@ -5,7 +5,7 @@ timeline:
   description: Call for Application opens on [Open Review](https://openreview.net/group?id=openlifesci.org/Open_Life_Science/2022/Cohort_5)
   details: See the [guidelines and templates](https://github.com/open-life-science/application-forms)
 - date: December 14, 2021
-  time: '17:00'
+  time: '16:00'
   duration: 60 min
   description: Application webinar
   type:

--- a/_data/ols-5-schedule.yaml
+++ b/_data/ols-5-schedule.yaml
@@ -15,7 +15,7 @@ timeline:
   recording: null
   details: Watch recordings from previous webinars on [**YouTube**](https://www.youtube.com/playlist?list=PL1CvC6Ez54KBsPT0fhPtkHmBaXR4f8Dqt)
 - date: January 7, 2022
-  time: '11:00'
+  time: '10:00'
   duration: 60 min
   description: Application Clinic Call
   type:
@@ -32,7 +32,7 @@ weeks:
     start: February 21, 2022
     calls:
     - date: February 21, 2022
-      time: '18:00'
+      time: '17:00'
       duration: 60 min
       content: |-
         In this call, participants will:
@@ -55,7 +55,7 @@ weeks:
         - Discuss their personal motivation, expectations, workin practices and project goals
       title: 1st mentor-mentee meeting
       type: Mentor-Mentee
-    - time: '10:00'
+    - time: '09:00'
       duration: 60 min
       content: |-
         In this call, participants will:
@@ -64,7 +64,7 @@ weeks:
       title: Mentor onboarding group 2
       type: Mentor
       date: March 02, 2022
-    - time: '16:00'
+    - time: '15:00'
       duration: 60 min
       content: |-
         In this call, participants will:
@@ -73,12 +73,12 @@ weeks:
       title: Mentor onboarding group 1
       type: Mentor
     - date: March 02, 2022
-      time: '14:00'
+      time: '13:00'
       duration: 180 min
       title: Mentor Skill Workshop by 360 Training - Group 2
       type: Mentor
     - date: March 03, 2022
-      time: '18:00'
+      time: '17:00'
       duration: 180 min
       title: Mentor Skill Workshop by 360 Training - Group 3
       type: Mentor
@@ -86,7 +86,7 @@ weeks:
     start: March 07, 2022
     calls:
     - date: March 07, 2022
-      time: '18:00'
+      time: '17:00'
       duration: 90 min
       notes: https://bit.ly/ols-5-week-02
       content: |-
@@ -126,7 +126,7 @@ weeks:
       title: 2nd mentor-mentee meeting
       type: Mentor-Mentee
     - date: March 16, 2022
-      time: '11:00'
+      time: '10:00'
       duration: 90 min
       notes: https://bit.ly/ols-5-week-03
       content: |-
@@ -173,7 +173,7 @@ weeks:
     start: March 21, 2022
     calls:
     - date: March 23, 2022
-      time: '11:00'
+      time: '10:00'
       duration: 90 min
       notes: https://bit.ly/ols-5-week-04
       content: "In this call, participants will:\n- Look at project structure as we\
@@ -226,7 +226,7 @@ weeks:
       title: 3rd mentor-mentee meeting
       type: Mentor-Mentee
     - date: March 28, 2022
-      time: '18:00'
+      time: '16:00'
       duration: 90 min
       notes: https://bit.ly/ols-5-week-05
       content: |-
@@ -252,7 +252,7 @@ weeks:
     start: April 04, 2022
     calls:
     - date: April 04, 2022
-      time: '18:00'
+      time: '16:00'
       duration: 90 min
       notes: https://bit.ly/ols-5-week-06
       content: |-
@@ -293,7 +293,7 @@ weeks:
       title: 4th mentor-mentee meeting
       type: Mentor-Mentee
     - date: April 13, 2022
-      time: '11:00'
+      time: '09:00'
       duration: 30 min
       notes: https://bit.ly/ols-5-week-07
       title: Q&A call
@@ -302,7 +302,7 @@ weeks:
     start: April 18, 2022
     calls:
     - date: April 20, 2022
-      time: '11:00'
+      time: '09:00'
       duration: 90 min
       notes: https://bit.ly/ols-5-week-08
       content: |-
@@ -337,7 +337,7 @@ weeks:
       title: 5th mentor-mentee meeting
       type: Mentor-Mentee
     - date: April 25, 2022
-      time: '18:00'
+      time: '16:00'
       duration: 90 min
       notes: https://bit.ly/ols-5-week-09
       content: "In this call, participants will:\n- Hear from the professionals from\
@@ -373,7 +373,7 @@ weeks:
     start: May 02, 2022
     calls:
     - date: May 02, 2022
-      time: '18:00'
+      time: '16:00'
       duration: 90 min
       notes: https://bit.ly/ols-5-week-10
       content: |-
@@ -416,7 +416,7 @@ weeks:
       title: 6th mentor-mentee meeting
       type: Mentor-Mentee
     - date: May 11, 2022
-      time: '11:00'
+      time: '09:00'
       duration: 30 min
       notes: https://bit.ly/ols-5-week-11
       title: Q&A call
@@ -425,7 +425,7 @@ weeks:
     start: May 16, 2022
     calls:
     - date: May 18, 2022
-      time: '11:00'
+      time: '09:00'
       duration: 90 min
       notes: https://bit.ly/ols-5-week-12
       title: Diversity and Inclusion & Ally skills
@@ -457,7 +457,7 @@ weeks:
       title: 7th mentor-mentee meeting
       type: Mentor-Mentee
     - date: May 23, 2022
-      time: '18:00'
+      time: '16:00'
       duration: 90 min
       notes: https://bit.ly/ols-5-week-13
       content: |-
@@ -480,7 +480,7 @@ weeks:
     start: May 30, 2022
     calls:
     - date: May 30, 2022
-      time: '18:00'
+      time: '16:00'
       duration: 90 min
       notes: https://bit.ly/ols-5-week-14
       content: "In this call, participants will:\n- Learn how to apply FAIR research\
@@ -515,7 +515,7 @@ weeks:
       title: 8th mentor-mentee meeting
       type: Mentor-Mentee
     - date: June 07, 2022
-      time: '10:00'
+      time: '08:00'
       duration: 60 min
       notes: https://bit.ly/ols-5-week-15
       content: |-
@@ -546,10 +546,10 @@ weeks:
         \ which you thrive - sustain them; identify the least fulfilling conditions\
         \ that frustrate you - avoid them.\n      \n      \n        \n      \n   \
         \     "
-      time: '15:00'
+      time: '13:00'
       duration: 60 min
     - date: June 09, 2022
-      time: '18:00'
+      time: '16:00'
       duration: 60 min
       notes: https://bit.ly/ols-5-week-15
       content: |-
@@ -569,7 +569,7 @@ weeks:
     start: June 13, 2022
     calls:
     - date: June 14, 2022
-      time: '10:00'
+      time: '08:00'
       duration: 60 min
       notes: https://pad.sfconservancy.org/p/ols-5-graduations-1
       content: |-
@@ -600,10 +600,10 @@ weeks:
         \ which you thrive - sustain them; identify the least fulfilling conditions\
         \ that frustrate you - avoid them.\n      \n      \n        \n      \n   \
         \     "
-      time: '15:00'
+      time: '13:00'
       duration: 60 min
     - date: June 16, 2022
-      time: '18:00'
+      time: '16:00'
       duration: 60 min
       notes: https://pad.sfconservancy.org/p/ols-5-graduations-3
       content: |-
@@ -620,7 +620,7 @@ weeks:
         \ that frustrate you - avoid them.\n      \n      \n        \n      \n   \
         \     "
     - date: July 18, 2022
-      time: '10:00'
+      time: '08:00'
       duration: 60 min
       notes: https://pad.sfconservancy.org/p/ols-5-graduations-4
       title: Final presentations & Graduation! - Group 4
@@ -633,7 +633,7 @@ weeks:
         \ that frustrate you - avoid them.\n      \n      \n        \n      \n   \
         \     "
     - date: July 20, 2022
-      time: '18:00'
+      time: '16:00'
       duration: 60 min
       notes: https://pad.sfconservancy.org/p/ols-5-graduations-5
       title: Final presentations & Graduation! - Group 5

--- a/_data/ols-5-schedule.yaml
+++ b/_data/ols-5-schedule.yaml
@@ -5,7 +5,7 @@ timeline:
   description: Call for Application opens on [Open Review](https://openreview.net/group?id=openlifesci.org/Open_Life_Science/2022/Cohort_5)
   details: See the [guidelines and templates](https://github.com/open-life-science/application-forms)
 - date: December 14, 2021
-  time: '16:00'
+  time: '17:00'
   duration: 60 min
   description: Application webinar
   type:
@@ -15,7 +15,7 @@ timeline:
   recording: null
   details: Watch recordings from previous webinars on [**YouTube**](https://www.youtube.com/playlist?list=PL1CvC6Ez54KBsPT0fhPtkHmBaXR4f8Dqt)
 - date: January 7, 2022
-  time: '10:00'
+  time: '11:00'
   duration: 60 min
   description: Application Clinic Call
   type:
@@ -32,7 +32,7 @@ weeks:
     start: February 21, 2022
     calls:
     - date: February 21, 2022
-      time: '17:00'
+      time: '18:00'
       duration: 60 min
       content: |-
         In this call, participants will:
@@ -41,7 +41,7 @@ weeks:
       title: Mentor onboarding group 1
       type: Mentor
     - date: February 22, 2022
-      time: '09:00'
+      time: '10:00'
       duration: 180 min
       title: Mentor Skill Workshop by 360 Training - Group 1
       type: Mentor
@@ -55,7 +55,7 @@ weeks:
         - Discuss their personal motivation, expectations, workin practices and project goals
       title: 1st mentor-mentee meeting
       type: Mentor-Mentee
-    - time: '09:00'
+    - time: '10:00'
       duration: 60 min
       content: |-
         In this call, participants will:
@@ -64,7 +64,7 @@ weeks:
       title: Mentor onboarding group 2
       type: Mentor
       date: March 02, 2022
-    - time: '15:00'
+    - time: '16:00'
       duration: 60 min
       content: |-
         In this call, participants will:
@@ -73,12 +73,12 @@ weeks:
       title: Mentor onboarding group 1
       type: Mentor
     - date: March 02, 2022
-      time: '13:00'
+      time: '14:00'
       duration: 180 min
       title: Mentor Skill Workshop by 360 Training - Group 2
       type: Mentor
     - date: March 03, 2022
-      time: '17:00'
+      time: '18:00'
       duration: 180 min
       title: Mentor Skill Workshop by 360 Training - Group 3
       type: Mentor
@@ -86,7 +86,7 @@ weeks:
     start: March 07, 2022
     calls:
     - date: March 07, 2022
-      time: '17:00'
+      time: '18:00'
       duration: 90 min
       notes: https://bit.ly/ols-5-week-02
       content: |-
@@ -118,7 +118,7 @@ weeks:
       - link: https://docs.google.com/presentation/d/1ncWeisU45m5INf-xNBMHtM-GGPvZ6v0mPlrwOh6FY_I/edit?usp=sharing
         type: slides
         title: Introducing Road Mapping
-      recording: https://youtu.be/O3yk0yrOHGM
+      recording: https://www.youtube.com/embed/O3yk0yrOHGM
   '03':
     start: March 14, 2022
     calls:
@@ -126,7 +126,7 @@ weeks:
       title: 2nd mentor-mentee meeting
       type: Mentor-Mentee
     - date: March 16, 2022
-      time: '10:00'
+      time: '11:00'
       duration: 90 min
       notes: https://bit.ly/ols-5-week-03
       content: |-
@@ -138,7 +138,7 @@ weeks:
         - Learn about common community interactions in open projects.
         - Learn about common value exchanges between community members in open science
       title: Welcome to Open Life Science!
-      recording: https://www.youtube.com/watch?v=NsVX4a3ZOF8&t=1969s
+      recording: https://www.youtube.com/embed/NsVX4a3ZOF8
       hosts:
       - yochannah
       - emmyft
@@ -173,7 +173,7 @@ weeks:
     start: March 21, 2022
     calls:
     - date: March 23, 2022
-      time: '10:00'
+      time: '11:00'
       duration: 90 min
       notes: https://bit.ly/ols-5-week-04
       content: "In this call, participants will:\n- Look at project structure as we\
@@ -182,7 +182,7 @@ weeks:
         \   The exact project structure and files used may look different on your\
         \ project.\n  "
       title: Tooling and roadmapping for Open projects
-      recording: https://youtu.be/kAxVZDI18RU
+      recording: https://www.youtube.com/embed/kAxVZDI18RU
       hosts:
       - yochannah
       - emmyft
@@ -226,7 +226,7 @@ weeks:
       title: 3rd mentor-mentee meeting
       type: Mentor-Mentee
     - date: March 28, 2022
-      time: '16:00'
+      time: '18:00'
       duration: 90 min
       notes: https://bit.ly/ols-5-week-05
       content: |-
@@ -252,7 +252,7 @@ weeks:
     start: April 04, 2022
     calls:
     - date: April 04, 2022
-      time: '16:00'
+      time: '18:00'
       duration: 90 min
       notes: https://bit.ly/ols-5-week-06
       content: |-
@@ -293,7 +293,7 @@ weeks:
       title: 4th mentor-mentee meeting
       type: Mentor-Mentee
     - date: April 13, 2022
-      time: '09:00'
+      time: '11:00'
       duration: 30 min
       notes: https://bit.ly/ols-5-week-07
       title: Q&A call
@@ -302,7 +302,7 @@ weeks:
     start: April 18, 2022
     calls:
     - date: April 20, 2022
-      time: '09:00'
+      time: '11:00'
       duration: 90 min
       notes: https://bit.ly/ols-5-week-08
       content: |-
@@ -337,7 +337,7 @@ weeks:
       title: 5th mentor-mentee meeting
       type: Mentor-Mentee
     - date: April 25, 2022
-      time: '16:00'
+      time: '18:00'
       duration: 90 min
       notes: https://bit.ly/ols-5-week-09
       content: "In this call, participants will:\n- Hear from the professionals from\
@@ -373,7 +373,7 @@ weeks:
     start: May 02, 2022
     calls:
     - date: May 02, 2022
-      time: '16:00'
+      time: '18:00'
       duration: 90 min
       notes: https://bit.ly/ols-5-week-10
       content: |-
@@ -416,7 +416,7 @@ weeks:
       title: 6th mentor-mentee meeting
       type: Mentor-Mentee
     - date: May 11, 2022
-      time: '09:00'
+      time: '11:00'
       duration: 30 min
       notes: https://bit.ly/ols-5-week-11
       title: Q&A call
@@ -425,7 +425,7 @@ weeks:
     start: May 16, 2022
     calls:
     - date: May 18, 2022
-      time: '09:00'
+      time: '11:00'
       duration: 90 min
       notes: https://bit.ly/ols-5-week-12
       title: Diversity and Inclusion & Ally skills
@@ -457,7 +457,7 @@ weeks:
       title: 7th mentor-mentee meeting
       type: Mentor-Mentee
     - date: May 23, 2022
-      time: '16:00'
+      time: '18:00'
       duration: 90 min
       notes: https://bit.ly/ols-5-week-13
       content: |-
@@ -480,7 +480,7 @@ weeks:
     start: May 30, 2022
     calls:
     - date: May 30, 2022
-      time: '16:00'
+      time: '18:00'
       duration: 90 min
       notes: https://bit.ly/ols-5-week-14
       content: "In this call, participants will:\n- Learn how to apply FAIR research\
@@ -515,7 +515,7 @@ weeks:
       title: 8th mentor-mentee meeting
       type: Mentor-Mentee
     - date: June 07, 2022
-      time: '08:00'
+      time: '10:00'
       duration: 60 min
       notes: https://bit.ly/ols-5-week-15
       content: |-
@@ -546,10 +546,10 @@ weeks:
         \ which you thrive - sustain them; identify the least fulfilling conditions\
         \ that frustrate you - avoid them.\n      \n      \n        \n      \n   \
         \     "
-      time: '13:00'
+      time: '15:00'
       duration: 60 min
     - date: June 09, 2022
-      time: '16:00'
+      time: '18:00'
       duration: 60 min
       notes: https://bit.ly/ols-5-week-15
       content: |-
@@ -569,7 +569,7 @@ weeks:
     start: June 13, 2022
     calls:
     - date: June 14, 2022
-      time: '08:00'
+      time: '10:00'
       duration: 60 min
       notes: https://pad.sfconservancy.org/p/ols-5-graduations-1
       content: |-
@@ -600,10 +600,10 @@ weeks:
         \ which you thrive - sustain them; identify the least fulfilling conditions\
         \ that frustrate you - avoid them.\n      \n      \n        \n      \n   \
         \     "
-      time: '13:00'
+      time: '15:00'
       duration: 60 min
     - date: June 16, 2022
-      time: '16:00'
+      time: '18:00'
       duration: 60 min
       notes: https://pad.sfconservancy.org/p/ols-5-graduations-3
       content: |-
@@ -620,7 +620,7 @@ weeks:
         \ that frustrate you - avoid them.\n      \n      \n        \n      \n   \
         \     "
     - date: July 18, 2022
-      time: '08:00'
+      time: '10:00'
       duration: 60 min
       notes: https://pad.sfconservancy.org/p/ols-5-graduations-4
       title: Final presentations & Graduation! - Group 4
@@ -633,7 +633,7 @@ weeks:
         \ that frustrate you - avoid them.\n      \n      \n        \n      \n   \
         \     "
     - date: July 20, 2022
-      time: '16:00'
+      time: '18:00'
       duration: 60 min
       notes: https://pad.sfconservancy.org/p/ols-5-graduations-5
       title: Final presentations & Graduation! - Group 5

--- a/_data/people.yaml
+++ b/_data/people.yaml
@@ -448,7 +448,7 @@ andreasancheztapia:
     (ENBT-JBRJ, Brazil). I am a member of RLadies and the Carpentries, and one of
     the leads for translation and localisation of The Turing Way.
   city: Merced, Ca
-  country: United Statesa
+  country: United States
   expertise:
   - Biodiversity informatics
   - Plant community ecology

--- a/_includes/week.md
+++ b/_includes/week.md
@@ -3,7 +3,7 @@
 ## {{ c.type }} call: {{ c.title }}
 
 {% if c.type != "Mentor-Mentee" and c.date %}
-<i class="fas fa-calendar-alt"></i> **Date**: {{ c.date }}{% if c.time %}, at [{{ c.time }} Universal Time](https://arewemeetingyet.com/UTC/{{ c.date | date: "%Y-%m-%d" }}/{{ c.time }}/
+<i class="fas fa-calendar-alt"></i> **Date**: {{ c.date }}{% if c.time %}, at [{{ c.time }} European Time](https://arewemeetingyet.com/Berlin/{{ c.date | date: "%Y-%m-%d" }}/{{ c.time }}/
 {{ cohort | upcase }}%20Cohort%20Call%20(Week%20{{ week-nb }})) ([<i class="fas fa-calendar-plus"></i> *Add to your calendar*]({{ c.calendar-event }})){% endif %}
 {% else %}
 <i class="fas fa-calendar-alt"></i> **Date**: During the week starting on {{ week.start }} (to define with mentors)
@@ -28,7 +28,8 @@
 
 **Resources**:
 - <i class="fas fa-clipboard"></i> [Notes]({{ c.notes }})
-- <i class="fab fa-youtube"></i> {% if c.recording %} [Recording]({{ c.recording }}) {% else %} Recording available on the [OLS YouTube channel]({{ site.youtube }}) after the call {% endif %}
+- <i class="fab fa-youtube"></i> {% if c.recording %} Resources
+<iframe src="{{ c.recording }}"></iframe> {% else %} Recording available on the [OLS YouTube channel]({{ site.youtube }}) after the call {% endif %}
 {% for r in c.resources %}
 - {% if r.type == 'slides' %}<i class="fas fa-file-powerpoint"></i>{% elsif r.type == 'document' %} <i class="fas fa-file"></i>{% elsif r.type == 'external-link' %} <i class="fas fa-external-link-square-alt"></i>{% endif %} {% if r.link %} [{{ r.title }}]({{ r.link }}){% else %} {{ r.title }}{% endif %}{% if r.type == 'slides' and r.speaker %}, by [{{ site.data.people[r.speaker].first-name }} {{ site.data.people[r.speaker].last-name }}](/{{ cohort }}#{{ r.speaker }}) {% endif %}
 {% endfor %}

--- a/_includes/week.md
+++ b/_includes/week.md
@@ -28,7 +28,7 @@
 
 **Resources**:
 - <i class="fas fa-clipboard"></i> [Notes]({{ c.notes }})
-- <i class="fab fa-youtube"></i> {% if c.recording %} Resources
+- <i class="fab fa-youtube"></i> {% if c.recording %} Recording
 <iframe src="{{ c.recording }}"></iframe> {% else %} Recording available on the [OLS YouTube channel]({{ site.youtube }}) after the call {% endif %}
 {% for r in c.resources %}
 - {% if r.type == 'slides' %}<i class="fas fa-file-powerpoint"></i>{% elsif r.type == 'document' %} <i class="fas fa-file"></i>{% elsif r.type == 'external-link' %} <i class="fas fa-external-link-square-alt"></i>{% endif %} {% if r.link %} [{{ r.title }}]({{ r.link }}){% else %} {{ r.title }}{% endif %}{% if r.type == 'slides' and r.speaker %}, by [{{ site.data.people[r.speaker].first-name }} {{ site.data.people[r.speaker].last-name }}](/{{ cohort }}#{{ r.speaker }}) {% endif %}


### PR DESCRIPTION
This PR fixes issue open-life-science/open-life-science.github.io#592.
I added an `<iframe>` tag where the video url is extracted.
Then, I put the proper embed code in the YouTube links.

![Embed_issue](https://user-images.githubusercontent.com/105166953/198884239-b593ff45-830a-464e-857c-4961b819a051.png)


**Note for Reviewers**
The video for Week 5 (Cohort 2) cannot play on external sites.

![EmbedPR](https://user-images.githubusercontent.com/105166953/198884245-346365e3-93c3-4dbc-9420-c16d6d04c6d8.png)

