### PR TITLE
Debug: Restore website deployment to GitHub Pages 

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,0 +1,50 @@
+name: Deploy Preview for Pull Requests
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.1
+        bundler-cache: true
+
+    - name: Install dependencies
+      run: |
+        bundle install
+
+    - name: Build Jekyll site
+      run: |
+        bundle exec jekyll build --destination _site
+
+    - name: Copy site to PR-specific folder
+      run: |
+        mkdir pr_preview
+        mv _site pr_preview/${{ github.event.pull_request.number }}
+
+    - name: Deploy to GitHub Pages for preview
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        personal_token: ${{ secrets.PR_PREVIEW_TOKEN }}
+        publish_branch: gh-pages 
+        publish_dir: ./pr_preview
+        external_repository: open-life-science/ols-site-preview 
+        cname: ''
+
+    - name: Comment with preview URL
+      env:
+        GITHUB_TOKEN: ${{ secrets.PR_PREVIEW_TOKEN }}
+      run: |
+        PREVIEW_URL="https://we-are-ols.org/ols-site-preview/${{ github.event.pull_request.number }}"
+        COMMENT_BODY="🎉 A preview of this PR is available at: [${PREVIEW_URL}](${PREVIEW_URL})"
+        gh pr comment ${{ github.event.pull_request.number }} --body "$COMMENT_BODY"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,50 +1,61 @@
-name: Deploy Preview for Pull Requests
+# Workflow for building and deploying a Jekyll site to GitHub Pages
+name: Deploy Jekyll site to Pages
 
 on:
-  pull_request:
-    branches:
-      - main
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
 
 jobs:
-  build-and-deploy:
-    runs-on: ubuntu-latest
-
+  # Build job
+  build:
+    runs-on: ubuntu-22.04
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # v1.146.0
+        with:
+          ruby-version: '3.1' # Not needed with a .ruby-version file
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+          cache-version: 0 # Increment this number if you need to re-download cached gems
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v3
+      - name: Build with Jekyll
+        # Outputs to the './_site' directory by default
+        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+        env:
+          JEKYLL_ENV: production
+      - name: Upload artifact
+        # Automatically uploads an artifact from the './_site' directory by default
+        uses: actions/upload-pages-artifact@v3
 
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: 3.1
-        bundler-cache: true
 
-    - name: Install dependencies
-      run: |
-        bundle install
-
-    - name: Build Jekyll site
-      run: |
-        bundle exec jekyll build --destination _site
-
-    - name: Copy site to PR-specific folder
-      run: |
-        mkdir pr_preview
-        mv _site pr_preview/${{ github.event.pull_request.number }}
-
-    - name: Deploy to GitHub Pages for preview
-      uses: peaceiris/actions-gh-pages@v3
-      with:
-        personal_token: ${{ secrets.PR_PREVIEW_TOKEN }}
-        publish_branch: gh-pages 
-        publish_dir: ./pr_preview
-        external_repository: open-life-science/ols-site-preview 
-        cname: ''
-
-    - name: Comment with preview URL
-      env:
-        GITHUB_TOKEN: ${{ secrets.PR_PREVIEW_TOKEN }}
-      run: |
-        PREVIEW_URL="http://we-are-ols.org/ols-site-preview/${{ github.event.pull_request.number }}"
-        COMMENT_BODY="🎉 A preview of this PR is available at: [${PREVIEW_URL}](${PREVIEW_URL})"
-        gh pr comment ${{ github.event.pull_request.number }} --body "$COMMENT_BODY"
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+        


### PR DESCRIPTION
<!-- Explain what the PR is about here, if appropriate :)  --> 

This PR fixes #994 - thanks again for flagging, Yo!

In #948, a new GitHub Action was added, which primarily provides a live deploy preview link under each open Pull Request.
However, the previous Action that handled deployment to GitHub pages was removed in the process. This PR addresses the resulting effects of that...action. :-)

:+1::tada: First of all, thanks for taking the time to contribute! :tada::+1:

## FOR CONTRIBUTOR

* [x] I have read the [CONTRIBUTING.md](https://github.com/open-life-science/open-life-science.github.io/blob/main/CONTRIBUTING.md) document

<!-- Select which of these two are true by putting an x between the square brackets [x] -->
PR Type: 
* [ ] This PR adds a new blog post
* [x] This PR does something else (explain above)

<!-- Leave this here so reviewers have a nice checklist to help them review the PR  --> 
## FOR REVIEWERS

Thanks for taking the time to review! :heart:

Here are the list of things to make sure of:
* [ ] The website builds (a check will fail if not)
* [ ] All images have been added within the Pull Request and they have Alt text
* [ ] If there are paragraphs or text, the key messages are highlighted
* [ ] All internal links (within OLS website) use the [`{% link path_to_file.md %}` format](https://jekyllrb.com/docs/liquid/tags/#link)
* [ ] The preview corresponds to the changes described in the Pull Request
* [ ] The code is tidy and passes the linting tests
