### PR TITLE
Update staff page to include  "former members" section.

### DIFF
--- a/_data/community.yaml
+++ b/_data/community.yaml
@@ -1,19 +1,21 @@
 ---
 team:
-  - bebatut
-  - emmyft
-  - malvikasharan
-  - yochannah
-  - pazbc
-  - tajuddeen1
-  - pherterich
-  - msundukova
-  - npdebs
-  - jilaga
-  - flavioazevedo
-  - bethaniley
-  - camille-gonz-va
-  - iramosp
+  - current:
+    - bebatut
+    - malvikasharan
+    - yochannah
+    - pazbc
+    - tajuddeen1
+    - pherterich
+    - msundukova
+    - npdebs
+    - jilaga
+    - flavioazevedo
+    - bethaniley
+    - camille-gonz-va
+    - iramosp
+  - past:
+    - emmyft
 governance:
   - anelda
   - batoolmm

--- a/_data/community.yaml
+++ b/_data/community.yaml
@@ -14,7 +14,7 @@ team:
     - bethaniley
     - camille-gonz-va
     - iramosp
-  past:
+  alumni:
     - emmyft
 governance:
   - anelda

--- a/_data/community.yaml
+++ b/_data/community.yaml
@@ -1,6 +1,6 @@
 ---
 team:
-  - current:
+  current:
     - bebatut
     - malvikasharan
     - yochannah
@@ -14,7 +14,7 @@ team:
     - bethaniley
     - camille-gonz-va
     - iramosp
-  - past:
+  past:
     - emmyft
 governance:
   - anelda

--- a/community.md
+++ b/community.md
@@ -35,7 +35,7 @@ We have high ethical standards, including:
 {% endfor %}
 </div>
 
-# Former team members
+# Alumni
 
 <div class="people">
 {% for entry in community.team.past %}

--- a/community.md
+++ b/community.md
@@ -35,7 +35,7 @@ We have high ethical standards, including:
 {% endfor %}
 </div>
 
-# Alumni
+## Alumni
 
 <div class="people">
 {% for entry in community.team.alumni %}

--- a/community.md
+++ b/community.md
@@ -38,7 +38,7 @@ We have high ethical standards, including:
 # Alumni
 
 <div class="people">
-{% for entry in community.team.past %}
+{% for entry in community.team.alumni %}
     {% assign username = entry %}
     {% assign user = people[username] %}
     {% include _includes/people.html username=username user=user %}

--- a/community.md
+++ b/community.md
@@ -28,7 +28,17 @@ We have high ethical standards, including:
 <!--As the graduates, mentors, and hosts of various Mozilla Open Leaders cohorts, we have gained expertise in the technical and culture track. Furthermore, we participate in a wide range of activities in different international communities of practice in the sciences: ELIXIR (European bioinformatics network), Galaxy, The Carpentries, Software Sustainability Institute (SSI), Open Bioinformatics Foundation (OBF), and Mozilla.-->
 
 <div class="people">
-{% for entry in community.team %}
+{% for entry in community.team.current %}
+    {% assign username = entry %}
+    {% assign user = people[username] %}
+    {% include _includes/people.html username=username user=user %}
+{% endfor %}
+</div>
+
+# Former team members
+
+<div class="people">
+{% for entry in community.team.past %}
     {% assign username = entry %}
     {% assign user = people[username] %}
     {% include _includes/people.html username=username user=user %}


### PR DESCRIPTION
This PR addresses issue #774.

**Changes made:**

- A nested list was created to differentiate "current" from "past" team members.
- Add a section for "Former team members.

**Deploy [preview here](https://deploy-preview-776--ols-bebatut.netlify.app/community)...**

**Note for reviewer(s):**
Like Yo mentioned, this may not be the most appropriate wording. So, suggestions are welcome.

Thanks for the review!