### PR TITLE
Resolve alignment on "posts" cards

### DIFF
--- a/css/custom.scss
+++ b/css/custom.scss
@@ -239,11 +239,12 @@ $link-active: $link-hover;
     width: auto;
     overflow: hidden;
 
+    img {
+       max-height: 100%;
+       object-fit: cover;
+    }
   }
-  .image img {
-    max-height: 100%;
-    object-fit: cover;
-  }
+  
 
   .card-content {
     padding: 2rem;

--- a/css/custom.scss
+++ b/css/custom.scss
@@ -248,9 +248,10 @@ $link-active: $link-hover;
 
   .card-content {
     padding: 2rem;
-  }
-  .card-content .content .title {
-    height: 250px;
+    
+    .content .title {
+       height: 250px;
+    }
   }
 
   @include mobile() {

--- a/css/custom.scss
+++ b/css/custom.scss
@@ -23,16 +23,13 @@ $link-active: $link-hover;
   a {
     border-bottom: 0;
     color: $link;
-    font-weight: normal;
-    text-decoration: none;
-
+    font-weight: 500;
+  
     &:active,
     &:focus,
     &:hover {
       background: none;
       color: $link-hover;
-      text-decoration: none;
-      color: $link;
     }
   }
 }
@@ -117,9 +114,9 @@ $link-active: $link-hover;
 
 .content {
   a {
+    border-bottom: 2px solid $link;
     color: inherit;
-    font-weight: bold;
-    text-decoration: none;
+    font-weight: 500;
     padding: 2px;
 
     &:active,
@@ -128,7 +125,6 @@ $link-active: $link-hover;
       background-color: $link;
       border-radius: 2px;
       color: $white;
-      text-decoration: none;
     }
   }
 }
@@ -261,9 +257,6 @@ $link-active: $link-hover;
     }
 }
 
-
-
-
 .post {
   @include mobile() {
     .card {
@@ -302,14 +295,12 @@ $link-active: $link-hover;
       border-bottom: none;
       color: inherit;
       padding: 2px;
-      text-decoration: none;
 
       &:active,
       &:focus,
       &:hover {
         color: $black;
         background: none;
-        text-decoration: none;
       }
     }
   }
@@ -371,14 +362,11 @@ $link-active: $link-hover;
   a {
     border-bottom: none;
     color: inherit;
-    text-decoration: none;
 
     &:active,
     &:focus,
     &:hover {
       background: none;
-      text-decoration: none;
-      color: #48b87d;
     }
   }
 }

--- a/css/custom.scss
+++ b/css/custom.scss
@@ -277,6 +277,13 @@ $link-active: $link-hover;
         display: none;
       }
     }
+
+    .image {
+      height: auto;
+    }
+    .card-content .content .title {
+      height: auto;
+    }
   }
 
   @include tablet() {

--- a/css/custom.scss
+++ b/css/custom.scss
@@ -221,10 +221,6 @@ $link-active: $link-hover;
   }
 }
 
-.section {
-  margin: 2rem auto;
-  height: 70%;
-}
 .post {
     display: flex;
     justify-content: center;

--- a/css/custom.scss
+++ b/css/custom.scss
@@ -222,38 +222,36 @@ $link-active: $link-hover;
 }
 
 .post {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    flex-wrap: wrap;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-wrap: wrap;
 
-    .card {
-      background-color: #fff;
-      box-shadow: 0 0 2.5rem rgba(0, 0, 0, 0.28);
-      height: 100%;
-      width: fit-content;
-    }
+  .card {
+    background-color: #fff;
+    box-shadow: 0 0 2.5rem rgba(0, 0, 0, 0.28);
+    height: 100%;
+    width: fit-content;
+  }
 
-    .image {
-      height: 300px;
-      width: auto;
-      overflow: hidden;
+  .image {
+    height: 300px;
+    width: auto;
+    overflow: hidden;
 
-    }
-    .image img {
-        max-height: 100%;
-        object-fit: cover;
-    }
+  }
+  .image img {
+    max-height: 100%;
+    object-fit: cover;
+  }
 
-    .card-content {
-      padding: 2rem;
-    }
-    .card-content .content .title {
-      height: 250px;
-    }
-}
+  .card-content {
+    padding: 2rem;
+  }
+  .card-content .content .title {
+    height: 250px;
+  }
 
-.post {
   @include mobile() {
     .card {
       margin-bottom: 1em;

--- a/css/custom.scss
+++ b/css/custom.scss
@@ -243,7 +243,7 @@ $link-active: $link-hover;
     }
 
     .image {
-      height: 250px;
+      height: 300px;
       width: auto;
       overflow: hidden;
 
@@ -255,6 +255,9 @@ $link-active: $link-hover;
 
     .card-content {
       padding: 2rem;
+    }
+    .card-content .content .title {
+      height: 250px;
     }
 }
 


### PR DESCRIPTION
This PR piggybacks on #441.
It fixes issue #433.

A lovely improvement was made on the card by @oluwatobiBolu. I added a fixed height to the text, which further aligned the card content.
![post-alignment](https://user-images.githubusercontent.com/105166953/224271810-99dfd1f2-9098-4355-956f-305790d7db98.png)
![post-alignment2](https://user-images.githubusercontent.com/105166953/224271833-8d08a7b3-132b-4e7f-9be6-5b9f130044a9.png)

*Note for reviewers:* The `text-decoration: green;` has been removed. To know which texts are links is now difficult to tell.