### PR TITLE
migrate from openlifesci.org to we-are-ols.org

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,7 +10,7 @@ finance_email: financemanagement@we-are-ols.org
 repository: open-life-science/open-life-science.github.io
 twitter: openlifesci
 gitter: open-life-sci/community
-url: https://openlifesci.org/
+url: https://we-are-ols.org/
 announcement_list: https://groups.google.com/g/ols-news
 youtube: https://www.youtube.com/channel/UCs12-ZgnDJOWIWN3Vo1XHXA/
 


### PR DESCRIPTION
<!-- Explain what the PR is about here, if appropriate :)  --> 

This is the jekyll change to implement we-are-ols.org rather than openlifesci.org :) 

:+1::tada: First of all, thanks for taking the time to contribute! :tada::+1:

## FOR CONTRIBUTOR

* [x] I have read the [CONTRIBUTING.md](https://github.com/open-life-science/open-life-science.github.io/blob/main/CONTRIBUTING.md) document

<!-- Select which of these two are true by putting an x between the square brackets [x] -->
PR Type: 
* [ ] This PR adds a new blog post
* [x] This PR does something else (explain above)

<!-- Leave this here so reviewers have a nice checklist to help them review the PR  --> 
## FOR REVIEWERS

Thanks for taking the time to review! :heart:

Here are the list of things to make sure of:
* [ ] The website builds (a check will fail if not)
* [ ] All images have been added within the Pull Request and they have Alt text
* [ ] If there are paragraphs or text, the key messages are highlighted
* [ ] All internal links (within OLS website) use the [`{% link path_to_file.md %}` format](https://jekyllrb.com/docs/liquid/tags/#link)
* [ ] The preview corresponds to the changes described in the Pull Request
* [ ] The code is tidy and passes the linting tests
