### PR TITLE
Link to branding repo from navbar.

### DIFF
--- a/_includes/default-header.html
+++ b/_includes/default-header.html
@@ -53,6 +53,7 @@
               <a class="navbar-item" href="{% link partners.md %}"> Partners </a>
               <a class="navbar-item" href="{% link knowledge_management.md %}"> Knowledge Management System </a>
               <a class="navbar-item" href="{% link publications.md %}"> Citing OLS & Publications </a>
+              <a class="navbar-item" href="https://github.com/open-life-science/branding"> Branding </a>
               <!--<a class="navbar-item" href="/events"> Events </a>-->
             </div>
           </div>

--- a/_includes/default-header.html
+++ b/_includes/default-header.html
@@ -53,7 +53,7 @@
               <a class="navbar-item" href="{% link partners.md %}"> Partners </a>
               <a class="navbar-item" href="{% link knowledge_management.md %}"> Knowledge Management System </a>
               <a class="navbar-item" href="{% link publications.md %}"> Citing OLS & Publications </a>
-              <a class="navbar-item" href="https://github.com/open-life-science/branding"> Branding </a>
+              <a class="navbar-item" href="{{ site.github.owner_url }}/branding"> Branding </a>
               <!--<a class="navbar-item" href="/events"> Events </a>-->
             </div>
           </div>


### PR DESCRIPTION
This PR is necessitated by Yo's comment about making it easier for community members to locate the logos (and other assets).

So, a new dropdown item `"branding"`, which links directly to the [branding repo](https://github.com/open-life-science/branding), has been added to the navbar.

_See screenshot below:_
![branding_dropdown](https://github.com/open-life-science/open-life-science.github.io/assets/105166953/0cf4111f-864d-4e82-bc9f-4410b1026496)

Thanks for reviewing!