### PR TITLE
Fix rowland id in RSE training course

### DIFF
--- a/_events/2024-10-research-software-engineer-training-course.md
+++ b/_events/2024-10-research-software-engineer-training-course.md
@@ -7,7 +7,7 @@ description: |
 
 contributions:
   organisers:
-  - rowland-mosbergen
+  - rowlandm
 
 date_start: 2024-10-17
 date_end: 2024-11-28


### PR DESCRIPTION
Fix Rowland's id in RSE Training Course event

:+1::tada: First of all, thanks for taking the time to contribute! :tada::+1:

## FOR CONTRIBUTOR

* [X] I have read the [CONTRIBUTING.md](https://github.com/open-life-science/open-life-science.github.io/blob/main/CONTRIBUTING.md) document

<!-- Select which of these two are true by putting an x between the square brackets [x] -->
PR Type: 
* [ ] This PR adds a new blog post
* [X] This PR does something else (explain above)

<!-- Leave this here so reviewers have a nice checklist to help them review the PR  --> 
## FOR REVIEWERS

Thanks for taking the time to review! :heart:

Here are the list of things to make sure of:
* [x] The website builds (a check will fail if not)
* [ ] All images have been added within the Pull Request and they have Alt text
* [ ] If there are paragraphs or text, the key messages are highlighted
* [ ] All internal links (within OLS website) use the [`{% link path_to_file.md %}` format](https://jekyllrb.com/docs/liquid/tags/#link)
* [x] The preview corresponds to the changes described in the Pull Request
* [x] The code is tidy and passes the linting tests
