### PR TITLE
Improve pr-preview action to accomodate previews for multiple open PRs

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -27,18 +27,14 @@ jobs:
       run: |
         bundle exec jekyll build --destination _site
 
-    - name: Copy site to PR-specific folder
-      run: |
-        mkdir pr_preview
-        mv _site pr_preview/${{ github.event.pull_request.number }}
-
     - name: Deploy to GitHub Pages for preview
       uses: peaceiris/actions-gh-pages@v3
       with:
         personal_token: ${{ secrets.PR_PREVIEW_TOKEN }}
-        publish_branch: gh-pages 
-        publish_dir: ./pr_preview
-        external_repository: open-life-science/ols-site-preview 
+        publish_branch: gh-pages
+        publish_dir: ./_site
+        destination_path: ${{ github.event.pull_request.number }}
+        external_repository: open-life-science/ols-site-preview
         cname: ''
 
     - name: Comment with preview URL

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -27,13 +27,17 @@ jobs:
       run: |
         bundle exec jekyll build --destination _site
 
+    - name: Create PR-specific folder
+      run: |
+        mkdir -p pr_preview/${{ github.event.pull_request.number }}
+        mv _site/* pr_preview/${{ github.event.pull_request.number }}
+
     - name: Deploy to GitHub Pages for preview
       uses: peaceiris/actions-gh-pages@v3
       with:
         personal_token: ${{ secrets.PR_PREVIEW_TOKEN }}
         publish_branch: gh-pages
-        publish_dir: ./_site
-        destination_path: ${{ github.event.pull_request.number }}
+        publish_dir: ./pr_preview/${{ github.event.pull_request.number }}
         external_repository: open-life-science/ols-site-preview
         cname: ''
 
@@ -41,6 +45,6 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.PR_PREVIEW_TOKEN }}
       run: |
-        PREVIEW_URL="https://we-are-ols.org/ols-site-preview/${{ github.event.pull_request.number }}"
+        PREVIEW_URL="https://we-are-ols.org/ols-site-preview/${{ github.event.pull_request.number }}/"
         COMMENT_BODY="🎉 A preview of this PR is available at: [${PREVIEW_URL}](${PREVIEW_URL})"
         gh pr comment ${{ github.event.pull_request.number }} --body "$COMMENT_BODY"

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:   # Allow manual trigger of workflow from "Actions" tab
 
 jobs:
   build-and-deploy:
@@ -27,19 +28,27 @@ jobs:
       run: |
         bundle exec jekyll build --destination _site
 
-    - name: Create PR-specific folder
-      run: |
-        mkdir -p pr_preview/${{ github.event.pull_request.number }}
-        mv _site/* pr_preview/${{ github.event.pull_request.number }}
+    - name: Clone existing gh-pages branch
+      run: | # Preserves previously deployed PR previews
+        git config --global user.name 'github-actions'
+        git config --global user.email 'github-actions@github.com'
+        git clone --depth 1 --branch gh-pages https://x-access-token:${{ secrets.PR_PREVIEW_TOKEN }}@github.com/open-life-science/ols-site-preview.git gh-pages
+      env:
+        GIT_TERMINAL_PROMPT: 0
 
-    - name: Deploy to GitHub Pages for preview
-      uses: peaceiris/actions-gh-pages@v3
-      with:
-        personal_token: ${{ secrets.PR_PREVIEW_TOKEN }}
-        publish_branch: gh-pages
-        publish_dir: ./pr_preview/${{ github.event.pull_request.number }}
-        external_repository: open-life-science/ols-site-preview
-        cname: ''
+    - name: Copy built site into PR folder
+      run: |
+        pr_number=${{ github.event.pull_request.number }}
+        mkdir -p gh-pages/$pr_number
+        rm -rf gh-pages/$pr_number/*
+        cp -r _site/* gh-pages/$pr_number/
+
+    - name: Push updated preview site
+      run: |
+        cd gh-pages
+        git add .
+        git commit -m "Deploy preview for PR #${{ github.event.pull_request.number }}"
+        git push origin gh-pages
 
     - name: Comment with preview URL
       env:


### PR DESCRIPTION
This PR is an extension of functionality introduced by the action in #948, where a PR preview workflow was implemented.

Previously, the action only allowed a single PR preview (i.e. the latest one) to be available per time because it overwrote the entire content of the _gh-pages_ branch, with the new changes. Here, the deploy action has been modified to accomodate previews for multiple open Pull Requests.

<!-- Explain what the PR is about here, if appropriate :)  --> 

:+1::tada: First of all, thanks for taking the time to contribute! :tada::+1:

## FOR CONTRIBUTOR

* [x] I have read the [CONTRIBUTING.md](https://github.com/open-life-science/open-life-science.github.io/blob/main/CONTRIBUTING.md) document

<!-- Select which of these two are true by putting an x between the square brackets [x] -->
PR Type: 
* [ ] This PR adds a new blog post
* [x] This PR does something else (explain above)

<!-- Leave this here so reviewers have a nice checklist to help them review the PR  --> 
## FOR REVIEWERS

Thanks for taking the time to review! :heart:

Here are the list of things to make sure of:
* [ ] The website builds (a check will fail if not)
* [ ] All images have been added within the Pull Request and they have Alt text
* [ ] If there are paragraphs or text, the key messages are highlighted
* [ ] All internal links (within OLS website) use the [`{% link path_to_file.md %}` format](https://jekyllrb.com/docs/liquid/tags/#link)
* [ ] The preview corresponds to the changes described in the Pull Request
* [ ] The code is tidy and passes the linting tests
