### PR TITLE
Use rainbowR logo with name

### DIFF
--- a/_data/community.yaml
+++ b/_data/community.yaml
@@ -147,4 +147,4 @@ incubator_fellows:
     name: "Ella Kaye, representing rainbowR"
     details: |
        <a href="https://github.com/EllaKaye/">Ella Kaye</a> is an OLS Incubator Fellow working with OLS for short-term fiscal sponsorship until <a href="https://rainbowr.org/">rainbowR</a> has an official legal structure and bank account. rainbowR's mission is to connect, support and promote LGBTQ+ people in the R community and to spread awareness of LGBTQ+ issues through data-driven activism.
-    logo: https://rainbowr.org/images/rainbow-hex.png
+    logo: https://rainbowr.org/images/rainbowr-hex.svg


### PR DESCRIPTION
Updated the logo URL for the rainbowR organization.

Thanks for adding me/rainbowR to the OLS website 🌈  
This PR is to use the full rainbowR hex logo with the community name (instead of the rainbow stripe hex).

:+1::tada: First of all, thanks for taking the time to contribute! :tada::+1:

## FOR CONTRIBUTOR

* [x] I have read the [CONTRIBUTING.md](https://github.com/open-life-science/open-life-science.github.io/blob/main/CONTRIBUTING.md) document

<!-- Select which of these two are true by putting an x between the square brackets [x] -->
PR Type: 
* [ ] This PR adds a new blog post
* [x] This PR does something else (explain above)

<!-- Leave this here so reviewers have a nice checklist to help them review the PR  --> 
## FOR REVIEWERS

Thanks for taking the time to review! :heart:

Here are the list of things to make sure of:
* [x] The website builds (a check will fail if not)
* [x] All images have been added within the Pull Request and they have Alt text
* [ ] If there are paragraphs or text, the key messages are highlighted
* [ ] All internal links (within OLS website) use the [`{% link path_to_file.md %}` format](https://jekyllrb.com/docs/liquid/tags/#link)
* [x] The preview corresponds to the changes described in the Pull Request
* [x] The code is tidy and passes the linting tests
