### PR TITLE
Create new index page for OLS

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: OLS
-description: A mentoring & training program for Open Science ambassadors
+description: A not-for-profit organisation dedicated to capacity building and diversifying leadership in research worldwide
 image: /images/index.jpg
 photos:
   name: Bérénice Batut
@@ -9,83 +9,69 @@ photos:
   url: https://flic.kr/p/2gHMJah
 ---
 
-The **OLS** program is for people interested in **applying open principles** in their work and **becoming Open Science ambassadors** in their communities.
+OLS is a not-for profit organisation dedicated to capacity building and diversifying leadership in research worldwide.
+We imagine a future where research is accessible, inclusive, and equitable for everyone.
 
-# About
+# Our three pillars:
+<div class="container">
+  <div class="columns">
+    <div class="column is-one-third">
+        <div class="card custom-card">
+            <div class="card-content">
+              <h1>Open Science Training</h1>
+            </div>
+        </div>
+    </div>
+    <div class="column is-one-third">
+        <div class="card custom-card">
+            <div class="card-content">
+              <h1>Research on Open</h1>
+            </div>
+        </div>
+    </div>
+    <div class="column is-one-third">
+        <div class="card custom-card">
+            <div class="card-content">
+              <h1>Open Incubator</h1>
+            </div>
+        </div>
+    </div>
+  </div>
+</div>
 
-This is a **16-week long personal mentorship and cohort-based training**, where participants (organisers, hosts, mentors and project leads/mentees) of this program will:
-- **share** their expertise and gain knowledge essential to create, lead, and sustain an Open Science project
-- **connect** with members across different projects, communities, backgrounds, and identities
-- **empower** each other to become effective Open Science ambassadors in their communities
+# Open Science Training 
+Online mentoring and training programs for individuals and teams worldwide to learn about and adopt open research practices.
 
-Participants join this program with a **project** that they either are already working on or want to develop during this program **individually or in teams**.
+Current work streams:
+- [Open Seeds (16-weeks)]({% link openseeds/index.md %})
+- [NASA TOPS (16-weeks)]({% link _posts/2023-05-05-NASA-grant-announcement.md %})
 
-![OLS schedule overview. In the middle, the timeline represents the 16 weeks. On the top, boxes in green represent the 8 different cohort calls pointing to the corresponding weeks (even week numbers). Below the week timeline, blue boxes represent the mentor-mentee meetings pointing to the uneven number weeks. Below the blue boxes, are red boxes corresponding to 3 skill-up calls: "GitHub tutorial for beginners" (week 5), "Open Leadership: Academia, industry, and beyond" (week 9), "Self-care & social call" (week 1s)](/images/schedule.png){: .schedule-overview}
+## What makes us different:
+- Curriculum development & pedagogical expertise specifically in teaching researchers.
+- Our programs are built with a global community of experienced community builders and open practitioners.
 
-# Applications
 
