### PR TITLE
BlogPost Schema Annotation for Posts

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -37,7 +37,7 @@
                 }
               },
             "datePublished": "
-              {%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
+              {%- assign date_format = site.minima.date_format | default: "%Y-%m-%d" -%}
               {{ page.date | date: date_format }}",
             "dateModified": ""
           }

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -23,14 +23,14 @@
             "headline": "{{ page.title }}",
             "description": "{{ page.excerpt | strip_html | strip_newlines | truncate: 200 }}",
             "image": "{{ page.image }}",
+            {% for author in page.authors %}
             "author": {
                   "@type": "Person",
-                  "name": "{{ page.authors | join: ", "}}",
+                  "name": "{{ author }}",
                   "url": 
-                  {% for author in page.authors %}
                   "{{ site.url }}/people#{{ author }}",
-                  {%- endfor -%}
-              },
+                },
+              {% endfor %}
             "publisher": {
               "@type": "Organization",
               "name": "Open Life Science",

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -40,8 +40,7 @@
                 }
               },
             "datePublished": "
-              {%- assign date_format = site.minima.date_format | default: "%Y-%m-%d" -%}
-              {{ page.date | date: date_format }}",
+              {{ page.date | date: "%Y-%m-%d" }}",
             "dateModified": ""
           }
         </script>

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -34,7 +34,7 @@
             "publisher": {
               "@type": "Organization",
               "name": "Open Life Science",
-              "url": "{{ site.url }}"
+              "url": "{{ site.url }}",
                 "logo": {
                   "@type": "ImageObject",
                   "url": "{{ site.url }}/images/logo.png"

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -26,7 +26,10 @@
             "author": {
                   "@type": "Person",
                   "name": "{{ page.authors | join: ", "}}",
-                  "url": "{{ site.url }}/people#{{ page.authors[0] }}"
+                  "url": 
+                  {% for author in page.authors %}
+                  "{{ site.url }}/people#{{ author }}",
+                  {%- endfor -%}
               },
             "publisher": {
               "@type": "Organization",

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -30,7 +30,7 @@
               },
             "publisher": {
               "@type": "Organization",
-              "name": "Openlifescience",
+              "name": "Open Life Science",
                 "logo": {
                   "@type": "ImageObject",
                   "url": "{{ site.url }}"

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -40,7 +40,7 @@
                   "url": "{{ site.url }}/images/logo.png"
                 }
               },
-            "datePublished": "{{ page.date | date: "%Y-%m-%d" }}",
+            "datePublished": "{{ page.date | date: "%Y-%m-%d" }}"
           }
         </script>
         {% endif %}

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -29,8 +29,8 @@
               "@type": "Person",
               "name": "{{ site.data.people[author].first-name }} {{ site.data.people[author].last-name }}",
               "url": "{{ site.url }}/people#{{ author }}"
-              }],
-            {%- endfor -%}
+              },
+            {%- endfor -%}]
             "publisher": {
               "@type": "Organization",
               "name": "Open Life Science",

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -10,6 +10,39 @@
         {% if page.description %}<meta name="description" content="{{ page.description }}">{% endif %}
         <link href="{{ site.baseurl }}/css/custom.css" rel="stylesheet" type="text/css">
         <link rel="stylesheet" href="https://cdn.rawgit.com/jpswalsh/academicons/master/css/academicons.min.css">
+        <!--Below is the schema annotation for blogposts-->
+        {% if page.layout == 'post' %}
+        <script type="application/ld+json">
+          {
+            "@context": "https://schema.org",
+            "@type": "BlogPosting",
+            "mainEntityOfPage": {
+              "@type": "WebPage",
+              "@id": "{{ site.url }}/posts/"
+              },
+            "headline": "{{ page.title }}",
+            "description": "{{ page.excerpt | strip_html | strip_newlines | truncate: 200 }}",
+            "image": "{{ page.image }}",
+            "author": {
+                  "@type": "Person",
+                  "name": "{{ page.authors | join: ", "}}",
+                  "url": "{{ site.url }}/people#{{ page.authors[0] }}"
+              },
+            "publisher": {
+              "@type": "Organization",
+              "name": "Openlifescience",
+                "logo": {
+                  "@type": "ImageObject",
+                  "url": "{{ site.url }}"
+                }
+              },
+            "datePublished": "
+              {%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
+              {{ page.date | date: date_format }}",
+            "dateModified": ""
+          }
+        </script>
+        {% endif %}
     </head>
 
     <body>

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -35,7 +35,7 @@
               "@type": "Organization",
               "name": "Open Life Science",
               "url": "{{ site.url }}",
-                "logo": {
+              "logo": {
                   "@type": "ImageObject",
                   "url": "{{ site.url }}/images/logo.png"
                 }

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -29,7 +29,11 @@
               "@type": "Person",
               "name": "{{ site.data.people[author].first-name }} {{ site.data.people[author].last-name }}",
               "url": "{{ site.url }}/people#{{ author }}"
-              },
+                {%- if forloop.last -%}
+                  }
+                  {%- else -%}
+                  },
+                {% endif %}
             {%- endfor -%}]
             "publisher": {
               "@type": "Organization",

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -29,8 +29,8 @@
               "@type": "Person",
               "name": "{{ site.data.people[author].first-name }} {{ site.data.people[author].last-name }}",
               "url": "{{ site.url }}/people#{{ author }}"
-              },
-            {%- endfor -%}]
+              }],
+            {%- endfor -%}
             "publisher": {
               "@type": "Organization",
               "name": "Open Life Science",

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -28,7 +28,7 @@
               {
               "@type": "Person",
               "name": "{{ site.data.people[author].first-name }} {{ site.data.people[author].last-name }}",
-              "url": "{{ site.url }}/people#{{ author }}",
+              "url": "{{ site.url }}/people#{{ author }}"
               },
             {%- endfor -%}]
             "publisher": {

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -23,23 +23,24 @@
             "headline": "{{ page.title }}",
             "description": "{{ page.excerpt | strip_html | strip_newlines | truncate: 200 }}",
             "image": "{{ page.image }}",
-            {% for author in page.authors %}
-            "author": {
-                  "@type": "Person",
-                  "name": "{{ author }}",
-                  "url": "{{ site.url }}/people#{{ author }}",
-                },
-              {% endfor %}
+            "author": [
+            {%- for author in page.authors -%}
+              {
+              "@type": "Person",
+              "name": "{{ site.data.people[author].first-name }} {{ site.data.people[author].last-name }}",
+              "url": "{{ site.url }}/people#{{ author }}",
+              },
+            {%- endfor -%}]
             "publisher": {
               "@type": "Organization",
               "name": "Open Life Science",
+              "url": "{{ site.url }}"
                 "logo": {
                   "@type": "ImageObject",
                   "url": "{{ site.url }}/images/logo.png"
                 }
               },
             "datePublished": "{{ page.date | date: "%Y-%m-%d" }}",
-            "dateModified": ""
           }
         </script>
         {% endif %}

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -34,7 +34,7 @@
                   {%- else -%}
                   },
                 {% endif %}
