### PR TITLE
Fix "buggy" redirect in the About dropdown menu.

### DIFF
--- a/_includes/default-header.html
+++ b/_includes/default-header.html
@@ -45,7 +45,7 @@
           </div>
 
           <div class="navbar-item has-dropdown is-hoverable">
-            <a class="navbar-link" href="{% link openseeds/about.md %}">About</a>
+            <a class="navbar-link" href="{% link index.md %}">About</a>
             <div class="navbar-dropdown">
               <a class="navbar-item" href="{% link people.md %}"> People </a>
               <a class="navbar-item" href="{% link ols-values.md %}"> Values </a>


### PR DESCRIPTION
Change the behaviour of the "About" navbar item. On click, the user is directed only to the OLS homepage, not the Pre-Seeds page.

:+1::tada: First of all, thanks for taking the time to contribute! :tada::+1:

## FOR CONTRIBUTOR

* [ ] I have read the [CONTRIBUTING.md](https://github.com/open-life-science/open-life-science.github.io/blob/main/CONTRIBUTING.md) document

<!-- Select which of these two are true by putting an x between the square brackets [x] -->
PR Type: 
* [ ] This PR adds a new blog post
* [ ] This PR does something else (explain above)

<!-- Leave this here so reviewers have a nice checklist to help them review the PR  --> 
## FOR REVIEWERS

Thanks for taking the time to review! :heart:

Here are the list of things to make sure of:
* [ ] The website builds (a check will fail if not)
* [ ] All images have been added within the Pull Request and they have Alt text
* [ ] If there are paragraphs or text, the key messages are highlighted
* [ ] All internal links (within OLS website) use the [`{% link path_to_file.md %}` format](https://jekyllrb.com/docs/liquid/tags/#link)
* [ ] The preview corresponds to the changes described in the Pull Request
* [ ] The code is tidy and passes the linting tests
