### PR TITLE
Changing name to OLS in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ Here are a few ways you can get started with contributing to this program.
 1. Help us address one of the [issues currently open in our repository](https://github.com/open-life-science/open-life-science.github.io/issues).
 2. [Create a new issue](https://github.com/open-life-science/open-life-science.github.io/issues/new) to suggest changes/improvements on our website/program.
 3. Send a pull request to correct typo, or fill any gap that you see on our website.
-4. Write about your [Mozilla Open Leader project and share with our participants](https://openlifesci.org/posts).
+4. Write about your [OLS project and share with our participants](https://openlifesci.org/posts).
 5. Contribute your blog posts that could be relevant for our participants. You can [check out our the stories](https://openlifesci.org/posts) to get an idea of what we post there.
 
 Do you have other ideas for contributions? Contact the organisers ([team@we-are-ols.org](mailto:team@we-are-ols.org)).


### PR DESCRIPTION
Substituting Mozilla Open Project (no longer relevant I think) for OLS

<!-- Explain what the PR is about here, if appropriate :)  --> 

:+1::tada: First of all, thanks for taking the time to contribute! :tada::+1:

## FOR CONTRIBUTOR

* [X] I have read the [CONTRIBUTING.md](https://github.com/open-life-science/open-life-science.github.io/blob/main/CONTRIBUTING.md) document

<!-- Select which of these two are true by putting an x between the square brackets [x] -->
PR Type: 
* [ ] This PR adds a new blog post
* [X] This PR does something else (explain above)

<!-- Leave this here so reviewers have a nice checklist to help them review the PR  --> 
## FOR REVIEWERS

Thanks for taking the time to review! :heart:

Here are the list of things to make sure of:
* [ ] The website builds (a check will fail if not)
* [ ] All images have been added within the Pull Request and they have Alt text
* [ ] If there are paragraphs or text, the key messages are highlighted
* [ ] All internal links (within OLS website) use the [`{% link path_to_file.md %}` format](https://jekyllrb.com/docs/liquid/tags/#link)
* [ ] The preview corresponds to the changes described in the Pull Request
* [ ] The code is tidy and passes the linting tests