-<!--[Apply via Open Review](https://openreview.net/group?id=openlifesci.org/Open_Life_Science/2023/Cohort_8){:.button .is-link .is-fullwidth}
+# Research on open
+Evidence base and interventions for widening participation in research.
+Current work streams:
+- WT impact research
+- Turing Skills Policy Award
 
-*Please register on Open Review before July 3, 2023 to allow activation of your Open Review profile as described in the [OLS-8 application guidelines and templates](https://github.com/open-life-science/application-forms).*-->
+## What makes us different:
+- Researchers with demonstrated track record in researching and influencing open.
+- Inclusivity and equity-focused approach to research: train and incubate independent research leaders, compensate contributors, foster collaborations.
 
-OLS-8 runs from September 2023 to January 2024. We are not sure if we will run OLS-9 in the same format - see our [blog post]({% link _posts/2023-05-05-NASA-grant-announcement.md %}). [Sign up to our low-traffic news list]({{ site.announcement_list }}) to get updates. 
 
-## Timeline
+# Open incubator
+“The greenhouse”: Hands-on support to empower the next generation of open leaders in research.
+Current work streams:
+- Resident fellows program
+- Online call facilitators training and transcription services
+- Catalyst
+- Grant writing training (to come)
+- Fiscal hosting (to come)
+- Consultancy and open research advice
 
-{% assign schedule = site.data.openseeds.ols-8.schedule %}
-{% include _includes/timeline.md %}
-
-Have a question or need any support to join this cohort?
-We are here to help - feel free to email [{{ site.email|replace:'@','[at]' }}](mailto:{{ site.email }}), or connect on Twitter [@{{ site.twitter }}](https://twitter.com/{{ site.twitter }}).
-
-# Cohorts
-{% assign all_participants = '' %}
-{%- assign all_mentors = '' -%}
-{%- assign all_experts = '' -%}
-{%- assign all_facilitators = '' -%}
-{%- assign all_projects = '' -%}
-{%- assign cohorts = site.data.openseeds | sort %}
-
-| Cohort | Schedule | Projects | Mentors | Experts | Facilitators |
-| --- | --- | --- | --- | --- | --- |
-{%- for cohort in cohorts -%}
-  {%- assign cohort_name = cohort[0] -%}
-  {%- assign experts = site.data.openseeds[cohort_name].metadata.experts | uniq | size -%}
-  {%- capture all_experts %}{{ all_experts }}, {{ site.data.openseeds[cohort_name].metadata.experts | join: ', ' }}{% endcapture -%}
-  {%- assign facilitators = site.data.openseeds[cohort_name].metadata.facilitators | uniq | size -%}
-  {%- capture all_facilitators %}{{ all_facilitators }}, {{ site.data.openseeds[cohort_name].metadata.facilitators | join: ', ' }}{% endcapture -%}
-  {%- assign projects = site.data.openseeds[cohort_name].projects -%}
-  {%- assign mentors = '' -%}
-  {%- assign participants = '' -%}
-  {%- assign project_name = '' -%}
-  {%- for project in projects -%}
-      {%- for p in project.participants -%}
-          {%- capture participants %}{{ participants }}, {{ p }}{% endcapture -%}
-      {%- endfor -%}
-      {%- for m in project.mentors -%}
-          {%- capture mentors %}{{ mentors }}, {{ m }}{% endcapture -%}
-      {%- endfor -%}
-      {%- for p-name in project.name -%}
-          {%- capture project_name %}{{ project_name }}, {{ p-name }}{% endcapture -%}
-      {%- endfor -%}
-  {%- endfor %}
-  {%- assign cohort_mentors = mentors | remove_first: ', ' | split: ", " | uniq | sort | size -%}
-  {%- capture all_mentors %}{{ all_mentors }}, {{ mentors }}{% endcapture -%}
-  {%- assign cohort_participants = participants | remove_first: ', ' | split: ", " | uniq | sort | size -%}
-  {%- capture all_participants %}{{ all_participants }}, {{ participants }}{% endcapture -%}
-  {%- assign cohort_projects = project_name | remove_first: ', ' | split: ", " | uniq | sort | size -%}
-  {%- capture all_projects %}{{ all_projects }}, {{ project_name }}{% endcapture -%}
-  {%- assign cohort_schedule = site.data.openseeds[cohort_name].schedule -%}
-  {%- assign cohort_start = cohort_schedule.weeks['01'].start -%}
-  {%- assign cohort_end = '' -%}
-  {%- for week in cohort_schedule.weeks -%}
-      {%- assign cohort_end = week[1].start -%}
-  {%- endfor %}
-| [{{ cohort_name | upcase }}]({% link openseeds/{{ cohort_name }}/index.md %}) | [{{ cohort_start }} - {{ cohort_end }}]({% link openseeds/{{ cohort_name }}/schedule.md %}) | {%- if cohort_participants > 0 -%}[{{ cohort_participants }} mentees]({% link openseeds/{{ cohort_name }}/projects-participants.md %}#participants) on {%- endif -%} {%- if cohort_projects > 0 -%} [{{ cohort_projects }} projects]({% link openseeds/{{ cohort_name }}/projects-participants.md %}#projects) {%- endif -%}| {%- if cohort_mentors > 0 -%}[{{ cohort_mentors }} mentors]({% link openseeds/{{ cohort_name }}/index.md %}#mentors) {%- endif -%}| {%- if experts > 0 -%}[{{ experts }} experts]({% link openseeds/{{ cohort_name }}/index.md %}#experts) {%- endif -%}| {%- if facilitators > 0 -%}[{{ facilitators }} facilitator(s)]({% link openseeds/{{ cohort_name }}/index.md %}#facilitators) {%- endif -%} |
-{%- endfor -%}
-{%- assign all_participants = all_participants | remove_first: ', ' | split: ", " | uniq | size -%}
-{%- assign all_mentors = all_mentors | remove_first: ', ' | split: ", " | uniq | size -%}
-{%- assign all_facilitators = all_facilitators | remove_first: ', ' | split: ", " | uniq | size -%}
-{%- assign all_experts = all_experts | remove_first: ', ' | split: ", " | uniq | size -%}
-{% assign all_projects = all_projects | remove_first: ', ' | split: ", " | uniq | size %}
-| **Total** | | {{ all_participants }} mentees on {{ all_projects }} projects | {{ all_mentors }} mentors | {{ all_experts }} experts | {{ all_facilitators }} facilitators |
+## What makes us different:
+- Curriculum development & pedagogical expertise specifically in teaching researchers.
+- Our programs are built with a global community of experienced community builders and open practitioners.


### PR DESCRIPTION
This PR addresses issue #645.

As mentioned by Yo [here](https://github.com/open-life-science/open-life-science.github.io/issues/646#issuecomment-1658205103), the content of the _we-are-ols.org_ landing page was _moved_ to the Open Seeds subsite. Thus, we needed to create new content.

Using the 3 Pillars created by Emmy (thank you!), Jilaga designed this lovely page ([figma link](https://www.figma.com/file/xbxXsphpiAJZf67vYtsMRu/ols-website?type=design&node-id=295-2996&mode=design&t=2RQ8cfdga7SDJ04r-0)).

![Screenshot (583)](https://github.com/open-life-science/open-life-science.github.io/assets/105166953/9df45c31-b94d-4770-96c6-67c0e1038d6f)

**Note for reviewers:**
- Icons are yet to be added to the page. They will be once these icons are uploaded to the branding repo.
- I am not sure where to link these items to...
    - WT impact research
    - Turing Skills Policy Award
    - Resident fellows program
    - Online call facilitators training and transcription services

Thanks for the review!