### PR TITLE
Automatically capitalise names

### DIFF
--- a/bin/prepare_website_data.py
+++ b/bin/prepare_website_data.py
@@ -463,8 +463,8 @@ def extract_people_info(row, people):
     :param people: dictionary with people information
     """
     info = {
-        "first-name": row["First name"].rstrip(),
-        "last-name": row["Last name"].rstrip(),
+        "first-name": row["First name"].rstrip().title(),
+        "last-name": row["Last name"].rstrip().title(),
         "twitter": row["Twitter"] if "Twitter" in row else None,
         "website": row["Website"] if "Website" in row else None,
         "orcid": row["ORCID"] if "ORCID" in row else None,

--- a/bin/prepare_website_data.py
+++ b/bin/prepare_website_data.py
@@ -375,7 +375,7 @@ def get_people_ids(names, people):
 
 
 def get_people_names(p_list, people):
-    """Get names of peoke
+    """Get names of people
 
     :param p_list: list of people id
     :param people: dictionary with people information


### PR DESCRIPTION
This PR relates to a minor issue observed in #736, which is the capitalisation of names.
Names inputed by community members on civi ought to be formatted properly to ensure consistent capitalisation in all fields.

*Changes made:*
First, I added the `.capitalise()` method, but that didn't do the job, since it only capitalised the first letter of the string.
![capitalise()](https://github.com/open-life-science/open-life-science.github.io/assets/105166953/a716a600-c964-4eb2-abba-b23184a74587)

So, the `.title()` method  has been applied instead, to improve readability.
![title()](https://github.com/open-life-science/open-life-science.github.io/assets/105166953/c4efb3d0-6eb7-41f6-b062-92e097b98415)

*Note for reviewer(s):*
I also corrected a typo in the scripts. :)

Thanks for reviewing!