### PR TITLE
fix image sizing for mermaid 🧜🏽‍♂️

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -12,7 +12,7 @@ layout: default
                     {{ content | toc_only }} 
                 </aside>
             </div>
-            <div class="column">
+            <div class="column is-four-fifths">
                 {{ content | inject_anchors }}
             </div>
         </div>


### PR DESCRIPTION
Previously the image is too big: 

<img width="807" alt="overflowing image that doesn't fit in the page" src="https://github.com/open-life-science/open-life-science.github.io/assets/9271438/5025911d-0f81-40d2-8272-1e471796455b">

Now:

<img width="829" alt="image that fits in the page" src="https://github.com/open-life-science/open-life-science.github.io/assets/9271438/f866c081-c92a-483c-b4a7-3f73bcc9a369">
