### PR TITLE
Fix anchor icon display 

### DIFF
--- a/css/custom.scss
+++ b/css/custom.scss
@@ -681,3 +681,20 @@ table.dataframe td.control {
   white-space: normal;
   word-wrap: break-word;
 }
+
+h1, h2, h3, h4, h5, h6 {
+  scroll-margin-top: 4rem;
+}
+
+a.anchor {
+  border-bottom: none !important;
+}
+
+.anchor .octicon-link {
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path d="m7.775 3.275 1.25-1.25a3.5 3.5 0 1 1 4.95 4.95l-2.5 2.5a3.5 3.5 0 0 1-4.95 0 .751.751 0 0 1 .018-1.042.751.751 0 0 1 1.042-.018 1.998 1.998 0 0 0 2.83 0l2.5-2.5a2.002 2.002 0 0 0-2.83-2.83l-1.25 1.25a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042Zm-4.69 9.64a1.998 1.998 0 0 0 2.83 0l1.25-1.25a.751.751 0 0 1 1.042.018.751.751 0 0 1 .018 1.042l-1.25 1.25a3.5 3.5 0 1 1-4.95-4.95l2.5-2.5a3.5 3.5 0 0 1 4.95 0 .751.751 0 0 1-.018 1.042.751.751 0 0 1-1.042.018 1.998 1.998 0 0 0-2.83 0l-2.5 2.5a1.998 1.998 0 0 0 0 2.83Z"/></svg>');
+  background-repeat: no-repeat;
+  vertical-align: middle;
+}


### PR DESCRIPTION
The `inject_anchors` filter from `jekyll-toc` adds a `<span class="octicon octicon-link">` to each heading, which requires the Octicons icon font. Since that font wasn't loaded in the site, the icon was rendering as a fallback character (a small dash-like character before the heading):


<img width="411" height="230" alt="Captura de pantalla 2026-04-21 a la(s) 5 06 06 p m" src="https://github.com/user-attachments/assets/6d650b0f-48e9-41b9-b02b-99c64c9c0565" />    


Fixed by embedding the link SVG directly as a CSS background image, removing the dependency on an external font.

<img width="502" height="241" alt="Captura de pantalla 2026-04-21 a la(s) 5 05 50 p m" src="https://github.com/user-attachments/assets/d0a0465a-eb19-46ac-98a0-89ce890ddc30" />


## FOR CONTRIBUTOR

* [x] I have read the [CONTRIBUTING.md](https://github.com/open-life-science/open-life-science.github.io/blob/main/CONTRIBUTING.md) document

<!-- Select which of these two are true by putting an x between the square brackets [x] -->
PR Type: 
* [ ] This PR adds a new blog post
* [x] This PR does something else (explain above)

<!-- Leave this here so reviewers have a nice checklist to help them review the PR  --> 
## FOR REVIEWERS

Thanks for taking the time to review! :heart:

Here are the list of things to make sure of:
* [ ] The website builds (a check will fail if not)
* [ ] All images have been added within the Pull Request and they have Alt text
* [ ] If there are paragraphs or text, the key messages are highlighted
* [ ] All internal links (within OLS website) use the [`{% link path_to_file.md %}` format](https://jekyllrb.com/docs/liquid/tags/#link)
* [ ] The preview corresponds to the changes described in the Pull Request
* [ ] The code is tidy and passes the linting tests
