### PR TITLE
Add former-titles field on people.yaml + update those roles

### DIFF
--- a/_data/people.yaml
+++ b/_data/people.yaml
@@ -1025,6 +1025,8 @@ andreasancheztapia:
   continent: South America
   longitude: -120.7678602
   latitude: 37.1641544
+  former-titles:
+    - OLS-SSI 2022 Fellow
 andreea-avramescu:
   affiliation: University Of Manchester/The Alan Turing Institute
   bio: My research interests lie in the fields of personalised medicine, optimisation,
@@ -4954,7 +4956,9 @@ iramosp:
   continent: North America
   longitude: -99.1331785
   latitude: 19.4326296
-  title: NASA Cohort Coordinator (contract)
+  title: Research Fellow (contract)
+  former-titles:
+    - NASA Cohort Coordinator (contract)
 iratxepuebla:
   affiliation: Asapbio
   bio: |-
@@ -7809,6 +7813,8 @@ melibleq:
   continent: South America
   longitude: -47.1583944
   latitude: -1.2043218
+  former-titles:
+    - OLS-SSI 2022 Fellow
 meliimming:
   first-name: Melanie
   last-name: Imming
@@ -9665,6 +9671,8 @@ pherterich:
   longitude: -3.1883749
   latitude: 55.9533456
   title: Co-Executive Director OLS
+  former-titles:
+    - Resident Fellow
 piero-beraun:
   affiliation: Scihack
   bio: 22 years old and Bachelor in Bioengineering. I like strawberries, plants, arthropods,
@@ -10090,6 +10098,7 @@ rivaquiroga:
   city: Valparaíso
   longitude: -71.6196749
   latitude: -33.0458456
+  title: Research Fellow (contract)
 rlwhall:
   first-name: Renée
   last-name: Hall
@@ -10602,6 +10611,8 @@ saravilla:
   last-name: Villa
   orcid: 0000-0001-9502-0888
   title: Community and Training Lead
+  former-titles:
+    - Resident Fellow
   pronouns: she/her
   country_3: GBR
   continent: Europe

--- a/_includes/people.html
+++ b/_includes/people.html
@@ -57,7 +57,7 @@
       </div>
     </div>
 
-    {% if user.title or ols-roles and ols-roles != '' %}
+    {% if user.title or ols-roles and ols-roles != '' or show-former-titles and user.former-titles %}
     <p class="people-description">
       Role in OLS:
       {% if user.title %}
@@ -66,6 +66,10 @@
       {% endif %}
       {% if ols-roles and ols-roles != '' %}
         {{ ols-roles }}
+      {% endif %}
+      {% if show-former-titles and user.former-titles %}
+        {% if ols-roles and ols-roles != '' %} / {% endif %}
+        {{ user.former-titles | join: ', ' }}
       {% endif %}
     </p>
     {% endif %}

--- a/_layouts/people.html
+++ b/_layouts/people.html
@@ -100,6 +100,7 @@ we ask that you follow our <a href="{{ site.github.owner_url }}/policies-procedu
     {% endif %}
   {% endfor %}
   {% assign ols-roles = ols-roles | remove_first: ' / ' %}
+  {% assign show-former-titles = true %}
   {% include _includes/people.html username=username user=user ols-roles=ols-roles %}
 {% endfor %}
 </div>


### PR DESCRIPTION
<!-- Explain what the PR is about here, if appropriate :)  --> 

Added support for `former-titles` field in `people.yaml`. When a team member has held more than one role, previous titles can now be listed under `former-titles:` as a list:

```
title: Co-Executive Director OLS
former-titles:
  - Resident Fellow
  - etc.
 ```
Former titles are displayed on the `/people.html` page alongside cohort roles, but do not appear on `/team.html`.

This PR also updates (AFAIK) all the cases where previous-titles was needed. 

Close #1186 

## FOR CONTRIBUTOR

* [x] I have read the [CONTRIBUTING.md](https://github.com/open-life-science/open-life-science.github.io/blob/main/CONTRIBUTING.md) document

<!-- Select which of these two are true by putting an x between the square brackets [x] -->
PR Type: 
* [ ] This PR adds a new blog post
* [x] This PR does something else (explain above)

<!-- Leave this here so reviewers have a nice checklist to help them review the PR  --> 
## FOR REVIEWERS

Thanks for taking the time to review! :heart:

Here are the list of things to make sure of:
* [ ] The website builds (a check will fail if not)
* [ ] All images have been added within the Pull Request and they have Alt text
* [ ] If there are paragraphs or text, the key messages are highlighted
* [ ] All internal links (within OLS website) use the [`{% link path_to_file.md %}` format](https://jekyllrb.com/docs/liquid/tags/#link)
* [ ] The preview corresponds to the changes described in the Pull Request
* [ ] The code is tidy and passes the linting tests
