### PR TITLE
update link for The Turing Way logo

### DIFF
--- a/_data/organizations.yaml
+++ b/_data/organizations.yaml
@@ -94,7 +94,7 @@ turing:
 turing-way:
     name: The Turing Way
     website: https://the-turing-way.netlify.com
-    logo: https://the-turing-way.netlify.app/_static/logo-detail-with-text.svg
+    logo: https://raw.githubusercontent.com/the-turing-way/the-turing-way/refs/heads/main/book/figures/logo-detail-with-text.svg
     country: United Kingdom
 university-freiburg:
     name: Albert-Ludwigs-Universität Freiburg


### PR DESCRIPTION
The link for the The Turing Way logo is broken:

<img width="923" height="736" alt="Captura de pantalla 2026-01-27 a la(s) 1 17 50 p m" src="https://github.com/user-attachments/assets/c1326979-4295-4f14-8c87-5f0c82efdd9a" />

I'm adding a new link

## FOR CONTRIBUTOR

* [x] I have read the [CONTRIBUTING.md](https://github.com/open-life-science/open-life-science.github.io/blob/main/CONTRIBUTING.md) document

<!-- Select which of these two are true by putting an x between the square brackets [x] -->
PR Type: 
* [ ] This PR adds a new blog post
* [x] This PR does something else (explain above)

<!-- Leave this here so reviewers have a nice checklist to help them review the PR  --> 
## FOR REVIEWERS

Thanks for taking the time to review! :heart:

Here are the list of things to make sure of:
* [ ] The website builds (a check will fail if not)
* [ ] All images have been added within the Pull Request and they have Alt text
* [ ] If there are paragraphs or text, the key messages are highlighted
* [ ] All internal links (within OLS website) use the [`{% link path_to_file.md %}` format](https://jekyllrb.com/docs/liquid/tags/#link)
* [ ] The preview corresponds to the changes described in the Pull Request
* [ ] The code is tidy and passes the linting tests