-            {%- endfor -%}]
+            {%- endfor -%}],
             "publisher": {
               "@type": "Organization",
               "name": "Open Life Science",

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -39,8 +39,7 @@
                   "url": "{{ site.url }}/images/logo.png"
                 }
               },
-            "datePublished": "
-              {{ page.date | date: "%Y-%m-%d" }}",
+            "datePublished": "{{ page.date | date: "%Y-%m-%d" }}",
             "dateModified": ""
           }
         </script>

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -27,8 +27,7 @@
             "author": {
                   "@type": "Person",
                   "name": "{{ author }}",
-                  "url": 
-                  "{{ site.url }}/people#{{ author }}",
+                  "url": "{{ site.url }}/people#{{ author }}",
                 },
               {% endfor %}
             "publisher": {

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -33,7 +33,7 @@
               "name": "Open Life Science",
                 "logo": {
                   "@type": "ImageObject",
-                  "url": "{{ site.url }}"
+                  "url": "{{ site.url }}/images/logo.png"
                 }
               },
             "datePublished": "

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -2,37 +2,4 @@
 layout: default
 ---
 
-<script type="application/ld+json">
-{
-    "@context": "https://schema.org",
-    "@type": "BlogPosting",
-    "mainEntityOfPage":
-    "@type": "WebPage",
-    "@id": "{{ site.url }}/posts/"
-    },
-
-    "headline": "{{ page.title }}",
-    "description": "{{ page.excerpt }}",
-    "image": "{{ page.image }}",  
-    "author": {
-        "@type": "Person",
-        "name": "{{ page.authors | join: ", "}}",
-        "url": "{{ site.url }}/people#{{ page.authors[0] }}"
-    },
-
-    "publisher": {
-        "@type": "Organization",
-        "name": "Openlifescience",
-        "logo": {
-            "@type": "ImageObject",
-            "url": ""
-        }
-    },
-
-    "datePublished": "
-        {%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
-        {{ page.date | date: date_format }}",
-    "dateModified": ""
-</script>
-
 {{content}}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -2,4 +2,37 @@
 layout: default
 ---
 
+<script type="application/ld+json">
+{
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    "mainEntityOfPage":
+    "@type": "WebPage",
+    "@id": "{{ site.url }}/posts/"
+    },
+
+    "headline": "{{ page.title }}",
+    "description": "{{ page.excerpt }}",
+    "image": "{{ page.image }}",  
+    "author": {
+        "@type": "Person",
+        "name": "{{ page.authors | join: ", "}}",
+        "url": "{{ site.url }}/people#{{ page.authors[0] }}"
+    },
+
+    "publisher": {
+        "@type": "Organization",
+        "name": "Openlifescience",
+        "logo": {
+            "@type": "ImageObject",
+            "url": ""
+        }
+    },
+
+    "datePublished": "
+        {%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
+        {{ page.date | date: date_format }}",
+    "dateModified": ""
+</script>
+
 {{content}}


### PR DESCRIPTION
This PR resolves issue #591.
A script was added to automatically generate structured data for all the pages with the layout "post." This should help our blogs rank higher in searches.

![BlogPost-Schema](https://user-images.githubusercontent.com/105166953/233869429-805dc55e-0224-415d-a359-eb2f4ebb8d26.png)

**Note for reviewers:**  See also the suggested fix for a similar PR (#469). Thank you!