### PR TITLE
add budget template for fscs

### DIFF
--- a/fiscal-hosting/fsc-policies.md
+++ b/fiscal-hosting/fsc-policies.md
@@ -51,6 +51,8 @@ Be prepared to answer:
 
 We will obtain written agreement for scenarios where advances are needed, and record it in the FSC decision log spreadsheet for your team. 
 
+### Preparing budgets for your work
+Please use the [OLS budget template](https://docs.google.com/spreadsheets/d/1JjFrWnZ0OgngXN0TM46o-Llo5m48XJwHQMCiEC5HFPY/copy) [This link will create a new copy of the document] to ensure it covers the items we find are necessary, including pay bands, exchange rates, and likely fields required by funders.  
 
 ### How to credit OLS
 We don't require this! However if you wish to, you could use this: 


### PR DESCRIPTION
This PR updates FSC documentation to clearly link to our budget template. 

## FOR CONTRIBUTOR

* [x] I have read the [CONTRIBUTING.md](https://github.com/open-life-science/open-life-science.github.io/blob/main/CONTRIBUTING.md) document

PR Type: 
* This PR does something else (explain above)

<!-- Leave this here so reviewers have a nice checklist to help them review the PR  --> 
## FOR REVIEWERS

Thanks for taking the time to review! :heart:

Here are the list of things to make sure of:
* [ ] The website builds (a check will fail if not)
* [ ] All images have been added within the Pull Request and they have Alt text
* [ ] If there are paragraphs or text, the key messages are highlighted
* [ ] All internal links (within OLS website) use the [`{% link path_to_file.md %}` format](https://jekyllrb.com/docs/liquid/tags/#link)
* [ ] The preview corresponds to the changes described in the Pull Request
* [ ] The code is tidy and passes the linting tests
