### PR TITLE
Add course description for RSE Leadership Training.

### DIFF
--- a/_consulting/organisational-leadership.md
+++ b/_consulting/organisational-leadership.md
@@ -59,7 +59,7 @@ Country-specific nuances, e.g. setting up a [stichting](https://en.wikipedia.org
 * **Course description:**
   * This leadership course is possibly the first in the world to provide an **intersectional framework** that underpins a leadership course for those in the tech industry.
   * It focuses on centering the individual and prioritising based on the “degree of difficulty” across recruitment, retention, as well as project, people, and relationship management.
-  * This course lays bare the core, practical concepts that you need to know to be an outstanding leader. 
+  * This course lays bare the core, practical concepts that you need to know to be an outstanding leader for a team of 1+ staff in an organisation. 
 
 * **Topics covered include:**
   * Using a Diversity and Inclusion framework to unearth talent.

--- a/_consulting/organisational-leadership.md
+++ b/_consulting/organisational-leadership.md
@@ -56,19 +56,25 @@ Country-specific nuances, e.g. setting up a [stichting](https://en.wikipedia.org
 **Costs: £3000**
 
 ##  Research Software Engineer (RSE) Leadership Training Course 
-* **Course description:**
-  * This leadership course is possibly the first in the world to provide an **intersectional framework** that underpins a leadership course for those in the tech industry.
-  * It focuses on centering the individual and prioritising based on the “degree of difficulty” across recruitment, retention, as well as project, people, and relationship management.
-  * This course lays bare the core, practical concepts that you need to know to be an outstanding leader for a team of 1+ staff in an organisation. 
 
-* **Topics covered include:**
-  * Using a Diversity and Inclusion framework to unearth talent.
-  * Using Continuous Improvement skills to identify talent.
-  * Setup and maintain pipelines to attract talent.
-  * Project Management.
-  * People managing high-performance teams.
-  * How to deal with difficult change management situations and build relationships.
+### Course description
 
-* **For the full workshop schedule, including dates and pricing, please see the [events page]({% link _events/2024-10-research-software-engineer-training-course.md%}).**
+This leadership course is possibly the first in the world to provide an **intersectional framework** that underpins a leadership course for those working as RSEs and those in the tech industry. It is also unique in that we meet with you first to understand what challenges you are facing and to to create an individual development plan just for you.
 
-LMIC discounts are available for all offers. If you are interested in any of the services, please contact us at **[team@we-are-ols.org](mailto:team@we-are-ols.org)**. 
+It focuses on centering the individual and prioritising based on the “degree of difficulty” across recruitment, retention, as well as project, people, and relationship management.
+
+This course lays bare the core, practical concepts that you need to know to be an outstanding leader for a team of 1+ staff in an organisation. 
+
+### Topics
+
+The course covers:
+* Using a Diversity and Inclusion framework to unearth talent.
+* Using Continuous Improvement skills to identify talent.
+* Setup and maintain pipelines to attract talent.
+* Project Management.
+* People managing high-performance teams.
+* How to deal with difficult change management situations and build relationships.
+
+### Iterations of the course
+
+- [October - November, 2024]({% link _events/2024-10-research-software-engineer-training-course.md%}).

--- a/_consulting/organisational-leadership.md
+++ b/_consulting/organisational-leadership.md
@@ -55,4 +55,21 @@ Country-specific nuances, e.g. setting up a [stichting](https://en.wikipedia.org
 
 **Costs: £3000**
 
-LMIC discounts are available for all offers. If you are interested in any of the services, please contact us at team@we-are-ols.org. 
+##  Research Software Engineer (RSE) Leadership Training Course 
+* **Course description:**
+  * This leadership course is possibly the first in the world to provide an **intersectional framework** that underpins a leadership course for those in the tech industry.
+  * It focuses on centering the individual and prioritising based on the "degree of difficulty" across recruitment, retention, and relationship management.
+  * This course lays bare the core, practical concepts that you need to know to be an outstanding leader. 
+
+* **Course content:**
+  * **17th October** - Using a Diversity and Inclusion framework to unearth talent.
+  * **24th October** - Using Continuous Improvement skills to identify talent.
+  * **7th November** - Setup and maintain pipelines to attract talent.
+  * **14th November** - Project and People managing high-performance teams.
+  * **21st November** - How to deal with difficult people and build relationships.
+  
+* **Pricing:** 
+  * **£499 GBP** for initial skills consult and personal development plan.
+  * **£1999 GBP** for 5-7 modules based on the initial consultation.
+
+LMIC discounts are available for all offers. If you are interested in any of the services, please contact us at **[team@we-are-ols.org](mailto:team@we-are-ols.org)**. 

--- a/_consulting/organisational-leadership.md
+++ b/_consulting/organisational-leadership.md
@@ -65,9 +65,11 @@ Country-specific nuances, e.g. setting up a [stichting](https://en.wikipedia.org
   * **17th October** - Using a Diversity and Inclusion framework to unearth talent.
   * **24th October** - Using Continuous Improvement skills to identify talent.
   * **7th November** - Setup and maintain pipelines to attract talent.
-  * **14th November** - Project and People managing high-performance teams.
-  * **21st November** - How to deal with difficult people and build relationships.
-  
+  * **14th November** - Project Management.
+  * **21st November** - People managing high-performance teams.
+  * **28th November** - How to deal with difficult change management
+   situations and build relationships.
+
 * **Pricing:** 
   * **£499 GBP** for initial skills consult and personal development plan.
   * **£1999 GBP** for 5-7 modules based on the initial consultation.

--- a/_consulting/organisational-leadership.md
+++ b/_consulting/organisational-leadership.md
@@ -58,7 +58,7 @@ Country-specific nuances, e.g. setting up a [stichting](https://en.wikipedia.org
 ##  Research Software Engineer (RSE) Leadership Training Course 
 * **Course description:**
   * This leadership course is possibly the first in the world to provide an **intersectional framework** that underpins a leadership course for those in the tech industry.
-  * It focuses on centering the individual and prioritising based on the "degree of difficulty" across recruitment, retention, and relationship management.
+  * It focuses on centering the individual and prioritising based on the “degree of difficulty” across recruitment, retention, as well as project, people, and relationship management.
   * This course lays bare the core, practical concepts that you need to know to be an outstanding leader. 
 
 * **Topics covered include:**

--- a/_consulting/organisational-leadership.md
+++ b/_consulting/organisational-leadership.md
@@ -61,17 +61,14 @@ Country-specific nuances, e.g. setting up a [stichting](https://en.wikipedia.org
   * It focuses on centering the individual and prioritising based on the "degree of difficulty" across recruitment, retention, and relationship management.
   * This course lays bare the core, practical concepts that you need to know to be an outstanding leader. 
 
-* **Course content:**
-  * **17th October** - Using a Diversity and Inclusion framework to unearth talent.
-  * **24th October** - Using Continuous Improvement skills to identify talent.
-  * **7th November** - Setup and maintain pipelines to attract talent.
-  * **14th November** - Project Management.
-  * **21st November** - People managing high-performance teams.
-  * **28th November** - How to deal with difficult change management
-   situations and build relationships.
+* **Topics covered include:**
+  * Using a Diversity and Inclusion framework to unearth talent.
+  * Using Continuous Improvement skills to identify talent.
+  * Setup and maintain pipelines to attract talent.
+  * Project Management.
+  * People managing high-performance teams.
+  * How to deal with difficult change management situations and build relationships.
 
-* **Pricing:** 
-  * **£499 GBP** for initial skills consult and personal development plan.
-  * **£1999 GBP** for 5-7 modules based on the initial consultation.
+* **For the full workshop schedule, including dates and pricing, please see the [events page]({% link _events/2024-10-research-software-engineer-training-course.md%}).**
 
 LMIC discounts are available for all offers. If you are interested in any of the services, please contact us at **[team@we-are-ols.org](mailto:team@we-are-ols.org)**. 

--- a/_events/2024-10-research-software-engineer-training-course.md
+++ b/_events/2024-10-research-software-engineer-training-course.md
@@ -15,7 +15,7 @@ date_end: 2024-11-28
 location:
   name: Online
 
-contact_email: person@we-are-ols.org
+contact_email: rowland@we-are-ols.org
 
 registration:
   link: 

--- a/_events/2024-10-research-software-engineer-training-course.md
+++ b/_events/2024-10-research-software-engineer-training-course.md
@@ -11,6 +11,7 @@ contributions:
 
 date_start: 2024-10-17
 date_end: 2024-11-28
+duration: "02:45:00"
 
 location:
   name: Online

--- a/_events/2024-10-research-software-engineer-training-course.md
+++ b/_events/2024-10-research-software-engineer-training-course.md
@@ -19,8 +19,8 @@ location:
 contact_email: rowland@we-are-ols.org
 
 registration:
-  link: 
-  deadline: 
+  link: https://events.humanitix.com/rse-leadership-course
+  deadline: 2024-09-24
 ---
 
 # Course description

--- a/_events/2024-10-research-software-engineer-training-course.md
+++ b/_events/2024-10-research-software-engineer-training-course.md
@@ -39,3 +39,5 @@ registration:
 * **Pricing:** 
   * **£499 GBP** for initial skills consult and personal development plan.
   * **£1999 GBP** ffor the practical training course designed just for you and a small group of other leaders.
+
+LMIC discounts are available for all offers. If you are interested in any of the services, please contact us at **[team@we-are-ols.org](mailto:team@we-are-ols.org)**.

--- a/_events/2024-10-research-software-engineer-training-course.md
+++ b/_events/2024-10-research-software-engineer-training-course.md
@@ -29,11 +29,11 @@ registration:
   * Course will run weekly from **17th of October** to **28th of November.**
 
 * **Topics covered include:**
-  * Using a Diversity and Inclusion framework to unearth talent.
+  * Using a Diversity and Inclusion framework to improve your team.
   * Using Continuous Improvement skills to identify talent.
   * Setup and maintain pipelines to attract talent.
-  * Project Management.
-  * People managing high-performance teams.
+  * Project Management in complex scenarios.
+  * Managing high-performance teams.
   * How to deal with difficult change management situations and build relationships.
 
 * **Pricing:** 

--- a/_events/2024-10-research-software-engineer-training-course.md
+++ b/_events/2024-10-research-software-engineer-training-course.md
@@ -41,7 +41,7 @@ The course will cover
 * Managing high-performance teams.
 * How to deal with difficult change management situations and build relationships.
 
-# Organization
+# Sessions
 
 - **Dates**: from **17th of October** to **28th of November
 - **Frequency**: weekly, on Tuesdays or Fridays, based on participant availability

--- a/_events/2024-10-research-software-engineer-training-course.md
+++ b/_events/2024-10-research-software-engineer-training-course.md
@@ -22,22 +22,31 @@ registration:
   deadline: 
 ---
 
-* **Course description:**
-  * This leadership course is possibly the first in the world to provide an **intersectional framework** that underpins a leadership course for those working as RSEs and those in the tech industry.
-  * It is also unique in that we meet with you first to understand what challenges you are facing and to to create an individual development plan just for you.
-  * We will then craft a practical training course just for you and a small group of other leaders to ensure all your needs are being met as an individual and as a group.
-  * Course will run weekly from **17th of October** to **28th of November.**
+# Course description
 
-* **Workshop topics:**
-  * Using a Diversity and Inclusion framework to improve your team.
-  * Using Continuous Improvement skills to identify talent.
-  * Setup and maintain pipelines to attract talent.
-  * Project Management in complex scenarios.
-  * Managing high-performance teams.
-  * How to deal with difficult change management situations and build relationships.
+This leadership course is possibly the first in the world to provide an **intersectional framework** that underpins a leadership course for those working as RSEs and those in the tech industry.
 
-* **Pricing:** 
-  * **£499 GBP** for initial skills consult and personal development plan.
-  * **£1999 GBP** for a series of workshops with a small number of other leaders, that is crafted to your needs based on the initial consultation.
+It is also unique in that we meet with you first to understand what challenges you are facing and to to create an individual development plan just for you.
 
-LMIC discounts are available for all offers. If you are interested in any of the services, please contact us at **[team@we-are-ols.org](mailto:team@we-are-ols.org)**.
+We will then craft a practical training course just for you and a small group of other leaders to ensure all your needs are being met as an individual and as a group.
+
+# Topics
+
+The course will cover
+* Using a Diversity and Inclusion framework to improve your team.
+* Using Continuous Improvement skills to identify talent.
+* Setup and maintain pipelines to attract talent.
+* Project Management in complex scenarios.
+* Managing high-performance teams.
+* How to deal with difficult change management situations and build relationships.
+
+# Organization
+
+Course will run weekly from **17th of October** to **28th of November.**
+
+# Pricing
+
+* **£499 GBP** for initial skills consult and personal development plan.
+* **£1999 GBP** for a series of workshops with a small number of other leaders, that is crafted to your needs based on the initial consultation.
+
+LMIC discounts are available for all offers. If you are interested in any of the services, please contact us at **[{{ site.email|replace:'@','[at]' }}](mailto:{{ site.email }})**.

--- a/_events/2024-10-research-software-engineer-training-course.md
+++ b/_events/2024-10-research-software-engineer-training-course.md
@@ -43,7 +43,9 @@ The course will cover
 
 # Organization
 
-Course will run weekly from **17th of October** to **28th of November, on Tuesdays or Fridays, based on participant availability.**
+- **Dates**: from **17th of October** to **28th of November
+- **Frequency**: weekly, on Tuesdays or Fridays, based on participant availability
+- **Duration**: around two and a half hours
 
 # Pricing
 

--- a/_events/2024-10-research-software-engineer-training-course.md
+++ b/_events/2024-10-research-software-engineer-training-course.md
@@ -28,7 +28,7 @@ registration:
   * We will then craft a practical training course just for you and a small group of other leaders to ensure all your needs are being met as an individual and as a group.
   * Course will run weekly from **17th of October** to **28th of November.**
 
-* **Topics covered include:**
+* **Workshop topics:**
   * Using a Diversity and Inclusion framework to improve your team.
   * Using Continuous Improvement skills to identify talent.
   * Setup and maintain pipelines to attract talent.
@@ -38,6 +38,6 @@ registration:
 
 * **Pricing:** 
   * **£499 GBP** for initial skills consult and personal development plan.
-  * **£1999 GBP** ffor the practical training course designed just for you and a small group of other leaders.
+  * **£1999 GBP** for a series of workshops with a small number of other leaders, that is crafted to your needs based on the initial consultation.
 
 LMIC discounts are available for all offers. If you are interested in any of the services, please contact us at **[team@we-are-ols.org](mailto:team@we-are-ols.org)**.

--- a/_events/2024-10-research-software-engineer-training-course.md
+++ b/_events/2024-10-research-software-engineer-training-course.md
@@ -43,7 +43,7 @@ The course will cover
 
 # Organization
 
-Course will run weekly from **17th of October** to **28th of November.**
+Course will run weekly from **17th of October** to **28th of November, on Tuesdays or Fridays, based on participant availability.**
 
 # Pricing
 

--- a/_events/2024-10-research-software-engineer-training-course.md
+++ b/_events/2024-10-research-software-engineer-training-course.md
@@ -1,0 +1,41 @@
+---
+layout: event
+title: Research Software Engineer (RSE) Leadership Training Course
+type: workshop
+description: |
+    This leadership course is possibly the first in the world to provide an intersectional framework that underpins a leadership course for those working as RSEs and those in  the tech industry.
+
+contributions:
+  organisers:
+  - rowland-mosbergen
+
+date_start: 2024-10-17
+date_end: 2024-11-28
+
+location:
+  name: Online
+
+contact_email: person@we-are-ols.org
+
+registration:
+  link: 
+  deadline: 
+---
+
+* **Course description:**
+  * This leadership course is possibly the first in the world to provide an **intersectional framework** that underpins a leadership course for those working as RSEs and those in the tech industry.
+  * It is also unique in that we meet with you first to understand what challenges you are facing and to to create an individual development plan just for you.
+  * We will then craft a practical training course just for you and a small group of other leaders to ensure all your needs are being met as an individual and as a group.
+  * Course will run weekly from **17th of October** to **28th of November.**
+
+* **Topics covered include:**
+  * Using a Diversity and Inclusion framework to unearth talent.
+  * Using Continuous Improvement skills to identify talent.
+  * Setup and maintain pipelines to attract talent.
+  * Project Management.
+  * People managing high-performance teams.
+  * How to deal with difficult change management situations and build relationships.
+
+* **Pricing:** 
+  * **£499 GBP** for initial skills consult and personal development plan.
+  * **£1999 GBP** ffor the practical training course designed just for you and a small group of other leaders.


### PR DESCRIPTION
This PR resolves issue #791.

To the existing [consulting](https://openlifesci.org/consulting/organisational-leadership/) page, a section has been added, with information about the Research Software Engineer (RSE) Leadership Training Course.

[Deploy preview](https://deploy-preview-792--ols-bebatut.netlify.app/consulting/organisational-leadership/#research-software-engineer-rse-leadership-training-course) here...

**Note for reviewer(s)**
- I haven't linked to the training materials yet. Are we ready to go live with it.

Thanks for the review!