### PR TITLE
Change organisers' email address in schedule page

### DIFF
--- a/_ols-2/speaker-guide.md
+++ b/_ols-2/speaker-guide.md
@@ -34,7 +34,7 @@ All our members, participants and speakers are expected to abide by our [Code of
 
 If you experience or witness any unacceptable behaviour, or have any other concerns, please report it by contacting the organisers - Bérénice, Malvika and Yo. ([{{ site.email }}](mailto:{{ site.email }})).
 
-To report an issue involving one of the organisers, please email one of the members individually ([berenice@openlifesci.org](mailto:berenice@openlifesci.org), [malvika@openlifesci.org](mailto:malvika@openlifesci.org), [yo@openlifesci.org](mailto:yo@openlifesci.org)).
+To report an issue involving one of the organisers, please email one of the members individually ([berenice@we-are-ols.org](mailto:berenice@we-are-ols.org), [malvika@we-are-ols.org](mailto:malvika@we-are-ols.org), [yo@we-are-ols.org](mailto:yo@we-are-ols.org)).
 
 # About the cohort calls
 

--- a/_ols-3/speaker-guide.md
+++ b/_ols-3/speaker-guide.md
@@ -32,7 +32,7 @@ All our members, participants and speakers are expected to abide by our [Code of
 
 If you experience or witness any unacceptable behaviour, or have any other concerns, please report it by contacting the organisers - Bérénice, Malvika and Yo. ([{{ site.email }}](mailto:{{ site.email }})).
 
-To report an issue involving one of the organisers, please email one of the members individually ([berenice@openlifesci.org](mailto:berenice@openlifesci.org), [malvika@openlifesci.org](mailto:malvika@openlifesci.org), [yo@openlifesci.org](mailto:yo@openlifesci.org)).
+To report an issue involving one of the organisers, please email one of the members individually ([berenice@owe-are-ols.org](mailto:berenice@owe-are-ols.org), [malvika@owe-are-ols.org](mailto:malvika@owe-are-ols.org), [yo@owe-are-ols.org](mailto:yo@owe-are-ols.org)).
 
 # About the cohort calls
 

--- a/_ols-4/speaker-guide.md
+++ b/_ols-4/speaker-guide.md
@@ -32,7 +32,7 @@ All our members, participants and speakers are expected to abide by our [Code of
 
 If you experience or witness any unacceptable behaviour, or have any other concerns, please report it by contacting the organisers - Bérénice, Malvika and Yo. ([{{ site.email }}](mailto:{{ site.email }})).
 
-To report an issue involving one of the organisers, please email one of the members individually ([berenice@openlifesci.org](mailto:berenice@openlifesci.org), [malvika@openlifesci.org](mailto:malvika@openlifesci.org), [yo@openlifesci.org](mailto:yo@openlifesci.org)), [emmy@openlifesci.org](mailto:emmy@openlifesci.org)).
+To report an issue involving one of the organisers, please email one of the members individually ([berenice@we-are-ols.org](mailto:berenice@we-are-ols.org), [malvika@we-are-ols.org](mailto:malvika@we-are-ols.org), [yo@we-are-ols.org](mailto:yo@we-are-ols.org)), [emmy@we-are-ols.org](mailto:emmy@we-are-ols.org)).
 
 # About the cohort calls
 

--- a/_ols-5/speaker-guide.md
+++ b/_ols-5/speaker-guide.md
@@ -30,7 +30,7 @@ All our members, participants and speakers are expected to abide by our [Code of
 
 If you experience or witness any unacceptable behaviour, or have any other concerns, please report it by contacting the organisers - Bérénice, Malvika and Yo. ([{{ site.email }}](mailto:{{ site.email }})).
 
-To report an issue involving one of the organisers, please email one of the members individually ([berenice@openlifesci.org](mailto:berenice@openlifesci.org), [malvika@openlifesci.org](mailto:malvika@openlifesci.org), [yo@openlifesci.org](mailto:yo@openlifesci.org)), [emmy@openlifesci.org](mailto:emmy@openlifesci.org)).
+To report an issue involving one of the organisers, please email one of the members individually ([berenice@we-are-ols.org](mailto:berenice@we-are-ols.org), [malvika@we-are-ols.org](mailto:malvika@we-are-ols.org), [yo@we-are-ols.org](mailto:yo@we-are-ols.org)), [emmy@we-are-ols.org](mailto:emmy@we-are-ols.org)).
 
 # About the cohort calls
 

