### PR TITLE
Link to OLS GitHub repo from KMS page

### DIFF
--- a/knowledge_management.md
+++ b/knowledge_management.md
@@ -9,7 +9,7 @@ photos:
   url: https://unsplash.com/photos/closeup-photo-of-grey-gear-part-n55IHMpkSoc
 ---
 
-Information and data about our different programs, our community, etc are managed via repositories in a [GitHub organization]({{ site.github.repository_url }}), [CiviCRM](https://civicrm.org/), and documents stored in Google Drive.
+Information and data about our different programs, our community, etc are managed via repositories in a [GitHub organization]({{ site.github.owner_url }}), [CiviCRM](https://civicrm.org/), and documents stored in Google Drive.
 
 # OLS community
 

--- a/knowledge_management.md
+++ b/knowledge_management.md
@@ -9,7 +9,7 @@ photos:
   url: https://unsplash.com/photos/closeup-photo-of-grey-gear-part-n55IHMpkSoc
 ---
 
-Information and data about our different programs, our community, etc are managed via repositories in a [GitHub organization]({{ site.owner_url }}), [CiviCRM](https://civicrm.org/), and documents stored in Google Drive.
+Information and data about our different programs, our community, etc are managed via repositories in a [GitHub organization]({{ site.github.repository_url }}), [CiviCRM](https://civicrm.org/), and documents stored in Google Drive.
 
 # OLS community
 


### PR DESCRIPTION
In the [Knowledge Management System](https://openlifesci.org/knowledge_management.html) page, the link provided does not link to OLS's GitHub repository. This happened because  `{{ site.owner_url }}` environmental variable was used, rather than `{{ site.github.repository_url }}`.

This PR addresses the issue by specifying the necessary variable.

Thanks for reviewing!
