### PR TITLE
Make "three pillars" cards occupy equal height

### DIFF
--- a/_includes/streams.md
+++ b/_includes/streams.md
@@ -1,4 +1,4 @@
-<div class="columns is-multiline">
+<div class="columns is-multiline three-pillars">
     {% for stream in page.streams %}
     <div class="column is-one-third">
         <a href="#{{ stream.title | slugify }}">

--- a/css/custom.scss
+++ b/css/custom.scss
@@ -501,6 +501,11 @@ code {
     position: sticky;
     top: 50px;
   }
+
+  // Equal heights for cards
+  .container .columns.three-pillars .column .card {
+  height: 100%;
+  }
 }
 
 .stream-card {

--- a/index.md
+++ b/index.md
@@ -15,7 +15,7 @@ We imagine a future where research is accessible, inclusive, and equitable for e
 # Our three pillars
 
 <div class="container">
-  <div class="columns">
+  <div class="columns three-pillars">
     <div class="column is-one-third">
       <a href="{% link open-science-training.md %}">
         <div class="card custom-card">


### PR DESCRIPTION
This PR fixes item (b) of issue #709.
The cards previously occupied different heights in the [homepage](https://openlifesci.org/) and other _three pillars_ pages.
This caused an inconsistency in the design and was not very aesthetically pleasing.

#### Changes made:
- Added a new class `three-pillars` to target and selectively style these cards.

- Tweaked the CSS as follows, to make the cards equal:

```
  @media (min-width: 780px) {
      ...
  .container .columns.three-pillars .column .card {
  height: 100%;
  }
}
```

#### See screenshots below:

![cards_responsiveness2](https://github.com/open-life-science/open-life-science.github.io/assets/105166953/43013b45-c2d2-42ce-9837-9504ec83a0e7)

![cards_responsiveness](https://github.com/open-life-science/open-life-science.github.io/assets/105166953/14ecb731-e9c3-4f6f-befd-7dd5c30ed63c)

![cards_responsiveness3](https://github.com/open-life-science/open-life-science.github.io/assets/105166953/4c525c39-ecef-4ea9-b052-5e1857a84203)

Preview [here](https://deploy-preview-741--ols-bebatut.netlify.app/)...

Thanks for the review!