### PR TITLE
Fix bug preventing GitHub links from working right.

### DIFF
--- a/_includes/streams.md
+++ b/_includes/streams.md
@@ -29,8 +29,9 @@
 
 <div class="people">
     {% for entry in stream.key_personal.ids %}
+        {% assign username = entry %}
         {% assign user = site.data.people[entry] %}
-        {% include _includes/people.html username=entry user=user %}
+        {% include _includes/people.html username=username user=user %}
     {% endfor %}
 </div>
 


### PR DESCRIPTION
This PR addresses issue #781.
Under the "Key personnel" section, the GitHub links did not include ids for each individual. As such, it only lead to the url `https://github.com/`, rather than the relevant profile(s).

This was also observed in all pages displayed using the [streams.md](https://github.com/open-life-science/open-life-science.github.io/blob/main/_includes/streams.md) include file (e.g [open-incubator)](https://openlifesci.org/open-incubator.html).

**Changes made:**
- Within the loop, a line that assigns the `username` variable to the value of each `entry` was added.
- The value of `username` was set to `username`.

**[Deploy preview link](https://deploy-preview-785--ols-bebatut.netlify.app/open-research)...**

Thanks for the review!