### PR TITLE
add preview link of edited md files

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -88,10 +88,23 @@ jobs:
           PAGES_LIST="${PAGES_LIST}\n- [${file}](${page_url})"
         done < <(gh pr diff ${{ github.event.pull_request.number || github.event.inputs.pr_number }} --name-only 2>/dev/null | grep '\.md$')
 
+        COMMENT_IDENTIFIER="<!-- preview-comment -->"
         if [ -n "$PAGES_LIST" ]; then
-          COMMENT_BODY="$(printf '🎉 A preview of this PR is available at: [%s/](%s/)\n\n**Changed pages:**\n%b' "$PREVIEW_URL" "$PREVIEW_URL" "$PAGES_LIST")"
+          COMMENT_BODY="$(printf '%s\n🎉 A preview of this PR is available at: [%s/](%s/)\n\n**Changed pages:**\n%b' "$COMMENT_IDENTIFIER" "$PREVIEW_URL" "$PREVIEW_URL" "$PAGES_LIST")"
         else
-          COMMENT_BODY="🎉 A preview of this PR is available at: [${PREVIEW_URL}/](${PREVIEW_URL}/)"
+          COMMENT_BODY="${COMMENT_IDENTIFIER}
+🎉 A preview of this PR is available at: [${PREVIEW_URL}/](${PREVIEW_URL}/)"
         fi
 
-        gh pr comment ${{ github.event.pull_request.number || github.event.inputs.pr_number }} --body "$COMMENT_BODY"
+        PR_NUMBER="${{ github.event.pull_request.number || github.event.inputs.pr_number }}"
+        EXISTING_COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+          --paginate \
+          --jq '.[] | select(.body | contains("<!-- preview-comment -->")) | .id' 2>/dev/null | head -1)
+
+        if [ -n "$EXISTING_COMMENT_ID" ]; then
+          gh api "repos/${{ github.repository }}/issues/comments/${EXISTING_COMMENT_ID}" \
+            -X PATCH \
+            -f body="$COMMENT_BODY"
+        else
+          gh pr comment "$PR_NUMBER" --body "$COMMENT_BODY"
+        fi

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -58,7 +58,28 @@ jobs:
     - name: Comment with preview URL
       env:
         GITHUB_TOKEN: ${{ secrets.PR_PREVIEW_TOKEN }}   # Step 7a: Use token for authentication.
-      run: | # Step 7b: Create a preview URL using the PR number, post a comment with the preview link on this PR.
-        PREVIEW_URL="https://we-are-ols.org/ols-site-preview/${{ github.event.pull_request.number }}/"
-        COMMENT_BODY="🎉 A preview of this PR is available at: [${PREVIEW_URL}](${PREVIEW_URL})"
+      run: | # Step 7b: Create a preview URL using the PR number, post a comment with the preview link on this PR. If .md files were changed, also add direct links to those pages.
+        PREVIEW_URL="https://we-are-ols.org/ols-site-preview/${{ github.event.pull_request.number }}"
+        PAGES_LIST=""
+
+        while IFS= read -r file; do
+          [ -z "$file" ] && continue
+          permalink=$(grep -m1 "^permalink:" "$file" 2>/dev/null | sed 's/permalink:[[:space:]]*//' | tr -d "\"' ")
+          if [ -n "$permalink" ]; then
+            page_url="${PREVIEW_URL}${permalink}"
+          else
+            relative=$(echo "$file" | sed 's/\.md$/\//' | sed 's/index\/$//')
+            relative="${relative#/}"  # strip leading slash to avoid double slashes
+            [ -z "$relative" ] && continue  # skip root index.md (would duplicate preview URL)
+            page_url="${PREVIEW_URL}/${relative}"
+          fi
+          PAGES_LIST="${PAGES_LIST}\n- [${file}](${page_url})"
+        done < <(gh pr diff ${{ github.event.pull_request.number }} --name-only 2>/dev/null | grep '\.md$')
+
+        if [ -n "$PAGES_LIST" ]; then
+          COMMENT_BODY="$(printf '🎉 A preview of this PR is available at: [%s/](%s/)\n\n**Changed pages:**\n%b' "$PREVIEW_URL" "$PREVIEW_URL" "$PAGES_LIST")"
+        else
+          COMMENT_BODY="🎉 A preview of this PR is available at: [${PREVIEW_URL}/](${PREVIEW_URL}/)"
+        fi
+
         gh pr comment ${{ github.event.pull_request.number }} --body "$COMMENT_BODY"

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -78,7 +78,7 @@ jobs:
             month="${basename:5:2}"
             day="${basename:8:2}"
             slug="${basename:11}"
