### PR TITLE
Update email: team@we-are-ols.org

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ Here are a few ways you can get started with contributing to this program.
 4. Write about your [Mozilla Open Leader project and share with our participants](https://openlifesci.org/posts).
 5. Contribute your blog posts that could be relevant for our participants. You can [check out our the stories](https://openlifesci.org/posts) to get an idea of what we post there.
 
-Do you have other ideas for contributions? Contact the organisers (team@openlifesci.org).
+Do you have other ideas for contributions? Contact the organisers ([{{ site.email }}](mailto:{{ site.email }})).
 
 ## How can I contribute in "advanced" mode?
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ Here are a few ways you can get started with contributing to this program.
 4. Write about your [Mozilla Open Leader project and share with our participants](https://openlifesci.org/posts).
 5. Contribute your blog posts that could be relevant for our participants. You can [check out our the stories](https://openlifesci.org/posts) to get an idea of what we post there.
 
-Do you have other ideas for contributions? Contact the organisers ([{{ site.email }}](mailto:{{ site.email }})).
+Do you have other ideas for contributions? Contact the organisers ([team@we-are-ols.org](mailto:team@we-are-ols.org)).
 
 ## How can I contribute in "advanced" mode?
 

--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,7 @@ title: "OLS"
 description: >
   A mentoring & training program for Open Science ambassadors
 logo: ''
-email: team@openlifesci.org
+email: team@we-are-ols.org
 repository: open-life-science/open-life-science.github.io
 twitter: openlifesci
 gitter: open-life-sci/community

--- a/_data/links.yaml
+++ b/_data/links.yaml
@@ -40,7 +40,7 @@ items:
     icon: fas fa-mail-bulk
   -
     text: Write us via email
-    link: mailto:team@openlifesci.org
+    link: mailto:team@we-are-ols.org
     icon: fas fa-at
   -
     text: Explore our GitHub repositories

--- a/_posts/2020-03-16-covid-response.md
+++ b/_posts/2020-03-16-covid-response.md
@@ -32,7 +32,7 @@ Looking for some lighter or more productive uses of your time? We have a shortli
 - Check out the Kaggle space for R users: [Novel Corona Virus dataset](https://www.kaggle.com/sudalairajkumar/novel-corona-virus-2019-dataset/tasks?taskId=508&utm_medium=email&utm_source=intercom&utm_campaign=tasks-award-march-2020)
 - Visualise Coronavirus Disease (COVID-19) – [Statistics and Research by our world in data](https://ourworldindata.org/coronavirus)
 
-In case of any concern - please contact us on [team@we-are-ols.org](mailto:team@we-are-ols.org) with any queries or worries - no question too small! 
+In case of any concern - please contact us on [{{ site.email }}](mailto:{{ site.email }}) with any queries or worries - no question too small! 
 
 **Stay safe and wash your hands, folks! (and stop touching your face!!)**
 

--- a/_posts/2020-03-16-covid-response.md
+++ b/_posts/2020-03-16-covid-response.md
@@ -32,7 +32,7 @@ Looking for some lighter or more productive uses of your time? We have a shortli
 - Check out the Kaggle space for R users: [Novel Corona Virus dataset](https://www.kaggle.com/sudalairajkumar/novel-corona-virus-2019-dataset/tasks?taskId=508&utm_medium=email&utm_source=intercom&utm_campaign=tasks-award-march-2020)
 - Visualise Coronavirus Disease (COVID-19) – [Statistics and Research by our world in data](https://ourworldindata.org/coronavirus)
 
-In case of any concern - please contact us on [team@openlifesci.org](mailto:team@openlifesci.org) with any queries or worries - no question too small! 
+In case of any concern - please contact us on [team@we-are-ols.org](mailto:team@we-are-ols.org) with any queries or worries - no question too small! 
 
 **Stay safe and wash your hands, folks! (and stop touching your face!!)**
 

--- a/_posts/2021-12-13-ols-5-promotion.md
+++ b/_posts/2021-12-13-ols-5-promotion.md
@@ -35,7 +35,7 @@ With this additional call, we want to offer extra support for folks interested i
 
 A recording from a previous webinar is available on our YouTube channel ([video link](https://youtu.be/rksUzRDFn20)).
 
-Please feel free to contact the OLS team for more information by emailing ([team@openlifesci.org](mailto:team@openlifesci.org)) or connecting on Twitter [@openlifesci](https://twitter.com/openlifesci).
+Please feel free to contact the OLS team for more information by emailing ([{{ site.email }}](mailto:{{ site.email }})) or connecting on Twitter [@openlifesci](https://twitter.com/openlifesci).
 
 ## Help us share about OLS-5 in your network!
 
@@ -87,7 +87,7 @@ Experts have existing experience in a relevant subject area and may be invited t
 
 ### Connect with us for more questions!
     
-Please contact the OLS team ([team@openlifesci.org](mailto:team@openlifesci.org)) for any additional information or to share your ideas for OLS-5.
+Please contact the OLS team ([{{ site.email }}](mailto:{{ site.email }})) for any additional information or to share your ideas for OLS-5.
 
 ### Other ways to connect!
 

--- a/_posts/2021-12-21-wt-open-research-fund.md
+++ b/_posts/2021-12-21-wt-open-research-fund.md
@@ -36,10 +36,10 @@ Drawing from previous graduates, existing collaborators and volunteers in the OL
 
 ## Collaborating with Mission-Aligned Organisations
 
-We are looking to establish partnerships with mission-aligned organisations and projects interested in collaborating with OLS and adopting our training models in their institutions. This includes funder and research institutes seeking to support open science training for their funded projects or interested in supporting OLS cohort activities. Fruitful partnerships will enable the growth of OLS by helping explore new impact pathways to reach communities, particularly those currently underrepresented in open science. To express early interest in a partnership, please email team@openlifesci.org.
+We are looking to establish partnerships with mission-aligned organisations and projects interested in collaborating with OLS and adopting our training models in their institutions. This includes funder and research institutes seeking to support open science training for their funded projects or interested in supporting OLS cohort activities. Fruitful partnerships will enable the growth of OLS by helping explore new impact pathways to reach communities, particularly those currently underrepresented in open science. To express early interest in a partnership, please email {{ site.email }}.
 
 ## Thank you! Connect with us.
 
 Thanks to all the OLS members - mentors, participants, experts, and speakers - who have supported the last four cohorts. We are very grateful for your support and engagement in the programme. We are proud of what we have done together and look forward to sharing this space for learning and growth in the coming years.
 
-For any inquiries regarding the OLS program, upcoming job vacancy and/or partnerships, please email [team@openlifesci.org](mailto:team@openlifesci.org).
+For any inquiries regarding the OLS program, upcoming job vacancy and/or partnerships, please email [{{ site.email }}](mailto:{{ site.email }}).

--- a/_posts/2022-01-27-runway-to-sustainability-czi-funding.md
+++ b/_posts/2022-01-27-runway-to-sustainability-czi-funding.md
@@ -37,7 +37,7 @@ While we’ve been a registered company for some time now, we’re having to do 
 - **Governance planning and establishment**: As mentioned in our previous blog post, we aspire to be radically transparent in our governance. With you, we want to build and strengthen diverse pathways to community leadership, to ensure accountability and capacity to continue to serve our and other open communities.
 - **Collaborations**: Are you working in research or a related domain, and interested in collaborating, forming institutional partnerships, or hiring our services?
 
-For all of these - please do contact team@openlifesci.org to set up a chat!
+For all of these - please do contact {{ site.email }} to set up a chat!
 
 ## In conclusion:
 

--- a/_posts/2022-12-14-OLS-Fellowships.md
+++ b/_posts/2022-12-14-OLS-Fellowships.md
@@ -43,6 +43,6 @@ During OLS residency Mayya will work with OLS on the marketing and communication
 
 After initial fellowship terms complete, we’re taking a leaf from the Software Sustainability Institute’s “Once a fellow, always a fellow” book. Whilst this initial cohort of Resident Fellows is highly experimental (and we’re grateful to Mayya and Patricia for being kind enough to let us learn about the process with their help), we hope this will only be the start of something exciting and longer term around rewarding our community members, working closely with people we care about, and building capacity in open and compassionate research community building. 
 
-If you’re interested in becoming a fellow in the future, or learning more about Open Life Science’s mentorship program, please consider applying for OLS-7 (if you haven’t joined as a community member in a previous cohort), or contact team@openlifesci.org to discuss your ideas. 
+If you’re interested in becoming a fellow in the future, or learning more about Open Life Science’s mentorship program, please consider applying for OLS-7 (if you haven’t joined as a community member in a previous cohort), or contact [{{ site.email }}](mailto:{{ site.email }}) to discuss your ideas. 
 
-If you’re interested in capacity building in open science and would like to help fund additional Resident Fellows or run a similar fellowship in-house at your organisation, we’re all ears. Contact team@openlifesci.org and we’ll set up a chat! 
+If you’re interested in capacity building in open science and would like to help fund additional Resident Fellows or run a similar fellowship in-house at your organisation, we’re all ears. Contact [{{ site.email }}](mailto:{{ site.email }}) and we’ll set up a chat! 

--- a/_posts/2022-12-15-OLS-SSI-Fellows.md
+++ b/_posts/2022-12-15-OLS-SSI-Fellows.md
@@ -48,4 +48,4 @@ Reina plans a case study on [LA-CoNGA physics](https://laconga.redclara.net/en/h
 
 *We can’t wait to welcome Andrea, Melissa and Reina as OLS/SSI Fellows and hope you do the same!*
 
-If you’re interested in capacity building in open science and would like to help fund additional Fellows or run a similar fellowship in-house at your organisation, we’re all ears. Contact [team@openlifesci.org](mailto:team@openlifesci.org) and we’ll set up a chat! 
+If you’re interested in capacity building in open science and would like to help fund additional Fellows or run a similar fellowship in-house at your organisation, we’re all ears. Contact [{{ site.email }}](mailto:{{ site.email }}) and we’ll set up a chat! 

--- a/_posts/2023-06-12-ols-7-graduations-and-ols-8-call.md
+++ b/_posts/2023-06-12-ols-7-graduations-and-ols-8-call.md
@@ -67,7 +67,7 @@ providing opportunities to meet in person every month during the Open Seeds OLS-
 
 - **Get inspirations from the previous projects**: We encourage you to watch the OLS graduations from the last four cohorts [on YouTube](https://www.youtube.com/openlifesci) to get a sense of what the project will be like (direct link to [OLS-5 graduation calls](https://youtu.be/9XMGsmekddM))).
 
-Meanwhile, if you have any further questions or any advice that might be helpful, please email the OLS team ([team@openlifesci.org](mailto:team@openlifesci.org)).
+Meanwhile, if you have any further questions or any advice that might be helpful, please email the OLS team ([{{ site.email }}](mailto:{{ site.email }})).
 
 All the best. 
 We can't wait to read your project proposals!

--- a/consulting.md
+++ b/consulting.md
@@ -55,7 +55,7 @@ The scope of the workshop does not include teaching members of marginalised grou
 
 ### Workshop Format, Content & Logistics
 
-OLS Ally Skills workshops are offered to external organisations and collaborators for a fee. Please email the OLS team (team@openlifesci.org) to express your interest to host and request a quote. Since the OLS team members manage two 16-week long training and mentoring cohorts each year, it is important to get in touch with them several weeks in advance to share your plan and identify potential dates for the workshops.
+OLS Ally Skills workshops are offered to external organisations and collaborators for a fee. Please email the OLS team ([{{ site.email }}](mailto:{{ site.email }})) to express your interest to host and request a quote. Since the OLS team members manage two 16-week long training and mentoring cohorts each year, it is important to get in touch with them several weeks in advance to share your plan and identify potential dates for the workshops.
 
 Customisation of our workshops: Our training is designed for researchers and scientific communities. We are happy to discuss if specific customisation in our workshop materials might be required for external organisations to represent their workspace culture. 
 


### PR DESCRIPTION
This PR addresses issue #659, in part.

The website email is now _team@we-are-ols.org_, rather than _team@openlifesci.org_.

**Future action:** Update URL as well (as soon as we-are-ols.org starts to work).