### PR TITLE
Make Catalyst schedule page accessible from navbar.

### DIFF
--- a/_includes/default-header.html
+++ b/_includes/default-header.html
@@ -23,6 +23,7 @@
             <div class="navbar-dropdown">
               <a class="navbar-item" href="{% link openseeds/index.md %}">Open Seeds</a>
               <a class="navbar-item" href="{% link nebula/index.md %}">Nebula</a>
+              <a class="navbar-item" href="{% link catalyst/cat-1/schedule.md %}">Catalyst</a>
             </div>
           </div>
           <div class="navbar-item has-dropdown is-hoverable">


### PR DESCRIPTION
This PR piggybacks on PR #788, where the Catalyst information (e.g schedule) was added to the website.
Here, the page has been made more findable, by adding it to the "Open Science Training" drop-down menu, as seen below.

![catalyst_schedule ](https://github.com/open-life-science/open-life-science.github.io/assets/105166953/08e6fae4-ea04-4189-a8ed-502ae16906e5)

[Deploy preview](https://deploy-preview-793--ols-bebatut.netlify.app/catalyst/cat-1/schedule)...

**Note for the reviewer(s):**
 The Catalyst project described under the `open-incubator` pillar, while the schedule page is linked under `open-science-training`.

1. What are your thoughts about having the same program in two different places?
2. Are there any confusions created by this new structure? 

Thanks for the review!