-            page_url="${PREVIEW_URL}/${year}/${month}/${day}/${slug}/"
+            page_url="${PREVIEW_URL}/posts/${year}/${month}/${day}/${slug}/"
           else
             relative=$(echo "$file" | sed 's/\.md$/\//' | sed 's/index\/$//')
             relative="${relative#/}"  # strip leading slash to avoid double slashes

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -92,8 +92,7 @@ jobs:
         if [ -n "$PAGES_LIST" ]; then
           COMMENT_BODY="$(printf '%s\n🎉 A preview of this PR is available at: [%s/](%s/)\n\n**Changed pages:**\n%b' "$COMMENT_IDENTIFIER" "$PREVIEW_URL" "$PREVIEW_URL" "$PAGES_LIST")"
         else
-          COMMENT_BODY="${COMMENT_IDENTIFIER}
-🎉 A preview of this PR is available at: [${PREVIEW_URL}/](${PREVIEW_URL}/)"
+          COMMENT_BODY="$(printf '%s\n🎉 A preview of this PR is available at: [%s/](%s/)' "$COMMENT_IDENTIFIER" "$PREVIEW_URL" "$PREVIEW_URL")"
         fi
 
         PR_NUMBER="${{ github.event.pull_request.number || github.event.inputs.pr_number }}"

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -80,8 +80,8 @@ jobs:
             slug="${basename:11}"
             page_url="${PREVIEW_URL}/posts/${year}/${month}/${day}/${slug}/"
           else
-            relative=$(echo "$file" | sed 's/\.md$/\//' | sed 's/index\/$//')
-            relative="${relative#/}"  # strip leading slash to avoid double slashes
+            relative=$(echo "$file" | sed 's/index\.md$//' | sed 's/\.md$/.html/')
+            relative="${relative#/}"
             [ -z "$relative" ] && continue  # skip root index.md (would duplicate preview URL)
             page_url="${PREVIEW_URL}/${relative}"
           fi

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main   # ...only if the PR targets the 'main' branch
   workflow_dispatch:   # Allow manual trigger of workflow from "Actions" tab
+    inputs:
+      pr_number:
+        description: 'PR number (for manual testing)'
+        required: true
+        type: string
 
 jobs:
   build-and-deploy:
@@ -26,7 +31,7 @@ jobs:
 
     - name: Build Jekyll site   # Step 4: Build the site with Jekyll, and put it in '_site' directory.
       env:
-        JEKYLL_BASEURL: /ols-site-preview/${{ github.event.pull_request.number }}
+        JEKYLL_BASEURL: /ols-site-preview/${{ github.event.pull_request.number || github.event.inputs.pr_number }}
       run: |
         echo "baseurl: $JEKYLL_BASEURL" > _config_preview.yml
         bundle exec jekyll build --config _config.yml,_config_preview.yml --destination _site
@@ -43,7 +48,7 @@ jobs:
     # Step 6: Copy the built site into the PR folder, so every PR has its own preview.    
     - name: Copy built site into PR folder   
       run: |
