### PR TITLE
Fix typo in "teams" page.

### DIFF
--- a/community.md
+++ b/community.md
@@ -21,7 +21,7 @@ We have high ethical standards, including:
 - **Modesty**: Know you don't know everything
 - **Community**: Carefully listen to any concerns and questions and respond honestly
 - **Respect**: Respect humans and all living systems
-- **Responsibility**: Recognize the complexity and dynamics os science and research and our responsibility towards them
+- **Responsibility**: Recognize the complexity and dynamics of science and research and our responsibility towards them
 
 # Core team
 


### PR DESCRIPTION
This PR fixes a tiny typo that was spotted in the [teams](https://openlifesci.org/community.html) page, as seen below:

![teams_typo](https://github.com/open-life-science/open-life-science.github.io/assets/105166953/00116281-31b4-4218-87d6-4b82b4e40e63)

**Changes made:**
The typo "os" was changed to "of."

Thanks!