### PR TITLE
Fix alt-text for github icons

### DIFF
--- a/_includes/people.html
+++ b/_includes/people.html
@@ -9,7 +9,7 @@
           <img
             class="is-rounded"
             src="https://avatars.githubusercontent.com/{{ username }}"
-            alt="The GitHub avatar of {{ user.name }}"
+            alt="The GitHub avatar of {{ user.first-name }} {{ user.last-name }}"
           />
         </figure>
       </div>

--- a/_layouts/people.html
+++ b/_layouts/people.html
@@ -17,7 +17,7 @@ Thank You! to the {{ site.data.people | size }} awesome people who participate i
                                 <img
                                     class="is-rounded"
                                     src="https://avatars.githubusercontent.com/{{ username }}"
-                                    alt="The GitHub avatar of {{ details.name }}"/>
+                                    alt="The GitHub avatar of {{ details.first-name }} {{ details.last-name }}"/>
                             </a>
                         </figure>
                     </div>


### PR DESCRIPTION
The alt text was using `name` which doesn't exist in the people data structure, so the sentence looked incomplete: "The GitHub avatar of  ". We need to use `first-name` and `last-name`. 


Close #634


## FOR CONTRIBUTOR

* [x] I have read the [CONTRIBUTING.md](https://github.com/open-life-science/open-life-science.github.io/blob/main/CONTRIBUTING.md) document

<!-- Select which of these two are true by putting an x between the square brackets [x] -->
PR Type: 
* [ ] This PR adds a new blog post
* [x] This PR does something else (explain above)

<!-- Leave this here so reviewers have a nice checklist to help them review the PR  --> 
## FOR REVIEWERS

Thanks for taking the time to review! :heart:

Here are the list of things to make sure of:
* [x] The website builds (a check will fail if not)
* [ ] All images have been added within the Pull Request and they have Alt text
* [ ] If there are paragraphs or text, the key messages are highlighted
* [ ] All internal links (within OLS website) use the [`{% link path_to_file.md %}` format](https://jekyllrb.com/docs/liquid/tags/#link)
* [x] The preview corresponds to the changes described in the Pull Request
* [x] The code is tidy and passes the linting tests