-        pr_number=${{ github.event.pull_request.number }}
+        pr_number=${{ github.event.pull_request.number || github.event.inputs.pr_number }}
         mkdir -p gh-pages/$pr_number
         rm -rf gh-pages/$pr_number/*
         cp -r _site/* gh-pages/$pr_number/
@@ -52,14 +57,14 @@ jobs:
       run: |
         cd gh-pages
         git add .
-        git commit -m "Deploy preview for PR #${{ github.event.pull_request.number }}"
+        git commit -m "Deploy preview for PR #${{ github.event.pull_request.number || github.event.inputs.pr_number }}"
         git push origin gh-pages
 
     - name: Comment with preview URL
       env:
         GITHUB_TOKEN: ${{ secrets.PR_PREVIEW_TOKEN }}   # Step 7a: Use token for authentication.
       run: | # Step 7b: Create a preview URL using the PR number, post a comment with the preview link on this PR. If .md files were changed, also add direct links to those pages.
-        PREVIEW_URL="https://we-are-ols.org/ols-site-preview/${{ github.event.pull_request.number }}"
+        PREVIEW_URL="https://we-are-ols.org/ols-site-preview/${{ github.event.pull_request.number || github.event.inputs.pr_number }}"
         PAGES_LIST=""
 
         while IFS= read -r file; do
@@ -81,7 +86,7 @@ jobs:
             page_url="${PREVIEW_URL}/${relative}"
           fi
           PAGES_LIST="${PAGES_LIST}\n- [${file}](${page_url})"
-        done < <(gh pr diff ${{ github.event.pull_request.number }} --name-only 2>/dev/null | grep '\.md$')
+        done < <(gh pr diff ${{ github.event.pull_request.number || github.event.inputs.pr_number }} --name-only 2>/dev/null | grep '\.md$')
 
         if [ -n "$PAGES_LIST" ]; then
           COMMENT_BODY="$(printf '🎉 A preview of this PR is available at: [%s/](%s/)\n\n**Changed pages:**\n%b' "$PREVIEW_URL" "$PREVIEW_URL" "$PAGES_LIST")"
@@ -89,4 +94,4 @@ jobs:
           COMMENT_BODY="🎉 A preview of this PR is available at: [${PREVIEW_URL}/](${PREVIEW_URL}/)"
         fi
 
-        gh pr comment ${{ github.event.pull_request.number }} --body "$COMMENT_BODY"
+        gh pr comment ${{ github.event.pull_request.number || github.event.inputs.pr_number }} --body "$COMMENT_BODY"

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -67,6 +67,13 @@ jobs:
           permalink=$(grep -m1 "^permalink:" "$file" 2>/dev/null | sed 's/permalink:[[:space:]]*//' | tr -d "\"' ")
           if [ -n "$permalink" ]; then
             page_url="${PREVIEW_URL}${permalink}"
