### PR TITLE
Update github link of logo creator

### DIFF
--- a/_includes/default-footer.html
+++ b/_includes/default-footer.html
@@ -42,7 +42,7 @@
           </p>
           <p>
             The logo was originally designed by
-            <a href="https://github.com/htmluke">Lucas Emanoell Medeiros e Silva</a> and
+            <a href="https://github.com/lukethebaka">Lucas Emanoell Medeiros e Silva</a> and
             then adapted by the team.
           </p>
           <p>


### PR DESCRIPTION
This PR addresses the issue of the wrong Github profile in the website's footer.

**Observed behaviour:**
In the footer is a [link](https://github.com/htmluke) that should ideally lead to the Github profile of the creator of OLS's logo.
The current link found there leads to a **404 page**. 

**Expected behaviour:**
A link to the [actual github account](https://github.com/lukethebaka) has been used to replace the other.

Thanks for the review. 🙏 