### PR TITLE
Implement ToC across cohort pages

### DIFF
--- a/css/custom.scss
+++ b/css/custom.scss
@@ -488,4 +488,16 @@ code {
 
 .columns-toc {
   margin-top: 2em;
+  
+  .column.is-one-fifth {
+    height: 90vh;
+    overflow: auto;
+  }
+}
+
+@media (min-width: 780px) {
+  .column.is-one-fifth {
+    position: sticky;
+    top: 50px;
+  }
 }

--- a/openseeds/ols-1/index.md
+++ b/openseeds/ols-1/index.md
@@ -11,6 +11,21 @@ redirect_from:
   - /ols-1
 ---
 
+<div class="columns columns-toc">
+<div class="column is-one-fifth" id="cohort-toc" markdown="1">
+
+### Table of content
+{:.no_toc}
+
+<aside class="menu" markdown="1">
+
+- TOC
+{:toc .menu-list}
+
+</aside>
+</div>
+
+<div class="column" markdown="1">
 {% include _includes/cohort-metadata.html cohort='ols-1' %}
 
 # The OLS-1 program
@@ -27,8 +42,6 @@ and international bioinformatics communities.
 1. **Sharing** essential knowledge required to create, lead, and sustain an Open Science project.
 2. **Connecting** members across different communities, backgrounds, and identities by creating space in this program for them to share their experiences and expertise.
 3. **Empowering** them to become effective Open Science ambassadors in their communities.
-
-{% include _includes/toc.html %}
 
 # Goals and Learning Objectives
 
@@ -211,3 +224,5 @@ Updates regarding new calls for applications, announcements, and final project p
 # Community Participation Guidelines
 
 {% include CODE_OF_CONDUCT.md %}
+
+</div>

--- a/openseeds/ols-1/schedule.md
+++ b/openseeds/ols-1/schedule.md
@@ -9,6 +9,22 @@ photos:
 redirect_from: /ols-1/schedule
 ---
 
+<div class="columns columns-toc">
+<div class="column is-one-fifth" markdown="1">
+
+### Table of content
+{:.no_toc}
+
+<aside class="menu" markdown="1">
+
+- TOC
+{:toc .menu-list}
+
+</aside>
+</div>
+
+<div class="column" markdown="1">
 {% assign cohort = 'ols-1' %}
 {% assign schedule = site.data.openseeds[cohort].schedule %}
 {% include _includes/schedule.md %}
+</div>

--- a/openseeds/ols-2/index.md
+++ b/openseeds/ols-2/index.md
@@ -11,6 +11,21 @@ redirect_from:
   - /ols-2
 ---
 
+<div class="columns columns-toc">
+<div class="column is-one-fifth" markdown="1">
+
+### Table of content
+{:.no_toc}
+
+<aside class="menu" markdown="1">
+
+- TOC
+{:toc .menu-list}
+
+</aside>
+</div>
+
+<div class="column" markdown="1">
 {% include _includes/cohort-metadata.html cohort='ols-2' %}
 
 # The OLS-2 program
@@ -27,8 +42,6 @@ and international bioinformatics communities.
 1. **Sharing** essential knowledge required to create, lead, and sustain an Open Science project.
 2. **Connecting** members across different communities, backgrounds, and identities by creating space in this program for them to share their experiences and expertise.
 3. **Empowering** them to become effective Open Science ambassadors in their communities.
-
-{% include _includes/toc.html %}
 
 # Goals and Learning Objectives
 
@@ -305,3 +318,4 @@ Updates regarding new calls for applications, announcements, and final project p
 # Community Participation Guidelines
 
 {% include CODE_OF_CONDUCT.md %}
+</div>

--- a/openseeds/ols-2/schedule.md
+++ b/openseeds/ols-2/schedule.md
@@ -9,6 +9,22 @@ photos:
 redirect_from: /ols-2/schedule
 ---
 
+<div class="columns columns-toc">
+<div class="column is-one-fifth" markdown="1">
+
+### Table of content
+{:.no_toc}
+
+<aside class="menu" markdown="1">
+
+- TOC
+{:toc .menu-list}
+
+</aside>
+</div>
+
+<div class="column" markdown="1">
 {% assign cohort = 'ols-2' %}
 {% assign schedule = site.data.openseeds[cohort].schedule %}
 {% include _includes/schedule.md %}
+</div>

--- a/openseeds/ols-3/index.md
+++ b/openseeds/ols-3/index.md
@@ -11,6 +11,21 @@ redirect_from:
   - /ols-3
 ---
 
+<div class="columns columns-toc">
+<div class="column is-one-fifth" markdown="1">
+
+### Table of content
+{:.no_toc}
+
+<aside class="menu" markdown="1">
+
+- TOC
+{:toc .menu-list}
+
+</aside>
+</div>
+
+<div class="column" markdown="1">
 {% include _includes/cohort-metadata.html cohort='ols-3' %}
 
 # The OLS-3 program
@@ -27,8 +42,6 @@ and international bioinformatics communities.
 1. **Sharing** essential knowledge required to create, lead, and sustain an Open Science project.
 2. **Connecting** members across different communities, backgrounds, and identities by creating space in this program for them to share their experiences and expertise.
 3. **Empowering** them to become effective Open Science ambassadors in their communities.
-
-{% include _includes/toc.html %}
 
 # Goals and Learning Objectives
 
@@ -395,3 +408,4 @@ Updates regarding new calls for applications, announcements, and final project p
 # Community Participation Guidelines
 
 {% include CODE_OF_CONDUCT.md %}
+</div>

--- a/openseeds/ols-3/schedule.md
+++ b/openseeds/ols-3/schedule.md
@@ -9,6 +9,22 @@ photos:
 redirect_from: /ols-3/schedule
 ---
 
+<div class="columns columns-toc">
+<div class="column is-one-fifth" markdown="1">
+
+### Table of content
+{:.no_toc}
+
+<aside class="menu" markdown="1">
+
+- TOC
+{:toc .menu-list}
+
+</aside>
+</div>
+
+<div class="column" markdown="1">
 {% assign cohort = 'ols-3' %}
 {% assign schedule = site.data.openseeds[cohort].schedule %}
 {% include _includes/schedule.md %}
+</div>

--- a/openseeds/ols-4/index.md
+++ b/openseeds/ols-4/index.md
@@ -11,6 +11,21 @@ redirect_from:
   - /ols-4
 ---
 
+<div class="columns columns-toc">
+<div class="column is-one-fifth" markdown="1">
+
+### Table of content
+{:.no_toc}
+
+<aside class="menu" markdown="1">
+
+- TOC
+{:toc .menu-list}
+
+</aside>
+</div>
+
+<div class="column" markdown="1">
 {% include _includes/cohort-metadata.html cohort='ols-4' %}
 
 # The OLS-4 program
@@ -27,8 +42,6 @@ and international bioinformatics communities.
 1. **Sharing** essential knowledge required to create, lead, and sustain an Open Science project.
 2. **Connecting** members across different communities, backgrounds, and identities by creating space in this program for them to share their experiences and expertise.
 3. **Empowering** them to become effective Open Science ambassadors in their communities.
-
-{% include _includes/toc.html %}
 
 # Goals and Learning Objectives
 
@@ -380,3 +393,4 @@ Updates regarding new calls for applications, announcements, and final project p
 # Community Participation Guidelines
 
 {% include CODE_OF_CONDUCT.md %}
+</div>

--- a/openseeds/ols-4/schedule.md
+++ b/openseeds/ols-4/schedule.md
@@ -9,6 +9,22 @@ photos:
 redirect_from: /ols-4/schedule
 ---
 
+<div class="columns columns-toc">
+<div class="column is-one-fifth" markdown="1">
+
+### Table of content
+{:.no_toc}
+
+<aside class="menu" markdown="1">
+
+- TOC
+{:toc .menu-list}
+
+</aside>
+</div>
+
+<div class="column" markdown="1">
 {% assign cohort = 'ols-4' %}
 {% assign schedule = site.data.openseeds[cohort].schedule %}
 {% include _includes/schedule.md %}
+</div>

--- a/openseeds/ols-5/index.md
+++ b/openseeds/ols-5/index.md
@@ -11,6 +11,21 @@ redirect_from:
   - /ols-5
 ---
 
+<div class="columns columns-toc">
+<div class="column is-one-fifth" markdown="1">
+
+### Table of content
+{:.no_toc}
+
+<aside class="menu" markdown="1">
+
+- TOC
+{:toc .menu-list}
+
+</aside>
+</div>
+
+<div class="column" markdown="1">
 {% include _includes/cohort-metadata.html cohort='ols-5' %}
 
 # The OLS-5 program
@@ -27,8 +42,6 @@ and international bioinformatics communities.
 1. **Sharing** essential knowledge required to create, lead, and sustain an Open Science project.
 2. **Connecting** members across different communities, backgrounds, and identities by creating space in this program for them to share their experiences and expertise.
 3. **Empowering** them to become effective Open Science ambassadors in their communities.
-
-{% include _includes/toc.html %}
 
 # Goals and Learning Objectives
 
@@ -380,3 +393,4 @@ Updates regarding new calls for applications, announcements, and final project p
 # Community Participation Guidelines
 
 {% include CODE_OF_CONDUCT.md %}
+</div>

--- a/openseeds/ols-5/schedule.md
+++ b/openseeds/ols-5/schedule.md
@@ -9,7 +9,23 @@ photos:
 redirect_from: /ols-5/schedule
 ---
 
+<div class="columns columns-toc">
+<div class="column is-one-fifth" markdown="1">
+
+### Table of content
+{:.no_toc}
+
+<aside class="menu" markdown="1">
+
+- TOC
+{:toc .menu-list}
+
+</aside>
+</div>
+
+<div class="column" markdown="1">
 {% assign cohort = 'ols-5' %}
 {% assign schedule = site.data.openseeds[cohort].schedule %}
 {% include _includes/overall-schedule.md %}
 {% include _includes/detailed-schedule.md %}
+</div>

--- a/openseeds/ols-6/index.md
+++ b/openseeds/ols-6/index.md
@@ -11,6 +11,21 @@ redirect_from:
   - /ols-6
 ---
 
+<div class="columns columns-toc">
+<div class="column is-one-fifth" markdown="1">
+
+### Table of content
+{:.no_toc}
+
+<aside class="menu" markdown="1">
+
+- TOC
+{:toc .menu-list}
+
+</aside>
+</div>
+
+<div class="column" markdown="1">
 {% include _includes/cohort-metadata.html cohort='ols-6' %}
 
 # The OLS-6 program
@@ -27,8 +42,6 @@ and international bioinformatics communities.
 1. **Sharing** essential knowledge required to create, lead, and sustain an Open Science project.
 2. **Connecting** members across different communities, backgrounds, and identities by creating space in this program for them to share their experiences and expertise.
 3. **Empowering** them to become effective Open Science ambassadors in their communities.
-
-{% include _includes/toc.html %}
 
 # Goals and Learning Objectives
 
@@ -380,3 +393,4 @@ Updates regarding new calls for applications, announcements, and final project p
 # Community Participation Guidelines
 
 {% include CODE_OF_CONDUCT.md %}
+</div>

--- a/openseeds/ols-6/schedule.md
+++ b/openseeds/ols-6/schedule.md
@@ -9,6 +9,22 @@ photos:
 redirect_from: /ols-6/schedule
 ---
 
+<div class="columns columns-toc">
+<div class="column is-one-fifth" markdown="1">
+
+### Table of content
+{:.no_toc}
+
+<aside class="menu" markdown="1">
+
+- TOC
+{:toc .menu-list}
+
+</aside>
+</div>
+
+<div class="column" markdown="1">
 {% assign cohort = 'ols-6' %}
 {% assign schedule = site.data.openseeds[cohort].schedule %}
 {% include _includes/schedule.md %}
+</div>

--- a/openseeds/ols-7/index.md
+++ b/openseeds/ols-7/index.md
@@ -11,6 +11,21 @@ redirect_from:
   - /ols-7
 ---
 
+<div class="columns columns-toc">
+<div class="column is-one-fifth" markdown="1">
+
+### Table of content
+{:.no_toc}
+
+<aside class="menu" markdown="1">
+
+- TOC
+{:toc .menu-list}
+
+</aside>
+</div>
+
+<div class="column" markdown="1">
 {% include _includes/cohort-metadata.html cohort='ols-7' %}
 
 # The OLS-7 program
@@ -27,8 +42,6 @@ and international bioinformatics communities.
 1. **Sharing** essential knowledge required to create, lead, and sustain an Open Science project.
 2. **Connecting** members across different communities, backgrounds, and identities by creating space in this program for them to share their experiences and expertise.
 3. **Empowering** them to become effective Open Science ambassadors in their communities.
-
-{% include _includes/toc.html %}
 
 # Goals and Learning Objectives
 
@@ -384,3 +397,4 @@ Updates regarding new calls for applications, announcements, and final project p
 # Community Participation Guidelines
 
 {% include CODE_OF_CONDUCT.md %}
+</div>

--- a/openseeds/ols-7/schedule.md
+++ b/openseeds/ols-7/schedule.md
@@ -9,6 +9,22 @@ photos:
 redirect_from: /ols-7/schedule
 ---
 
+<div class="columns columns-toc">
+<div class="column is-one-fifth" markdown="1">
+
+### Table of content
+{:.no_toc}
+
+<aside class="menu" markdown="1">
+
+- TOC
+{:toc .menu-list}
+
+</aside>
+</div>
+
+<div class="column" markdown="1">
 {% assign cohort = 'ols-7' %}
 {% assign schedule = site.data.openseeds[cohort].schedule %}
 {% include _includes/schedule.md %}
+</div>

--- a/openseeds/ols-8/index.md
+++ b/openseeds/ols-8/index.md
@@ -11,6 +11,21 @@ redirect_from:
   - /ols-8
 ---
 
+<div class="columns columns-toc">
+<div class="column is-one-fifth" markdown="1">
+
+### Table of content
+{:.no_toc}
+
+<aside class="menu" markdown="1">
+
+- TOC
+{:toc .menu-list}
+
+</aside>
+</div>
+
+<div class="column" markdown="1">
 {% include _includes/cohort-metadata.html cohort='ols-8' %}
 
 # The Open Seeds 8 program
@@ -27,8 +42,6 @@ and scientific communities.
 1. **Sharing** essential knowledge required to create, lead, and sustain an Open Science project.
 2. **Connecting** members across different communities, backgrounds, and identities by creating space in this program for them to share their experiences and expertise.
 3. **Empowering** them to become effective Open Science ambassadors in their communities.
-
-{% include _includes/toc.html %}
 
 # Goals and Learning Objectives
 
@@ -380,3 +393,4 @@ Updates regarding new calls for applications, announcements, and final project p
 # Community Participation Guidelines
 
 {% include CODE_OF_CONDUCT.md %}
+</div>

--- a/openseeds/ols-8/schedule.md
+++ b/openseeds/ols-8/schedule.md
@@ -9,6 +9,22 @@ photos:
 redirect_from: /ols-8/schedule
 ---
 
+<div class="columns columns-toc">
+<div class="column is-one-fifth" markdown="1">
+
+### Table of content
+{:.no_toc}
+
+<aside class="menu" markdown="1">
+
+- TOC
+{:toc .menu-list}
+
+</aside>
+</div>
+
+<div class="column" markdown="1">
 {% assign cohort = 'ols-8' %}
 {% assign schedule = site.data.openseeds[cohort].schedule %}
 {% include _includes/schedule.md %}
+</div>


### PR DESCRIPTION
This PR is a less chaotic version of PR #502. :)
It addresses issue #415 (finally!).

The **ToC** has been implemented following the pattern used in the [library](https://openlifesci.org/library) page.
Additionally, the ToC sidebar has been placed in _`sticky`_ position and made responsive.

![Screenshot (575)](https://github.com/open-life-science/open-life-science.github.io/assets/105166953/a08c0a6c-1f2f-4977-a0e7-d4155e2663ef)
![Screenshot (576)](https://github.com/open-life-science/open-life-science.github.io/assets/105166953/ad21ab61-8d43-4a47-b7ff-378629ee7f9c)

**Note for reviewer(s):**
To make this less repetitive, I did try to implement it differently, by putting the ToC in a new layout called _cohort_...but that did not go as expected.
![Screenshot (574)](https://github.com/open-life-science/open-life-science.github.io/assets/105166953/8b54099f-ae16-4362-b0f8-a13f8b8ca6ff)