--- a/_ols-6/speaker-guide.md
+++ b/_ols-6/speaker-guide.md
@@ -32,7 +32,7 @@ All our members, participants and speakers are expected to abide by our [Code of
 
 If you experience or witness any unacceptable behaviour, or have any other concerns, please report it by contacting the organisers - Bérénice, Malvika and Yo. ([{{ site.email }}](mailto:{{ site.email }})).
 
-To report an issue involving one of the organisers, please email one of the members individually ([berenice@openlifesci.org](mailto:berenice@openlifesci.org), [malvika@openlifesci.org](mailto:malvika@openlifesci.org), [yo@openlifesci.org](mailto:yo@openlifesci.org)), [emmy@openlifesci.org](mailto:emmy@openlifesci.org)).
+To report an issue involving one of the organisers, please email one of the members individually ([berenice@we-are-ols.org](mailto:berenice@we-are-ols.org), [malvika@we-are-ols.org](mailto:malvika@we-are-ols.org), [yo@we-are-ols.org](mailto:yo@we-are-ols.org)), [emmy@we-are-ols.org](mailto:emmy@we-are-ols.org)).
 
 # About the cohort calls
 

--- a/_ols-7/speaker-guide.md
+++ b/_ols-7/speaker-guide.md
@@ -32,7 +32,7 @@ All our members, participants and speakers are expected to abide by our [Code of
 
 If you experience or witness any unacceptable behaviour, or have any other concerns, please report it by contacting the organisers - Bérénice, Malvika and Yo. ([{{ site.email }}](mailto:{{ site.email }})).
 
-To report an issue involving one of the organisers, please email one of the members individually ([berenice@openlifesci.org](mailto:berenice@openlifesci.org), [malvika@openlifesci.org](mailto:malvika@openlifesci.org), [yo@openlifesci.org](mailto:yo@openlifesci.org)), [emmy@openlifesci.org](mailto:emmy@openlifesci.org)).
+To report an issue involving one of the organisers, please email one of the members individually ([berenice@we-are-ols.org](mailto:berenice@we-are-ols.org), [malvika@we-are-ols.org](mailto:malvika@we-are-ols.org), [yo@we-are-ols.org](mailto:yo@we-are-ols.org)), [emmy@we-are-ols.org](mailto:emmy@we-are-ols.org)).
 
 # About the cohort calls
 

--- a/_ols-8/speaker-guide.md
+++ b/_ols-8/speaker-guide.md
@@ -32,7 +32,7 @@ All our members, participants and speakers are expected to abide by our [Code of
 
 If you experience or witness any unacceptable behaviour, or have any other concerns, please report it by contacting the organisers - Bérénice, Malvika and Yo. ([{{ site.email }}](mailto:{{ site.email }})).
 
-To report an issue involving one of the organisers, please email one of the members individually ([berenice@openlifesci.org](mailto:berenice@openlifesci.org), [malvika@openlifesci.org](mailto:malvika@openlifesci.org), [yo@openlifesci.org](mailto:yo@openlifesci.org)), [emmy@openlifesci.org](mailto:emmy@openlifesci.org)).
+To report an issue involving one of the organisers, please email one of the members individually ([berenice@we-are-ols.org](mailto:berenice@we-are-ols.org), [malvika@we-are-ols.org](mailto:malvika@we-are-ols.org), [yo@we-are-ols.org](mailto:yo@we-are-ols.org)), [emmy@we-are-ols.org](mailto:emmy@we-are-ols.org)).
 
 # About the cohort calls
 

--- a/_posts/2020-10-05-ally-skills-training.md
+++ b/_posts/2020-10-05-ally-skills-training.md
@@ -34,7 +34,7 @@ Open Life Science is a non-profit organisation. Proceeds will be used to pay tra
 
 Our goals with this workshop are to make ally skills more accessible to others as well as raising money for OLS, but we do not wish to exclude anyone who would find it genuinely difficult to pay for this workshop. If you would like to participate and your organisation is unable to sponsor a full-price ticket, please fill out [this short form to request a reduced-price](https://forms.gle/fewzxJZBnBVTvwu28).
 
-Tickets are free to OLS mentors, experts, mentees/project leads, and call hosts - approach us by emailing team@openlifesci.org for a ticket discount code.
+Tickets are free to OLS mentors, experts, mentees/project leads, and call hosts - approach us by emailing team@we-are-ols.org for a ticket discount code.
 
 ## Who will be delivering this workshop:
 


### PR DESCRIPTION
This PR addresses part of issue #659.
In PR #660, the website email was changed from [team@openlifesci.org](mailto:team@openlifesci.org) to [team@we-are-ols.org](mailto:team@we-are-ols.org).
Here, the email addresses of organisers have been changed as well.

![Screenshot (563)](https://github.com/open-life-science/open-life-science.github.io/assets/105166953/58ad7037-c826-4979-b16c-8739617250c0)

**Future action:** Update website URL as well (as soon as we-are-ols.org starts to work).