### PR TITLE
Expanding consultancy page(s)

### DIFF
--- a/_data/consulting.yaml
+++ b/_data/consulting.yaml
@@ -1,0 +1,19 @@
+---
+- name: Ally Skills
+  url: /consulting/ally-skills
+  description:  |
+        Multiple OLS community members are trained Ally skill facilitators. 
+        We offer ad-hoc in-house workshops (starting at £2,000 GBP for universities) 
+        as well as anyone-may-register workshops...
+
+- name: Accessibilty Consulting
+  url: /consulting/accessibility-consulting
+  description:  |
+        OLS has a long history of captioning videos as part of running online inclusive calls. 
+        Currently, we offer scientific video preparation and captioning, including... 
+        
+- name: Organisational Leadership
+  url: /consulting/organisational-leadership
+  description:  |
+        We offer a range of workshop options to help you think through 
+        setting up governance for your organisation...

--- a/_data/consulting.yaml
+++ b/_data/consulting.yaml
@@ -1,19 +1,19 @@
 ---
 - name: Ally Skills
-  url: /consulting/ally-skills
+  url: /consulting/ally-skills.html
   description:  |
         Multiple OLS community members are trained Ally skill facilitators. 
         We offer ad-hoc in-house workshops (starting at £2,000 GBP for universities) 
         as well as anyone-may-register workshops...
 
 - name: Accessibilty Consulting
-  url: /consulting/accessibility-consulting
+  url: /consulting/accessibility-consulting.html
   description:  |
         OLS has a long history of captioning videos as part of running online inclusive calls. 
         Currently, we offer scientific video preparation and captioning, including... 
         
 - name: Organisational Leadership
-  url: /consulting/organisational-leadership
+  # url: /consulting/organisational-leadership.html
   description:  |
         We offer a range of workshop options to help you think through 
         setting up governance for your organisation...

--- a/_data/consulting.yaml
+++ b/_data/consulting.yaml
@@ -6,7 +6,7 @@
         We offer ad-hoc in-house workshops (starting at £2,000 GBP for universities) 
         as well as anyone-may-register workshops...
 
-- name: Accessibilty Consulting
+- name: Video call accessibility
   url: /consulting/accessibility-consulting.html
   description:  |
         OLS has a long history of captioning videos as part of running online inclusive calls. 

--- a/_includes/default-header.html
+++ b/_includes/default-header.html
@@ -67,7 +67,7 @@
           <div class="navbar-item has-dropdown is-hoverable">
             <a class="navbar-link" href="{% link about.md %}">Services</a>
             <div class="navbar-dropdown">
-              <a class="navbar-item" href="{% link consulting.md %}"> Consulting </a>
+              <a class="navbar-item" href="{% link consulting/index.md %}"> Consulting </a>
               <!--<a class="navbar-item" href="/training"> On demand training </a>
               <a class="navbar-item" href="/"> Fiscal hosting </a>-->
             </div>

--- a/consulting/accessibility-consulting.md
+++ b/consulting/accessibility-consulting.md
@@ -1,0 +1,21 @@
+---
+layout: page
+title: Accessibility Consulting
+image: https://images.unsplash.com/photo-1429962714451-bb934ecdc4ec?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1650&q=80
+photos:
+  name: Anthony DELANOIX
+  license: Unsplash License
+  url: https://unsplash.com/photos/hzgs56Ze49s
+---
+
+## Scientific video captioning and live streaming / accessibility consulting.
+
+OLS has a long history of captioning videos as part of running online inclusive calls. Currently, we offer scientific video preparation and captioning, including: 
+
+- Transcript preparation and correction (mixture of online automatic captioning, with human corrections for quality control and accent/scientific terminology correction). 
+- Upload and segmentation. 
+- Live stream advice for multilingual and hearing-accessible calls
+
+Sample work: [youtube.com/openlifesci]({{ site.youtube }})
+
+Rates start at $75USD / hour for video captioning. 

--- a/consulting/ally-skills.md
+++ b/consulting/ally-skills.md
@@ -1,24 +1,12 @@
 ---
 layout: page
-title: Consulting
+title: Ally Skills
 image: https://images.unsplash.com/photo-1429962714451-bb934ecdc4ec?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1650&q=80
 photos:
   name: Anthony DELANOIX
   license: Unsplash License
   url: https://unsplash.com/photos/hzgs56Ze49s
 ---
-
-## Scientific video captioning and live streaming / accessibility consulting.
-
-OLS has a long history of captioning videos as part of running online inclusive calls. Currently, we offer scientific video preparation and captioning, including: 
-
-- Transcript preparation and correction (mixture of online automatic captioning, with human corrections for quality control and accent/scientific terminology correction). 
-- Upload and segmentation. 
-- Live stream advice for multilingual and hearing-accessible calls
-
-Sample work: [youtube.com/openlifesci]({{ site.youtube }})
-
-Rates start at $75USD / hour for video captioning. 
 
 ## Ally Skills
 

--- a/consulting/index.md
+++ b/consulting/index.md
@@ -1,0 +1,27 @@
+---
+layout: page
+title: Consulting
+image: https://images.unsplash.com/photo-1429962714451-bb934ecdc4ec?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1650&q=80
+photos:
+  name: Anthony DELANOIX
+  license: Unsplash License
+  url: https://unsplash.com/photos/hzgs56Ze49s
+---
+
+<div class="container">
+  <section class="section">
+    <h1 class="title">Our Consulting Services</h1>
+    <div class="columns is-multiline">
+      {% for service in site.data.consulting %}
+        <div class="column is-one-third">
+          <div class="card">
+            <div class="card-content">
+              <h2 class="title is-4"><a href="{{ service.url }}">{{ service.name }}</a></h2>
+              <p class="content">{{ service.description }}</p>
+            </div>
+          </div>
+        </div>
+      {% endfor %}
+    </div>
+  </section>
+</div>


### PR DESCRIPTION
This PR addresses issue #678.
Following the request to add more consultancy services to the website, a new index page is now under construction.

**Changes made:**
1. Created a `/consulting` subfolder to house all the individual services offered by OLS.
2. Added an `index.md` file to the newly created subfolder which will be the new landing page.
3. Stored the information about services in a `consulting.yaml` file.
4. Displayed the stored information on small cards in the index page (i.e /consulting). On these cards are links to individual services.
5. Used separate _service-x.md_ files for more consultancy pages (with url `/consulting/ally-skills`).

![Screenshot (573)](https://github.com/open-life-science/open-life-science.github.io/assets/105166953/ec8d4e0b-5199-42b3-b945-bdd7473752cd)

**Questions/Comment for reviewer(s):**
1. Is there any info missing from the cards that should be added?
2. Currently, the same hero image is used across all the pages. Should each page have its unique photo that best captures the service?
3. Finally, if Patri's PR #679 is merged first (for the sake of urgency), it will be added to the correct directory in this PR. 

Thanks!