+          elif [[ "$file" == _posts/* ]]; then
+            basename=$(basename "$file" .md)
+            year="${basename:0:4}"
+            month="${basename:5:2}"
+            day="${basename:8:2}"
+            slug="${basename:11}"
+            page_url="${PREVIEW_URL}/${year}/${month}/${day}/${slug}/"
           else
             relative=$(echo "$file" | sed 's/\.md$/\//' | sed 's/index\/$//')
             relative="${relative#/}"  # strip leading slash to avoid double slashes

--- a/_includes/default-header.html
+++ b/_includes/default-header.html
@@ -36,7 +36,7 @@
           <div class="navbar-item has-dropdown is-hoverable">
             <a class="navbar-link" href="{% link open-incubator.md %}">Open Incubator</a>
             <div class="navbar-dropdown">
-              <a class="navbar-item" href="https://catalystproject.cloud/">Catalyst</a>
+              <a class="navbar-item" href="https://czi-catalystproject.github.io/">Catalyst</a>
               <a class="navbar-item" href="{% link open-incubator.md %}#fellowship-programmes">Fellowship Programmes</a>
               <a class="navbar-item" href="{% link open-incubator.md %}#facilitators-training-and-transcription-services">Facilitators Training and Transcription Services</a>
               <a class="navbar-item" href="{% link open-incubator.md %}#grant-writing-training">Grant writing training</a>

--- a/_posts/2024-07-15-openseeds-in-2024.md
+++ b/_posts/2024-07-15-openseeds-in-2024.md
@@ -23,9 +23,9 @@ Malvika Sharan will lead the delivery of this track. She will be joined by a Res
 
 ## OLS-9 Catalyst Track
 
-As part of OLS's involvement in the [Catalyst Project](https://catalystproject.cloud/training.html), the "**OLS-9 Catalyst Track**" will be offered to the Catalyst community. 
+As part of OLS's involvement in the [Catalyst Project](https://czi-catalystproject.github.io/training.html), the "**OLS-9 Catalyst Track**" will be offered to the Catalyst community. 
 This initiative aims to support the adoption of open science principles in underserved biomedical research communities by providing reliable and sustainable cloud computing infrastructure.
-Funded by the Chan Zuckerberg Initiative (CZI), Catalyst is a collaboration among seven organizations ([read details](https://catalystproject.cloud/#)) covering a range of open science skills and expertise.
+Funded by the Chan Zuckerberg Initiative (CZI), Catalyst is a collaboration among seven organizations ([read details](https://czi-catalystproject.github.io/#)) covering a range of open science skills and expertise.
 
 The project leads/mentees in the 'OLS-9 Catalyst Track' will be representatives from communities from African and Latin American organizations onboarded in the Catalyst project.
 [Tajudeen (Taj) Gwadabe]({% link people.md %}#tajuddeen1) will lead the delivery of this track.

--- a/_posts/2024-07-22-emmy-farewell.md
+++ b/_posts/2024-07-22-emmy-farewell.md
@@ -38,7 +38,7 @@ As the eLife cohort concluded and Emmy moved to her next role, it was a **natura
 
 With other OLS directors, Emmy was involved in scoping the [CZI grant]({% link _posts/2022-01-27-runway-to-sustainability-czi-funding.md %}) and responsible for managing the finances as we learned how to scale sustainably.
 
-As the **Director of Finance and Operations**, Emmy focused on finance management, implementing HR processes, managing microgrants, accounting, and honoraria. She also **led OLS's participation in the [Catalyst project](https://catalystproject.cloud/)**, supervising Tajuddeen Gwadabe (Taj), who is the Program Manager for the consortium.
+As the **Director of Finance and Operations**, Emmy focused on finance management, implementing HR processes, managing microgrants, accounting, and honoraria. She also **led OLS's participation in the [Catalyst project](https://czi-catalystproject.github.io/)**, supervising Tajuddeen Gwadabe (Taj), who is the Program Manager for the consortium.
 
 Emmy stepped down from the Board of Directors in March this year to **focus on her role as the Engagement Lead at [Invest in Open Infrastructure](https://investinopen.org/)**, which she joined in 2022.
 

--- a/_posts/2024-10-31-introducing-the-catalyst-project-community-partner-highlights.md
+++ b/_posts/2024-10-31-introducing-the-catalyst-project-community-partner-highlights.md
@@ -4,14 +4,14 @@ title: Introducing the Catalyst Project Community Partner Highlights
 authors: 
 - Katie Pratt
 - slldec
-image: https://media.licdn.com/dms/image/v2/D5610AQGPZaXMJKu5Wg/image-shrink_800/image-shrink_800/0/1730385031498?e=1731063600&v=beta&t=-F0ZI4Zj-oKi2cRQyrZcypICq2RuwQAaNyJQubPH3mg
+image: https://media.licdn.com/dms/image/v2/D5610AQGPZaXMJKu5Wg/image-shrink_1280/image-shrink_1280/0/1730385031946?e=2147483647&v=beta&t=r_2yVyOQ2K8Hrk9io3Z0UMyhuYMaj70wlaFoA4DOTMM
 photos:
   name: Picture by The Catalyst Project
   license: CC BY-SA 4.0
   url: https://www.linkedin.com/posts/2i2c-org_as-part-of-our-work-on-the-catalyst-project-activity-7257760964647755777-4fNn
 ---
 
-The **[Catalyst Project](https://catalystproject.cloud/)** is a community-engaged initiative designed to support the adoption of open science principles in **under-served bioscientific research communities** through the provision of reliable and sustainable cloud computing infrastructure. It’s a project we’ve been working on now for almost two years, which involves staff from seven different organizations: [2i2c](https://2i2c.org/), [The Carpentries](https://carpentries.org/about/), [CCAD](https://ccad.unc.edu.ar/), [CSCCE](https://www.cscce.org/), [IOI](http://investinopen.org/), [MetaDocencia](https://www.metadocencia.org/), and [OLS]({{ site.url }}), and is funded by the [Chan Zuckerberg Initiative](https://chanzuckerberg.com/).
+The **[Catalyst Project](https://czi-catalystproject.github.io/)** is a community-engaged initiative designed to support the adoption of open science principles in **under-served bioscientific research communities** through the provision of reliable and sustainable cloud computing infrastructure. It’s a project we’ve been working on now for almost two years, which involves staff from seven different organizations: [2i2c](https://2i2c.org/), [The Carpentries](https://carpentries.org/about/), [CCAD](https://ccad.unc.edu.ar/), [CSCCE](https://www.cscce.org/), [IOI](http://investinopen.org/), [MetaDocencia](https://www.metadocencia.org/), and [OLS]({{ site.url }}), and is funded by the [Chan Zuckerberg Initiative](https://chanzuckerberg.com/).
 
 A key part of the project is engaging with **Community Partners in Africa and Latin America**: Institutions, organizations, and individuals who are undertaking bioscientific research projects that require **cloud computing infrastructure**. As collaborators on the Catalyst Project, Community Partners can access and use 2i2c’s open science cloud services, and also receive training from 2i2c, The Carpentries, MetaDocencia, and OLS to support their work. Community Partners also play a vital role in shaping an evolving governance model for the Catalyst Project to help sustain, scale, and maximize impact in Latin America, Africa, and under-served communities around the world.
 
@@ -24,7 +24,7 @@ The Catalyst Project currently involves **19 Community Partners**, **9 in Africa
 
 <div class="columns">
   <div class="column is-3" markdown="1">
-  ![Logo of African Institute of Biomedical Science and Technology: The picture shows a primarily red and navy blue logo. On the left, a circle wraps around a double helix. Around the circle, the words "African Institute" and "of Biomedical Science and Technology" are written in navy blue and red respectively. On the right, the rest of the logo is formed by a capitalised acronym of the institute's name - AiBST. Only the letter "i" is written in lowercase red text, while the others are in navy blue.](https://catalystproject.cloud/_images/aibst-logo.jpg)
+  ![Logo of African Institute of Biomedical Science and Technology: The picture shows a primarily red and navy blue logo. On the left, a circle wraps around a double helix. Around the circle, the words "African Institute" and "of Biomedical Science and Technology" are written in navy blue and red respectively. On the right, the rest of the logo is formed by a capitalised acronym of the institute's name - AiBST. Only the letter "i" is written in lowercase red text, while the others are in navy blue.](https://czi-catalystproject.github.io/_images/aibst-logo.jpg)
   </div>
   <div class="column" markdown="1">
 
@@ -32,7 +32,7 @@ At the African Institute of Biomedical Sciences and Technology (AiBST) in Zimbab
 
 *"**Through the Catalyst Project we are able to bring genomic information interpretation to patient bedsides.**"* - Zedias Chikwambi
 
-Read more about AiBST’s work with the Catalyst Project: [ENG](https://catalystproject.cloud/blog/community-highlight-aibst-en.html); [ESP](https://catalystproject.cloud/blog/community-highlight-aibst-es.html)
+Read more about AiBST’s work with the Catalyst Project: [ENG](https://czi-catalystproject.github.io/blog/community-highlight-aibst-en.html); [ESP](https://czi-catalystproject.github.io/blog/community-highlight-aibst-es.html)
 
   </div>
 </div>
@@ -48,7 +48,7 @@ The Catalyst Project Community at the Malawi University of Science and Technolog
 
 *“**...many staff and students need… a robust and easily accessible platform from which they c[an] efficiently run their machine learning models and do advanced data analysis for their data science research…**”* - Bennett Kankuzi 
 
-Read more about MUST’s work with the Catalyst Project: [ENG](https://catalystproject.cloud/blog/community-highlight-must-en.html); [ESP](https://catalystproject.cloud/blog/community-highlight-must-es.html)
+Read more about MUST’s work with the Catalyst Project: [ENG](https://czi-catalystproject.github.io/blog/community-highlight-must-en.html); [ESP](https://czi-catalystproject.github.io/blog/community-highlight-must-es.html)
   </div>
 </div>
 
@@ -56,7 +56,7 @@ Read more about MUST’s work with the Catalyst Project: [ENG](https://catalystp
 
 <div class="columns">
   <div class="column is-3" markdown="1">
-![Logo of MolerHealth](https://catalystproject.cloud/_images/molerhealth-logo.png) 
+![Logo of MolerHealth](https://czi-catalystproject.github.io/_images/molerhealth-logo.png) 
   </div>
   <div class="column" markdown="1">
 
@@ -64,7 +64,7 @@ MolerHealth is focused on revolutionizing healthcare in Nigeria by developing an
 
 *“**Access to training, like The Carpentries Instructor Training, has empowered our team with essential skills for effective teaching and collaboration.**”* - Monsurat Onabajo
 
-Read more about MolerHealth’s work with the Catalyst Project: [ENG](https://catalystproject.cloud/blog/community-highlight-molerhealth-en.html); [ESP](https://catalystproject.cloud/blog/community-highlight-molerhealth-es.html)
+Read more about MolerHealth’s work with the Catalyst Project: [ENG](https://czi-catalystproject.github.io/blog/community-highlight-molerhealth-en.html); [ESP](https://czi-catalystproject.github.io/blog/community-highlight-molerhealth-es.html)
 
   </div>
 </div>
@@ -73,7 +73,7 @@ Read more about MolerHealth’s work with the Catalyst Project: [ENG](https://ca
 
 <div class="columns">
   <div class="column is-3" markdown="1">
-![Logo of Nelson Mandela African Institute of Science and Technology: Image displays a circle containing the words "Nelson Mandela" and "Institute of Science and Technology" that are written in a way that they form an arch around three elements. These elements are a microscope, a wheel and an open book. On the lower end, within the circle, the word "Arusha" is wrriten in black, just underneath the open book. Under the circle is written "Academia for Society and Industry."](https://catalystproject.cloud/_images/nm-aist-logo.png)
+![Logo of Nelson Mandela African Institute of Science and Technology: Image displays a circle containing the words "Nelson Mandela" and "Institute of Science and Technology" that are written in a way that they form an arch around three elements. These elements are a microscope, a wheel and an open book. On the lower end, within the circle, the word "Arusha" is wrriten in black, just underneath the open book. Under the circle is written "Academia for Society and Industry."](https://czi-catalystproject.github.io/_images/nm-aist-logo.png)
   </div>
   <div class="column" markdown="1">
 
@@ -81,7 +81,7 @@ The Northern Tanzania One Health Research Group, hosted at the Nelson Mandela Af
 
 *“**...access to training, particularly through the 2i2c Hub Champion Training, has significantly enhanced our ability to manage and optimize cloud-based resources.**"* - Beatus M Lyimo
 
-Read more about NM-AIST’s work with the Catalyst Project: [ENG](https://catalystproject.cloud/blog/community-highlight-nmaist-en.html); [ESP](https://catalystproject.cloud/blog/community-highlight-nmaist-es.html)
+Read more about NM-AIST’s work with the Catalyst Project: [ENG](https://czi-catalystproject.github.io/blog/community-highlight-nmaist-en.html); [ESP](https://czi-catalystproject.github.io/blog/community-highlight-nmaist-es.html)
 
   </div>
 </div>
@@ -89,7 +89,7 @@ Read more about NM-AIST’s work with the Catalyst Project: [ENG](https://cataly
 ## Nodo Nacional de Bioinformática (NNB-CCG) 
 <div class="columns">
   <div class="column is-3" markdown="1">
-![Logo of Nodo Nacional de Bioinformática: The logo is divided into two halves by a black line running down the middle. To the left of the dividing line, a circle with teal background contains the acronym "NNB". To the right, the words "Nodo Nacional de Bioinformática" are written in the same teal colour, and immediately under the text is "CCG UNAM" in a light shade of green.](https://catalystproject.cloud/_images/unam-logo.jpg)
+![Logo of Nodo Nacional de Bioinformática: The logo is divided into two halves by a black line running down the middle. To the left of the dividing line, a circle with teal background contains the acronym "NNB". To the right, the words "Nodo Nacional de Bioinformática" are written in the same teal colour, and immediately under the text is "CCG UNAM" in a light shade of green.](https://czi-catalystproject.github.io/_images/unam-logo.jpg)
   </div>
   <div class="column" markdown="1">
 
@@ -97,7 +97,7 @@ The Nodo Nacional de Bioinformática (NNB-CCG) of the Centro de Ciencias Genómi
 
 *“**[Our] goal is to optimize our participation in events, assess the usefulness of the Catalyst Project's resources, and, in turn, provide the Catalyst Project with guidelines to improve their service by identifying the necessary areas for improvement within the institutions.**"* - Shirley Alquicira Hernández
 
-Read more about NNB-CCG’s work with the Catalyst Project: [ENG](https://catalystproject.cloud/blog/community-highlight-nnbccg-en.html); [ESP](https://catalystproject.cloud/blog/community-highlight-nnbccg-es.html)
+Read more about NNB-CCG’s work with the Catalyst Project: [ENG](https://czi-catalystproject.github.io/blog/community-highlight-nnbccg-en.html); [ESP](https://czi-catalystproject.github.io/blog/community-highlight-nnbccg-es.html)
 
   </div>
 </div>
@@ -105,7 +105,7 @@ Read more about NNB-CCG’s work with the Catalyst Project: [ENG](https://cataly
 ## Instituto Nacional de Enfermedades Respiratorias (INER)
 <div class="columns">
   <div class="column is-3" markdown="1">
-![Logo of Instituto Nacional de Enfermedades Respiratorias: The logo consists of the acronym "UCDS" in bold, teal and capitalised, above the words "UNIDAD DE CIENCIA DE DATOS EN SALUD." Another logo is found under the first in this image and contains the word "labbic" above the words "Laboratorio de Biología Computacional." Both texts are in navy blue.](https://catalystproject.cloud/_images/iner-logo.jpeg)
+![Logo of Instituto Nacional de Enfermedades Respiratorias: The logo consists of the acronym "UCDS" in bold, teal and capitalised, above the words "UNIDAD DE CIENCIA DE DATOS EN SALUD." Another logo is found under the first in this image and contains the word "labbic" above the words "Laboratorio de Biología Computacional." Both texts are in navy blue.](https://czi-catalystproject.github.io/_images/iner-logo.jpeg)
   </div>
   <div class="column" markdown="1">
 
@@ -113,7 +113,7 @@ Collaborators at INER are using the Catalyst Cloud Infrastructure to implement m
 
 *"**The Catalyst Project is helping us to collaborate more efficiently and work remotely.**"* - Yalbi I. Balderas-Martinez
 
-Read more about INER’s work with the Catalyst Project: [ENG](https://catalystproject.cloud/blog/community-highlight-iner-en.html); [ESP](https://catalystproject.cloud/blog/community-highlight-iner-es.html)
+Read more about INER’s work with the Catalyst Project: [ENG](https://czi-catalystproject.github.io/blog/community-highlight-iner-en.html); [ESP](https://czi-catalystproject.github.io/blog/community-highlight-iner-es.html)
   </div>
 </div>
 
@@ -121,7 +121,7 @@ Read more about INER’s work with the Catalyst Project: [ENG](https://catalystp
 ## Centro Interdisciplinario en Ciencia de Datos y Aprendizaje Automático (CICADA)  
 <div class="columns">
   <div class="column is-3" markdown="1">
-![Logo of Centro Interdisciplinario en Ciencia de Datos y Aprendizaje Automático: This image shows a blue logo, comprising of a circle on the left, and the acronym "CICADA" on the right.](https://catalystproject.cloud/_images/cicada-logo.png)
+![Logo of Centro Interdisciplinario en Ciencia de Datos y Aprendizaje Automático: This image shows a blue logo, comprising of a circle on the left, and the acronym "CICADA" on the right.](https://czi-catalystproject.github.io/_images/cicada-logo.png)
   </div>
   <div class="column" markdown="1">
 
@@ -129,11 +129,11 @@ CICADA, an interdisciplinary center researching data science and machine learnin
 
 "**The Catalyst Project…trainings are attractive, as they are respectful of the people, no previous knowledge is assumed, and the instructors are welcoming.**” - María Inés Fariello Rico 
 
-Read more about CICADA’s work with the Catalyst Project: [ENG](https://catalystproject.cloud/blog/community-highlight-cicada-en.html); [ESP](https://catalystproject.cloud/blog/community-highlight-cicada-es.html)
+Read more about CICADA’s work with the Catalyst Project: [ENG](https://czi-catalystproject.github.io/blog/community-highlight-cicada-en.html); [ESP](https://czi-catalystproject.github.io/blog/community-highlight-cicada-es.html)
   </div>
 </div>
 
-You can find a full list of all of the Catalyst Project Community Partners on [the Catalyst Project website](https://catalystproject.cloud/current-community-partners.html). 
+You can find a full list of all of the Catalyst Project Community Partners on [the Catalyst Project website](https://czi-catalystproject.github.io/current-community-partners.html). 
 
 ## About these blog posts - acknowledgements
 Creating a series of blog posts to highlight the work of the Catalyst Community Partners was a collaborative effort involving staff from CSCCE, 2i2c, OLS, and MetaDocencia. Specifically, **Lou Woodley, Katie Pratt, Jenny Wong, and Tajuddeen Gwadabe** conceived the idea during our regular Catalyst Project “website team” meetings, and developed a strategy for reaching out to community partners to gather information. 

--- a/_posts/2025-02-16-the-fosdem-2025-experience.md
+++ b/_posts/2025-02-16-the-fosdem-2025-experience.md
@@ -3,11 +3,11 @@ layout: post
 title: "The FOSDEM 2025 Experience"
 authors:
 - npdebs
-image: https://images.unsplash.com/photo-1739957240497-57ab71d9ed1a
+image: https://images.unsplash.com/photo-1550305080-4e029753abcf?q=80&w=2071
 photos:
-  name: NPDebs
-  license: CC BY-SA 4.0
-  url: https://unsplash.com/@npdebs
+  name: Jaime Lopes
+  license: Unsplash License
+  url: https://unsplash.com/photos/people-raising-hands-with-bokeh-lights-0RDBOAdnbWM
 ---
 
 Let me start by saying that **this trip almost didn’t happen**. A visa application I started in early November was still unresolved a day before FOSDEM. Without my passport, I had to cancel my flight. But with just a few hours to go, something changed.

--- a/_posts/2026-02-25-retro-five-years-OLS.md
+++ b/_posts/2026-02-25-retro-five-years-OLS.md
@@ -64,7 +64,7 @@ This core set of pillars is prominent on our [homepage]({{ site.url }}), with ic
 
 New money often takes a year or more to bring in, even once it is agreed by a funder or client. We also didn't want to be a solely grant-funded organisation - it made sense to us to diversify our funding sources, and not rely on any single source. Ideally whilst also somehow making sure not to over-stretch ourselves :joy: - an easy task of course. 
 
-So far, this has gone well. We collaborated with MetaDocencia to win two NASA grants (focused on our training and mentoring pillar), which became [Nebula](https://we-are-ols.org/nebula/) and [ALTa ciencia abierta](https://www.metadocencia.org/proyecto/nasa-spanish/). The [Catalyst project](https://catalystproject.cloud/) spanned training and incubation pillars. 
+So far, this has gone well. We collaborated with MetaDocencia to win two NASA grants (focused on our training and mentoring pillar), which became [Nebula](https://we-are-ols.org/nebula/) and [ALTa ciencia abierta](https://www.metadocencia.org/proyecto/nasa-spanish/). The [Catalyst project](https://czi-catalystproject.github.io/) spanned training and incubation pillars. 
 
 [Open Seeds](https://we-are-ols.org/openseeds/) was named Open Seeds - previously it had been just "OLS", to distinguish it from the NASA work, and to distinguish it from OLS as an organisation. We also successfully offered [Open Seeds OLS-9 as a contracted service]({%link _posts/2024-07-15-openseeds-in-2024.md %}), rather than solely a grant-funded activity - an important first! 
 

--- a/open-incubator.md
+++ b/open-incubator.md
@@ -11,7 +11,7 @@ streams:
   -
     title: Catalyst
     description: |
-      Funded by [Chan Zuckerberg Initiative](https://chanzuckerberg.com/), the [Catalyst Project](https://catalystproject.cloud/) aims to develop a **collaborative service** to **facilitate access** to **cloud infrastructure** for biomedical research communities in **Latin America** and **Africa**. You can read more about it in the [submitted proposal](https://zenodo.org/records/7025288).
+      Funded by [Chan Zuckerberg Initiative](https://chanzuckerberg.com/), the [Catalyst Project](https://czi-catalystproject.github.io/) aims to develop a **collaborative service** to **facilitate access** to **cloud infrastructure** for biomedical research communities in **Latin America** and **Africa**. You can read more about it in the [submitted proposal](https://zenodo.org/records/7025288).
     image: 
       link: images/logo/catalyst-logo-dark-bg-white.png
       alt: |

--- a/openseeds/ols-9-catalyst/schedule.md
+++ b/openseeds/ols-9-catalyst/schedule.md
@@ -25,7 +25,7 @@ Participants join this program with a **project** that they either are already w
 ## Timeline
 
 The first cohort (CAT-1) runs from **August 26th to December 9th, 2024**. 
-For more information, see the [Catalyst website](https://catalystproject.cloud/).
+For more information, see the [Catalyst website](https://czi-catalystproject.github.io/).
 
 # Schedule
 


### PR DESCRIPTION
Previously, the preview comment only posted the top-level preview URL. Which is not very useful for posts, subpages, etc. 

Now, if markdown files were modified, the comment also lists each changed page with a link to its preview URL.



Tests close #1159 

## FOR CONTRIBUTOR

* [x] I have read the [CONTRIBUTING.md](https://github.com/open-life-science/open-life-science.github.io/blob/main/CONTRIBUTING.md) document

<!-- Select which of these two are true by putting an x between the square brackets [x] -->
PR Type: 
* [ ] This PR adds a new blog post
* [x] This PR does something else (explain above)

<!-- Leave this here so reviewers have a nice checklist to help them review the PR  --> 
## FOR REVIEWERS

Thanks for taking the time to review! :heart:

Here are the list of things to make sure of:
* [ ] The website builds (a check will fail if not)
* [ ] All images have been added within the Pull Request and they have Alt text
* [ ] If there are paragraphs or text, the key messages are highlighted
* [ ] All internal links (within OLS website) use the [`{% link path_to_file.md %}` format](https://jekyllrb.com/docs/liquid/tags/#link)
* [ ] The preview corresponds to the changes described in the Pull Request
* [ ] The code is tidy and passes the linting tests
