### PR TITLE
fix bibtexparser

### DIFF
--- a/environment-osx.yml
+++ b/environment-osx.yml
@@ -27,3 +27,4 @@ dependencies:
   - tox
   - jinja2
   - pyzotero
+  - bibtexparser<2

--- a/environment.yml
+++ b/environment.yml
@@ -26,4 +26,5 @@ dependencies:
   - geopy
   - tox
   - pyzotero
+  - bibtexparser<2
   - jinja2


### PR DESCRIPTION
The CI job that updates the bibliography from Zotero (`bin/prepare_website_data.py updatebibliography`) started failing with: AttributeError: module 'bibtexparser' has no attribute 'bparser'

The cause seems to be that `environment.yml` / `environment-osx.yml` install `pyzotero` from conda-forge without constraining its `bibtexparser` dependency. On PyPI, `pyzotero` declares `bibtexparser>=1.4.3,<2.0.0`, but the conda-forge package doesn't carry that same upper bound, so conda resolves the latest `bibtexparser` (2.x). That release removed the legacy `bparser` module that `pyzotero`'s internal BibTeX parsing code still depends on.

The inmediate fix is pinning `bibtexparser<2` explicitly in both environment files, matching the constraint `pyzotero` already declares on PyPI. Verified locally that this restores `pyzotero`'s bibtex parsing.

Worth revisiting this pin once conda-forge's `pyzotero` recipe correctly propagates its upstream `bibtexparser` constraint



## FOR CONTRIBUTOR

* [ ] I have read the [CONTRIBUTING.md](https://github.com/open-life-science/open-life-science.github.io/blob/main/CONTRIBUTING.md) document

<!-- Select which of these two are true by putting an x between the square brackets [x] -->
PR Type: 
* [ ] This PR adds a new blog post
* [ ] This PR does something else (explain above)

<!-- Leave this here so reviewers have a nice checklist to help them review the PR  --> 
## FOR REVIEWERS

Thanks for taking the time to review! :heart:

Here are the list of things to make sure of:
* [ ] The website builds (a check will fail if not)
* [ ] All images have been added within the Pull Request and they have Alt text
* [ ] If there are paragraphs or text, the key messages are highlighted
* [ ] All internal links (within OLS website) use the [`{% link path_to_file.md %}` format](https://jekyllrb.com/docs/liquid/tags/#link)
* [ ] The preview corresponds to the changes described in the Pull Request
* [ ] The code is tidy and passes the linting tests
