### PR TITLE
Add Blog launch for RSE AUNZ fiscal sponsorship

### DIFF
--- a/_data/people.yaml
+++ b/_data/people.yaml
@@ -8375,7 +8375,7 @@ rowland-mosbergen:
   affiliation: Practical Diversity and Inclusion Project
   country: Australia
   first-name: Rowland
-  github: false
+  github: rowlandm
   last-name: Mosbergen
   country_3: AUS
   continent: Oceania

--- a/_posts/2024-07-12-RSE-AUNZ-joins-OLS.md
+++ b/_posts/2024-07-12-RSE-AUNZ-joins-OLS.md
@@ -29,14 +29,11 @@ The [RSE-AUNZ website](https://rse-aunz.org) contains the goals for the communit
 
 If you want to join the community, sign-up to the [Google Groups mailing list](https://groups.google.com/forum/#!forum/rse-nz-au/join).
 
-## RSE Asia Australia 
+## RSE Asia Australia Unconference
 
-One of the major reasons that RSE-AUNZ wanted to get fiscal sponsorship from OLS was because of the flagship event with RSE Asia, [Research Software Engineer Asia Australia](https://rseaa
-org).
+A major driver for RSE-AUNZ seeking fiscal sponsorship from OLS was the flagship event - [Research Software Engineer Asia Australia Unconference](https://rseaa.org), organised jointly with RSE Asia. This online event occurs every September and is attended by RSEs from many different research domains, all of whom work in some capacity with research software.
 
-This online event occurs every September and is attended by RSEs from many different research domains, all who work in some capacity with research software.
-
-Without support of OLS they would not have been able to run this event, due to both associations being at the start of their organisational journey.
+OLS support was crucial to run this event, since neither RSE associations have the necessary infrastructure to make financial transactions *necessary* for organising the Unconference.
 
 ## Fiscal Sponsorship with OLS
 

--- a/_posts/2024-07-12-RSE-AUNZ-joins-OLS.md
+++ b/_posts/2024-07-12-RSE-AUNZ-joins-OLS.md
@@ -3,7 +3,8 @@ layout: post
 title: RSE-AUNZ joins OLS as their first fiscally sponsored community
 authors:
 - yochannah
-- rowland
+- rowland-mosbergen
+- Manodeep 
 image: https://images.unsplash.com/photo-1560328055-e938bb2ed50a
 photos:
   name: Kelli McClintock

--- a/_posts/2024-07-12-RSE-AUNZ-joins-OLS.md
+++ b/_posts/2024-07-12-RSE-AUNZ-joins-OLS.md
@@ -1,0 +1,45 @@
+---
+layout: post
+title: RSE-AUNZ joins OLS as their first fiscally sponsored community
+authors:
+- yochannah
+- rowland
+- 
+image: 
+photos:
+  name: 
+  license: CC-BY
+  url: 
+---
+
+We're excited to share that [RSE-AUNZ](https://rse-aunz.github.io/) are joining OLS as our first [Fiscally Sponsored Community (FSC)]()! We'll be exploring this over the next year with RSE-AUNZ as they run their flagship [2024 RSE Asia Australia unconference](https://rseaa.github.io/). 
+
+## About RSE-AUNZ
+
+
+The community of Research Software Engineers (Australia & New Zealand) was formed in mid-2017. The community has grown steadily over the years and is now well over 450 members ![Graph showing membership growing stteaily over time from ~10 members in December 2017 to more than 400 in March 2023](http://rse-aunz.org/assets/RSE-Members-2023-03-01.png).
+
+The [RSE-AUNZ website](https://rse-aunz.org) contains the goals for the community. In 2023, the RSE-AUNZ Steering Committee completed a [Strategic Plan](https://doi.org/10.6084/m9.figshare.21385392.v1) to be explicit about the community priorities are, and came up with a set of five strategic selection criteria:
+
+- Does this make RSEs value themselves?
+- Does this make Senior Managers value RSEs?
+- Does this grow community or raise awareness?
+- Does this or can this support Diversity, Equity & Inclusion (DEI)?
+- Does this sit in the policy advocacy space?
+
+If you want to join the community, sign-up to the [Google Groups mailing list](https://groups.google.com/forum/#!forum/rse-nz-au/join).
+
+## RSE Asia Australia 
+
+One of the major reasons that RSE-AUNZ wanted to get fiscal sponsorship from OLS was because of the flagship event with RSE Asia, [Research Software Engineer Asia Australia](https://rseaa
+org).
+
+This online event occurs every September and is attended by RSEs from many different research domains, all who work in some capacity with research software.
+
+Without support of OLS they would not have been able to run this event, due to both associations being at the start of their organisational journey.
+
+## Fiscal Sponsorship with OLS
+
+Fiscal sponsorship is a relatively new program for OLS, mainly in response to the fact that people participating in the OLS mentorship programs ([Open Seeds](https://we-are-ols.org/openseeds/) and [Nebula](https://we-are-ols.org/nebula/)) often desire to take "next steps" for their communities or projects, but may not have the legal infrastructure to do so (e.g. ways to handle money, accounting, a registered organisation, etc.), or may have an institution they can work with that may not have the desired flexibility to meet their needs. 
+
+If you want to learn more about the program, visit: [https://we-are-ols.org/open-incubator/fiscal-hosting/](https://we-are-ols.org/open-incubator/fiscal-hosting/).

--- a/_posts/2024-07-12-RSE-AUNZ-joins-OLS.md
+++ b/_posts/2024-07-12-RSE-AUNZ-joins-OLS.md
@@ -4,12 +4,11 @@ title: RSE-AUNZ joins OLS as their first fiscally sponsored community
 authors:
 - yochannah
 - rowland
-- 
-image: 
+image: https://images.unsplash.com/photo-1560328055-e938bb2ed50a
 photos:
-  name: 
-  license: CC-BY
-  url: 
+  name: Kelli McClintock
+  license: CC BY-SA 4.0
+  url: https://images.unsplash.com/photo-1560328055-e938bb2ed50a
 ---
 
 We're excited to share that [RSE-AUNZ](https://rse-aunz.github.io/) are joining OLS as our first [Fiscally Sponsored Community (FSC)]()! We'll be exploring this over the next year with RSE-AUNZ as they run their flagship [2024 RSE Asia Australia unconference](https://rseaa.github.io/). 


### PR DESCRIPTION
This PR resolves issue #803.

**Changes made:**
- Added content of blog post, as written by @yochannah, @rowlandm and @manodeep
- Updated Rowland's GitHub username in `people.yaml` file.
- Reused hero image from [fiscal sponsorship](https://openlifesci.org/open-incubator/fiscal-hosting/) page.

**[Deploy preview link](https://deploy-preview-804--ols-bebatut.netlify.app/posts/2024/07/12/RSE-AUNZ-joins-OLS/)**...

**See screenshot below:**

<img width="1905" alt="Screenshot of AUNZ fiscal sponsorship blog post" src="https://github.com/user-attachments/assets/1bc69f02-b2e3-44c9-ad5a-48e18437d21b">

**Note for reviewers:**
Please, let me know if you're happy with the choice of hero image, or would prefer something else. 

Thanks for the review!